### PR TITLE
feat: Sympy and user-provided functions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+Do not use && to join terminal commands, the default terminal is powershell and these don't work.
+When creating tests, use pytest fixtures. Strongly prefer fixtures instantiating cubie objects over creating mocks or 
+patches unless absolutely unavoidable.
+Only run tests in current test file, as total test run is slow.
+Expect any tests requiring cuda to fail. Prompt user to run tests if they use any cuda functionality.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ initial value problems. The source code is available on `Github <https://github.
    getting_started
    systems
    cuda
+   userfunctions
    Algorithms
    api/index
 

--- a/docs/source/userfunctions.rst
+++ b/docs/source/userfunctions.rst
@@ -1,0 +1,77 @@
+User functions and derivatives
+==============================
+
+Cubie lets you call your own functions inside dx/dt equations. There are two main cases:
+
+- Pure Python callables: These are treated like ordinary functions. When possible, Cubie inlines them symbolically.
+- CUDA device functions: These are detected and treated as opaque calls in generated code. For differentiation (Jacobian/JVP/VJP), provide a corresponding derivative function.
+
+Providing functions
+-------------------
+
+Pass a mapping of names to callables via user_functions to parse_input. If your function name collides with a SymPy built-in (e.g., exp), the user function takes precedence.
+
+Example (Python function):
+
+- Define a simple function:
+  def ex_squared(x):
+      return x**2
+
+- Use it in equations:
+  index_map, symbols, funcs, eqs, fn_hash = parse_input(
+      dxdt=["dx = ex_squared(a)", "y = x"],
+      user_functions={"ex_squared": ex_squared}
+  )
+
+- print_cuda_multiple(eqs, symbols) will emit ex_squared(a) in code unless it could inline it symbolically.
+
+Device functions and derivatives
+--------------------------------
+
+CUDA device functions are detected automatically if they are created with numba.cuda.jit(..., device=True).
+For differentiation, also provide a derivative function in user_function_derivatives with the same key as the original function name.
+
+- The derivative callable signature must be: d_userfunc(funcargs..., argindex)
+  where argindex is 0-based index of the argument with respect to which the derivative is taken.
+- The derivative callable’s __name__ is used in generated code, so choose a descriptive name (e.g., myfunc_grad).
+
+Example:
+
+- Define device function and its derivative name:
+  from numba import cuda
+
+  @cuda.jit(device=True)
+  def myfunc(a, b):
+      return a * b
+
+  # This can be device or pure Python; codegen only needs the name
+  def myfunc_grad(a, b, index):
+      if index == 0:
+          return b
+      elif index == 1:
+          return a
+      return 0
+
+- Parse equations with both maps:
+  index_map, symbols, funcs, eqs, fn_hash = parse_input(
+      dxdt=["dx = myfunc(x, y)", "dy = x"],
+      states=["x", "y"], parameters=[], constants=[], observables=[],
+      user_functions={"myfunc": myfunc},
+      user_function_derivatives={"myfunc": myfunc_grad}
+  )
+
+- Generate JVP code:
+  code = generate_jvp_code(eqs, index_map)
+  # The code will contain calls to myfunc_grad(..., argindex) in the Jacobian terms.
+
+Name collisions with SymPy
+--------------------------
+
+If your user function has the same name as a SymPy function, Cubie ensures your function wins. Internally it renames your function to a safe symbolic token during parsing and maps it back to your original name when printing code.
+
+Tips
+----
+- If your derivative function is a CUDA device function, use @cuda.jit(device=True).
+- If you don’t provide a derivative for a device function, auto-generated jacobians will not work.
+- Pure Python user functions that can be evaluated on SymPy symbols may be inlined symbolically; otherwise they are called by name in code.
+

--- a/docs/source/userfunctions.rst
+++ b/docs/source/userfunctions.rst
@@ -23,7 +23,9 @@ Example (Python function):
       user_functions={"ex_squared": ex_squared}
   )
 
-- print_cuda_multiple(eqs, symbols) will emit ex_squared(a) in code unless it could inline it symbolically.
+- print_cuda_multiple(eqs, symbols) will emit a*a in code if it can inline the function (i.e. it's simple and uses Sympy
+-compatible logic, otherwise it will call ex_squared(a) in code. If it calls ex_squared(a), it will also call
+ex_squared_grad(a, 0) in Jacobian terms, so you need to provide that function in user_function_derivatives.
 
 Device functions and derivatives
 --------------------------------
@@ -71,7 +73,7 @@ If your user function has the same name as a SymPy function, Cubie ensures your 
 
 Tips
 ----
-- If your derivative function is a CUDA device function, use @cuda.jit(device=True).
 - If you don’t provide a derivative for a device function, auto-generated jacobians will not work.
-- Pure Python user functions that can be evaluated on SymPy symbols may be inlined symbolically; otherwise they are called by name in code.
+- Pure Python user functions that can be evaluated on SymPy symbols may be inlined symbolically; otherwise they are
+called by name in code, and you'll need to provide a derivative function for differentiation.
 

--- a/src/cubie/_utils.py
+++ b/src/cubie/_utils.py
@@ -16,9 +16,9 @@ from numba.cuda.random import (
     xoroshiro128p_normal_float32,
     xoroshiro128p_normal_float64,
 )
+from attrs import fields, has
 
 xoro_type = from_dtype(xoroshiro128p_dtype)
-from attrs import fields, has
 
 
 def slice_variable_dimension(slices, indices, ndim):

--- a/src/cubie/systemmodels/symbolic/numba_cuda_printer.py
+++ b/src/cubie/systemmodels/symbolic/numba_cuda_printer.py
@@ -4,6 +4,19 @@ from typing import Dict, Iterable, Optional, Tuple
 import sympy as sp
 from sympy.printing.pycode import PythonCodePrinter
 
+CUDA_FUNCTIONS: Dict[str, str] = {
+    'exp': 'math.exp',
+    'log': 'math.log',
+    'sin': 'math.sin',
+    'cos': 'math.cos',
+    'tan': 'math.tan',
+    'sqrt': 'math.sqrt',
+    'Abs': 'math.Abs',
+    'Min': 'math.Min',
+    'Max': 'math.Max',
+    'sign': 'math.sign',
+}
+
 
 class CUDAPrinter(PythonCodePrinter):
     """SymPy printer for CUDA code generation with symbol substitutions and optimizations."""

--- a/src/cubie/systemmodels/symbolic/parser.py
+++ b/src/cubie/systemmodels/symbolic/parser.py
@@ -13,18 +13,71 @@ from .sym_utils import hash_system_definition
 # Lambda notation, Auto-number, factorial notation, implicit multiplication
 PARSE_TRANSORMS = (T[0][0],T[3][0], T[4][0], T[8][0])
 
-KNOWN_FUNCTIONS = {'exp': sp.exp,
-                   'log': sp.log,
-                   'sin': sp.sin,
-                   'cos': sp.cos,
-                   'tan': sp.tan,
-                   'sqrt': sp.sqrt,
-                   'Piecewise': sp.Piecewise,
-                   'Abs': sp.Abs,
-                   'Min': sp.Min,
-                   'Max': sp.Max,
-                   'sign': sp.sign,
-                   }
+KNOWN_FUNCTIONS = {
+    # Basic mathematical functions
+    'exp': sp.exp,
+    'log': sp.log,
+    'sqrt': sp.sqrt,
+    'pow': sp.Pow,
+
+    # Trigonometric functions
+    'sin': sp.sin,
+    'cos': sp.cos,
+    'tan': sp.tan,
+    'asin': sp.asin,
+    'acos': sp.acos,
+    'atan': sp.atan,
+    'atan2': sp.atan2,
+
+    # Hyperbolic functions
+    'sinh': sp.sinh,
+    'cosh': sp.cosh,
+    'tanh': sp.tanh,
+    'asinh': sp.asinh,
+    'acosh': sp.acosh,
+    'atanh': sp.atanh,
+
+    # Special functions
+    'erf': sp.erf,
+    'erfc': sp.erfc,
+    'gamma': sp.gamma,
+    'lgamma': sp.loggamma,
+
+    # Rounding and absolute
+    'Abs': sp.Abs,
+    'abs': sp.Abs,
+    'floor': sp.floor,
+    'ceil': sp.ceiling,
+    'ceiling': sp.ceiling,
+
+    # Min/Max
+    'Min': sp.Min,
+    'Max': sp.Max,
+    'min': sp.Min,
+    'max': sp.Max,
+
+    # Functions that need custom handling - placeholder will not
+    # work for differentiation.
+    # 'log10': sp.Function('log10'),
+    # 'log2': sp.Function('log2'),
+    # 'log1p': sp.Function('log1p'),
+    # 'hypot': sp.Function('hypot'),
+    # 'expm1': sp.Function('expm1'),
+    # 'copysign': sp.Function('copysign'),
+    # 'fmod': sp.Function('fmod'),
+    # 'modf': sp.Function('modf'),
+    # 'frexp': sp.Function('frexp'),
+    # 'ldexp': sp.Function('ldexp'),
+    # 'remainder': sp.Function('remainder'),
+    # 'fabs': sp.Abs,
+    # 'isnan': sp.Function('isnan'),
+    # 'isinf': sp.Function('isinf'),
+    # 'isfinite': sp.Function('isfinite'),
+
+    # Existing functions
+    'Piecewise': sp.Piecewise,
+    'sign': sp.sign,
+}
 class EquationWarning(Warning):
     pass
 
@@ -45,7 +98,6 @@ def _replace_if(expr_str: str):
         return f"Piecewise(({true_str}, {cond_str}), ({false_str}, True))"
     return expr_str
 
-# -------------------------- Process equations ------------------------------ #
 def _process_calls(equations_input: Iterable[str],
                    user_functions: Optional[Dict[str, callable]] = None):
     """ map known SymPy callables (e.g., 'exp') to Sympy functions """
@@ -330,7 +382,7 @@ def parse_input(
     if states is None:
         states = {}
         if strict:
-            raise ValueError("No state symbols were provided - if you want to" 
+            raise ValueError("No state symbols were provided - if you want to"
             "build a model from a set of equations alone, set strict=False")
     if observables is None:
         observables = []

--- a/src/cubie/systemmodels/symbolic/parser.py
+++ b/src/cubie/systemmodels/symbolic/parser.py
@@ -13,6 +13,18 @@ from .sym_utils import hash_system_definition
 # Lambda notation, Auto-number, factorial notation, implicit multiplication
 PARSE_TRANSORMS = (T[0][0],T[3][0], T[4][0], T[8][0])
 
+KNOWN_FUNCTIONS = {'exp': sp.exp,
+                   'log': sp.log,
+                   'sin': sp.sin,
+                   'cos': sp.cos,
+                   'tan': sp.tan,
+                   'sqrt': sp.sqrt,
+                   'Piecewise': sp.Piecewise,
+                   'Abs': sp.Abs,
+                   'Min': sp.Min,
+                   'Max': sp.Max,
+                   'sign': sp.sign,
+                   }
 class EquationWarning(Warning):
     pass
 
@@ -44,18 +56,18 @@ def _process_calls(equations_input: Iterable[str],
         calls |= set(_func_call_re.findall(line))
     funcs = {}
     for name in calls:
-        fn = getattr(sp, name, None)
-        if fn is None:
-            if name in user_functions:
-                funcs[name] = user_functions[name]
-            else:
-                raise ValueError(f"Your dxdt code contains a call to a "
-                                 f"function {name}() that isn't part of Sympy "
-                                 f"and wasn't provided in the user_functions "
-                                 f"dict.")
-        elif callable(fn):
-            funcs[name] = fn
-
+        if name in user_functions:
+            funcs[name] = user_functions[name]
+        elif name in KNOWN_FUNCTIONS:
+            funcs[name] = KNOWN_FUNCTIONS[name]
+        else:
+            raise ValueError(f"Your dxdt code contains a call to a "
+                             f"function {name}() that isn't part of Sympy "
+                             f"and wasn't provided in the user_functions "
+                             f"dict.")
+    # Tests: non-listed sympy function errors
+    # Tests: user function passes
+    # Tests: user function overrides listed sympy function
     return funcs
 
 def _process_parameters(states,

--- a/src/cubie/systemmodels/symbolic/symbolicODE.py
+++ b/src/cubie/systemmodels/symbolic/symbolicODE.py
@@ -123,6 +123,7 @@ class SymbolicODE(BaseODE):
               drivers: Optional[Iterable[str]] = None,
               user_functions: Optional[Optional[dict[str, Callable]]] = None,
               name: Optional[str] = None,
+              generate_jac = True,
               strict=False):
 
         sys_components = parse_input(
@@ -142,6 +143,8 @@ class SymbolicODE(BaseODE):
                    name=name,
                    fn_hash=fn_hash,
                    user_functions = functions,
+                   autojvp = generate_jac,
+                   autovjp = generate_jac,
                    precision=np.float64)
 
 

--- a/tests/systemmodels/symbolic/test_cuda_printer.py
+++ b/tests/systemmodels/symbolic/test_cuda_printer.py
@@ -262,3 +262,8 @@ def test_piecewise_inside_expression_assignment():
 
     # Expect: _cse10 = E_v*(_cse1 if _cse3 else (0))
     assert _compact(out) == _compact("_cse10 = E_v*(_cse1 if _cse3 else (0))")
+
+def test_functions():
+    """Test that expressions containing SymPy functions are successfully
+    converted to CUDA-compatible functions as given by CUDA_FUNCTIONS"""
+    pass

--- a/tests/systemmodels/symbolic/test_parser.py
+++ b/tests/systemmodels/symbolic/test_parser.py
@@ -590,21 +590,6 @@ class TestFunctions:
 
         assert code == ["dx = exp(a) + exp(b)", "dy = x"]
 
-
-    def test_differentiation(self):
-        """ Run jacobian codegen on some code containing user-defined and sympy
-        functions."""
-        def custom_func(x):
-            return x**2
-        userfuncs = {'ex_squared': custom_func}
-        eqs = ["dx = ex_squared(y)",
-               "dy = ex_squared(x)"]
-        index_map, symbols, funcs, eq_map, fn_hash = parse_input(dxdt=eqs,
-                     user_functions=userfuncs)
-
-        code = generate_jvp_code(eq_map, index_map)
-        print(code)
-
     def test_device_userfunc_derivative_mapping(self):
         """Ensure device-like user functions use provided derivative name in JVP code without CUDA runtime."""
         # Pseudo device function: has .targetoptions['device']=True and is callable

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -173,19 +173,19 @@ def test_slice_variable_dimension():
 
 
 @attrs.define
-class TestAttrsClass:
+class AttrsClasstest:
     field1: int
     _field2: str
 
 
-class TestRegularClass:
+class RegularClasstest:
     def __init__(self):
         self.field1 = 1
 
 
 def test_in_attr():
     """Test in_attr function."""
-    attrs_instance = TestAttrsClass(1, "test")
+    attrs_instance = AttrsClasstest(1, "test")
 
     # Test existing field
     assert in_attr("field1", attrs_instance) == True
@@ -200,8 +200,8 @@ def test_in_attr():
 
 def test_is_attrs_class():
     """Test is_attrs_class function."""
-    attrs_instance = TestAttrsClass(1, "test")
-    regular_instance = TestRegularClass()
+    attrs_instance = AttrsClasstest(1, "test")
+    regular_instance = RegularClasstest()
 
     assert is_attrs_class(attrs_instance) == True
     assert is_attrs_class(regular_instance) == False


### PR DESCRIPTION
The user can now include calls to CUDA-compatible (i.e. implemented by Numba) math functions through a Sympy expression mid-step. For example, "exp" in a string is converted to a sp.exp expression, whose derivative is known by Sympy, so jacobian-vector products generate successfully.

Alternatively, the user can provide a self-written device function, as long as they also provide a self-written derivative function. 

