### PR TITLE
fix: dict inputs map to state/parameter slots by key name (#530)

### DIFF
--- a/src/cubie/batchsolving/BatchInputHandler.py
+++ b/src/cubie/batchsolving/BatchInputHandler.py
@@ -449,14 +449,11 @@ def extend_grid_to_array(
         # When multidimensional ensure the grid row count matches indices
         if grid.shape[0] != indices.shape[0]:
             raise ValueError("Grid shape does not match indices shape.")
-        if default_values.shape[0] == indices.shape[0]:
-            # All indices swept, just pass the array straight through
-            array = grid
-        else:
-            # Create array with default values for all runs
-            n_runs = grid.shape[1]
-            array = np_column_stack([default_values] * n_runs)
-            array[indices, :] = grid
+        # Scatter grid rows to their variable indices; grid rows follow
+        # the caller's key order, which need not match declared order.
+        n_runs = grid.shape[1]
+        array = np_column_stack([default_values] * n_runs)
+        array[indices, :] = grid
 
     return array
 

--- a/tests/batchsolving/test_batch_input_handler.py
+++ b/tests/batchsolving/test_batch_input_handler.py
@@ -219,6 +219,17 @@ def test_extend_grid_all_swept(system):
     assert_array_equal(result, grid)
 
 
+def test_extend_grid_all_swept_permuted(system):
+    """Scatters rows to their variable indices when all swept."""
+    defaults = system.parameters.values_array
+    n = defaults.shape[0]
+    grid = np.arange(n * 3, dtype=float).reshape(n, 3)
+    indices = np.roll(np.arange(n), 1)
+    result = extend_grid_to_array(grid, indices, defaults)
+    for row, target in enumerate(indices):
+        assert_array_equal(result[target, :], grid[row, :])
+
+
 def test_extend_grid_partial_sweep(system):
     """Creates default array and overwrites swept indices."""
     defaults = system.parameters.values_array
@@ -298,6 +309,34 @@ def test_call_processes_inputs(input_handler, system):
         kind="combinatorial",
     )
     assert inits.shape[1] == params.shape[1] == 4
+
+
+def test_call_dict_order_independent(input_handler, system):
+    """Full dicts map by key name regardless of insertion order."""
+    state_names = list(system.initial_values.names)
+    param_names = list(system.parameters.names)
+    states = {
+        name: [float(i + 1)] for i, name in enumerate(state_names)
+    }
+    params = {
+        name: [10.0 * (i + 1)] for i, name in enumerate(param_names)
+    }
+    shuffled_states = {
+        name: states[name] for name in reversed(state_names)
+    }
+    shuffled_params = {
+        name: params[name] for name in reversed(param_names)
+    }
+    inits, param_arr = input_handler(states, params, "verbatim")
+    inits_s, params_s = input_handler(
+        shuffled_states, shuffled_params, "verbatim"
+    )
+    assert_array_equal(inits_s, inits)
+    assert_array_equal(params_s, param_arr)
+    expected_inits = np.arange(1.0, len(state_names) + 1.0)
+    expected_params = 10.0 * np.arange(1.0, len(param_names) + 1.0)
+    assert_array_equal(inits[:, 0], expected_inits)
+    assert_array_equal(param_arr[:, 0], expected_params)
 
 
 def test_call_aligns_run_counts(input_handler, system):


### PR DESCRIPTION
## Summary
Closes #530. `Solver.solve`/`solve_ivp` dict inputs were mapped onto the state/parameter arrays by dict insertion order whenever *every* variable was supplied: `extend_grid_to_array`'s all-swept fast path (`BatchInputHandler.py`) passed the grid through positionally, discarding the key->index mapping the grid builders had correctly computed. Two calls with identical key->value pairs in different insertion order silently integrated different systems with status 0.

## Fix
The all-swept fast path is removed; grid rows are always scattered to their variable indices (`array[indices, :] = grid`), for full and partial sweeps alike. Partial-dict default-filling semantics are unchanged, and unknown keys already raise `KeyError` upstream.

## Verification
- New unit test: all-swept grid with a permuted index vector lands each row at its target slot (fails on main).
- New end-to-end test: shuffled vs declared-order dicts produce identical `(variable, run)` arrays with the declared-order values.
- Issue reproducer (Lotka-Volterra, tsit5, real GPU): declared and shuffled orders now both return `[1.0263448, 0.90969104]`.
- `tests/batchsolving/test_batch_input_handler.py`: 72 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)