### PR TITLE
fix: set cse to False by default in the linear operator, preconditioner, and residual functions

### DIFF
--- a/src/cubie/odesystems/symbolic/codegen/linear_operators.py
+++ b/src/cubie/odesystems/symbolic/codegen/linear_operators.py
@@ -323,7 +323,7 @@ def generate_operator_apply_code_from_jvp(
     index_map: IndexedBases,
     M: sp.Matrix,
     func_name: str = "operator_apply_factory",
-    cse: bool = True,
+    cse: bool = False,
 ) -> str:
     """Emit the operator apply factory from precomputed JVP expressions."""
 
@@ -412,7 +412,7 @@ def generate_operator_apply_code(
     index_map: IndexedBases,
     M: Optional[Union[sp.Matrix, Iterable[Iterable[sp.Expr]]]] = None,
     func_name: str = "operator_apply_factory",
-    cse: bool = True,
+    cse: bool = False,
     jvp_equations: Optional[JVPEquations] = None,
 ) -> str:
     """Generate the linear operator factory from system equations."""
@@ -447,7 +447,7 @@ def generate_cached_operator_apply_code(
     index_map: IndexedBases,
     M: Optional[Union[sp.Matrix, Iterable[Iterable[sp.Expr]]]] = None,
     func_name: str = "linear_operator_cached",
-    cse: bool = True,
+    cse: bool = False,
     jvp_equations: Optional[JVPEquations] = None,
 ) -> str:
     """Generate the cached linear operator factory."""
@@ -480,7 +480,7 @@ def generate_prepare_jac_code(
     equations: ParsedEquations,
     index_map: IndexedBases,
     func_name: str = "prepare_jac",
-    cse: bool = True,
+    cse: bool = False,
     jvp_equations: Optional[JVPEquations] = None,
 ) -> Tuple[str, int]:
     """Generate the cached auxiliary preparation factory."""
@@ -507,7 +507,7 @@ def generate_cached_jvp_code(
     equations: ParsedEquations,
     index_map: IndexedBases,
     func_name: str = "calculate_cached_jvp",
-    cse: bool = True,
+    cse: bool = False,
     jvp_equations: Optional[JVPEquations] = None,
 ) -> str:
     """Generate the cached Jacobian-vector product factory."""
@@ -537,7 +537,7 @@ def _build_n_stage_operator_lines(
     stage_coefficients: sp.Matrix,
     stage_nodes: Tuple[sp.Expr, ...],
     jvp_equations: JVPEquations,
-    cse: bool = True,
+    cse: bool = False,
 ) -> str:
     """Construct CUDA statements for the FIRK n-stage linear operator."""
 
@@ -711,7 +711,7 @@ def generate_n_stage_linear_operator_code(
     stage_nodes: Sequence[Union[float, sp.Expr]],
     M: Optional[Union[sp.Matrix, Iterable[Iterable[sp.Expr]]]] = None,
     func_name: str = "n_stage_linear_operator",
-    cse: bool = True,
+    cse: bool = False,
     jvp_equations: Optional[JVPEquations] = None,
 ) -> str:
     """Generate a flattened n-stage FIRK linear operator factory."""

--- a/src/cubie/odesystems/symbolic/codegen/nonlinear_residuals.py
+++ b/src/cubie/odesystems/symbolic/codegen/nonlinear_residuals.py
@@ -93,7 +93,7 @@ def _build_residual_lines(
     equations: ParsedEquations,
     index_map: IndexedBases,
     M: sp.Matrix,
-    cse: bool = True,
+    cse: bool = False,
 ) -> str:
     """Construct CUDA code lines for the stage-increment residual."""
 
@@ -183,7 +183,7 @@ def _build_n_stage_residual_lines(
     M: sp.Matrix,
     stage_coefficients: sp.Matrix,
     stage_nodes: Tuple[sp.Expr, ...],
-    cse: bool = True,
+    cse: bool = False,
 ) -> str:
     """Construct CUDA statements for the FIRK n-stage residual."""
 
@@ -305,7 +305,7 @@ def generate_residual_code(
     index_map: IndexedBases,
     M: Optional[Union[sp.Matrix, Iterable[Iterable[sp.Expr]]]] = None,
     func_name: str = "residual_factory",
-    cse: bool = True,
+    cse: bool = False,
 ) -> str:
     """Emit the stage-increment residual factory for Newton--Krylov integration."""
 
@@ -335,7 +335,7 @@ def generate_stage_residual_code(
     index_map: IndexedBases,
     M: Optional[Union[sp.Matrix, Iterable[Iterable[sp.Expr]]]] = None,
     func_name: str = "stage_residual",
-    cse: bool = True,
+    cse: bool = False,
 ) -> str:
     """Generate the stage residual factory."""
     _default_timelogger.start_event("codegen_generate_stage_residual_code")
@@ -358,7 +358,7 @@ def generate_n_stage_residual_code(
     stage_nodes: Sequence[Union[float, sp.Expr]],
     M: Optional[Union[sp.Matrix, Iterable[Iterable[sp.Expr]]]] = None,
     func_name: str = "n_stage_residual",
-    cse: bool = True,
+    cse: bool = False,
 ) -> str:
     """Generate a flattened n-stage FIRK residual factory."""
     _default_timelogger.start_event("codegen_generate_n_stage_residual_code")

--- a/src/cubie/odesystems/symbolic/codegen/preconditioners.py
+++ b/src/cubie/odesystems/symbolic/codegen/preconditioners.py
@@ -264,7 +264,7 @@ def _build_n_stage_neumann_lines(
     stage_coefficients: sp.Matrix,
     stage_nodes: Tuple[sp.Expr, ...],
     jvp_equations: JVPEquations,
-    cse: bool = True,
+    cse: bool = False,
 ) -> str:
     """Construct CUDA statements computing J·v for flattened FIRK stages."""
 
@@ -426,7 +426,7 @@ def generate_n_stage_neumann_preconditioner_code(
     stage_coefficients: Sequence[Sequence[Union[float, sp.Expr]]],
     stage_nodes: Sequence[Union[float, sp.Expr]],
     func_name: str = "n_stage_neumann_preconditioner",
-    cse: bool = True,
+    cse: bool = False,
     jvp_equations: Optional[JVPEquations] = None,
 ) -> str:
     """Generate a flattened n-stage FIRK Neumann preconditioner factory."""


### PR DESCRIPTION
This PR sets the default `cse` argument to codegen functions for the 'solver helper' functions which generate linear operators, nonlinear residuals, and neumann preconditioners as part of the codegen pipeline for implicit solvers. Codegen is slow, but not the main performance bottleneck for large systems (see #431). This is a quick fix, however, so worth spending a few minutes on to potentially saving a few minutes per compile.

Tests to run before merging

Does this make codegen quicker for the modified functions, as measured by the internal timelogger?
Does this make compilation take longer, as measured by a script which compares first-run time to second-run time for a medium-complexity system?
Does this make runtime longer, as measured by NSight Compute?

This PR will likely sit dormant while I swat bigger flies.