### PR TITLE
Enable manual symbolic system setup

### DIFF
--- a/src/cubie/systemmodels/symbolic/__init__.py
+++ b/src/cubie/systemmodels/symbolic/__init__.py
@@ -1,6 +1,9 @@
 """Symbolic system building utilities."""
 
-from cubie.systemmodels.symbolic.symbolic import SymbolicODESystem
+from cubie.systemmodels.symbolic.symbolic import (
+    SymbolicODESystem,
+    setup_system,
+)
 from cubie.systemmodels.symbolic.math_functions import (
     exp_,
     sin_,
@@ -12,6 +15,7 @@ from cubie.systemmodels.symbolic.math_functions import (
 
 __all__ = [
     "SymbolicODESystem",
+    "setup_system",
     "exp_",
     "sin_",
     "cos_",

--- a/tests/systemmodels/symbolic/test_manual_setup.py
+++ b/tests/systemmodels/symbolic/test_manual_setup.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+
+from cubie.systemmodels.symbolic import setup_system
+
+
+def manual_settings_defaults():
+    return {
+        "observables": ["obs"],
+        "parameters": {"k": 1.0},
+        "constants": {},
+        "drivers": ["d"],
+        "states": {"x": 1.0},
+        "dxdt": ["obs = k * x * d", "dx = obs"],
+    }
+
+
+@pytest.fixture(scope="function")
+def manual_settings_override(request):
+    return request.param if hasattr(request, "param") else {}
+
+
+@pytest.fixture(scope="function")
+def manual_settings(manual_settings_override):
+    settings = manual_settings_defaults()
+    settings.update(manual_settings_override)
+    return settings
+
+
+def test_setup_system(manual_settings, precision):
+    system = setup_system(**manual_settings, precision=precision)
+    system.build()
+    states = np.array([1.0], dtype=precision)
+    params = np.array([2.0], dtype=precision)
+    drivers = np.array([3.0], dtype=precision)
+    dxdt, obs = system.correct_answer_python(states, params, drivers)
+    assert dxdt[0] == pytest.approx(6.0)
+    assert obs[0] == pytest.approx(6.0)


### PR DESCRIPTION
## Summary
- support driver symbols and add `setup_system` helper for manual models
- export manual setup API from symbolic package
- test building a symbolic system from string definitions

## Testing
- `PYTHONPATH=src pytest tests/systemmodels/symbolic -q` *(fails: CUDA driver library cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a55b947e18832699205749d7824a34