### PR TITLE
fix: no-op controller/algorithm updates keep buffer registration (#525)

### DIFF
--- a/src/cubie/batchsolving/solver.py
+++ b/src/cubie/batchsolving/solver.py
@@ -151,6 +151,12 @@ def solve_ivp(
     if summarise_variables is not None:
         kwargs.setdefault("summarise_variables", summarise_variables)
 
+    # Solve-time options go to solve(); the rest configure the Solver.
+    solve_option_keys = ("blocksize", "stream", "results_type")
+    solve_options = {
+        key: kwargs.pop(key) for key in solve_option_keys if key in kwargs
+    }
+
     solver = Solver(
         system,
         algorithm=method,
@@ -167,11 +173,11 @@ def solve_ivp(
         parameters,
         drivers=drivers,
         duration=duration,
-        warmup=settling_time,
+        settling_time=settling_time,
         t0=t0,
         grid_type=grid_type,
         nan_error_trajectories=nan_error_trajectories,
-        **kwargs,
+        **solve_options,
     )
 
     # Stop wall-clock timing (summary printed by Solver.solve)
@@ -281,6 +287,11 @@ class Solver:
             valid_keys=ALL_OUTPUT_FUNCTION_PARAMETERS,
             user_settings=output_settings,
         )
+        # Label kwargs are converted to index settings, not forwarded.
+        for key in ("save_variables", "summarise_variables"):
+            if key in kwargs:
+                output_settings.setdefault(key, kwargs[key])
+                output_recognized.add(key)
         self.convert_output_labels(output_settings)
 
         memory_settings, memory_recognized = merge_kwargs_into_settings(

--- a/src/cubie/batchsolving/solver.py
+++ b/src/cubie/batchsolving/solver.py
@@ -288,10 +288,12 @@ class Solver:
             user_settings=output_settings,
         )
         # Label kwargs are converted to index settings, not forwarded.
-        for key in ("save_variables", "summarise_variables"):
-            if key in kwargs:
-                output_settings.setdefault(key, kwargs[key])
-                output_recognized.add(key)
+        output_settings, label_recognized = merge_kwargs_into_settings(
+            kwargs=kwargs,
+            valid_keys=("save_variables", "summarise_variables"),
+            user_settings=output_settings,
+        )
+        output_recognized |= label_recognized
         self.convert_output_labels(output_settings)
 
         memory_settings, memory_recognized = merge_kwargs_into_settings(

--- a/src/cubie/integrators/SingleIntegratorRunCore.py
+++ b/src/cubie/integrators/SingleIntegratorRunCore.py
@@ -607,10 +607,9 @@ class SingleIntegratorRunCore(CUDAFactory):
             return set()
         precision = updates_dict.get('precision', self.precision)
 
-        buffer_registry.reset()
-
         new_algo = updates_dict.get("algorithm").lower()
         if new_algo != self.compile_settings.algorithm:
+            buffer_registry.reset()
             old_settings = self._algo_step.settings_dict
             old_settings["algorithm"] = new_algo
             self._algo_step = get_algorithm_step(
@@ -647,10 +646,10 @@ class SingleIntegratorRunCore(CUDAFactory):
             return set()
         precision = updates_dict.get('precision', self.precision)
 
-        buffer_registry.reset()
         new_controller = updates_dict.get("step_controller").lower()
 
         if new_controller != self.compile_settings.step_controller:
+            buffer_registry.reset()
             old_settings = self._step_controller.settings_dict
             old_settings["step_controller"] = new_controller
             old_settings["algorithm_order"] = updates_dict.get(

--- a/src/cubie/integrators/step_control/base_step_controller.py
+++ b/src/cubie/integrators/step_control/base_step_controller.py
@@ -400,7 +400,7 @@ class BaseStepController(CUDAFactory):
         # propagation
         recognised |= valid_but_inapplicable
 
-        if valid_but_inapplicable:
+        if valid_but_inapplicable and not silent:
             controller_type = self.__class__.__name__
             params_str = ", ".join(sorted(valid_but_inapplicable))
             warnings.warn(

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -450,6 +450,58 @@ def test_solve_ivp_function(
     assert isinstance(result, SolveResult)
 
 
+def test_solve_ivp_adaptive_controller(
+    system, simple_initial_values, simple_parameters, driver_settings
+):
+    """solve_ivp with an adaptive controller solves and keeps settings."""
+    result = solve_ivp(
+        system=system,
+        y0=simple_initial_values,
+        parameters=simple_parameters,
+        drivers=driver_settings,
+        method="tsit5",
+        step_controller="pi",
+        atol=1e-6,
+        rtol=1e-6,
+        dt_min=1e-7,
+        dt_max=0.1,
+        save_every=0.02,
+        duration=0.05,
+        output_types=["state", "time"],
+    )
+
+    assert isinstance(result, SolveResult)
+    spec = result.solve_settings
+    assert spec.atol == pytest.approx(1e-6)
+    assert spec.rtol == pytest.approx(1e-6)
+    assert spec.save_every == pytest.approx(0.02)
+
+
+def test_solve_ivp_forwards_save_every_and_settling_time(
+    system, simple_initial_values, simple_parameters, driver_settings
+):
+    """solve_ivp applies save_every and settling_time to the solve."""
+    result = solve_ivp(
+        system=system,
+        y0=simple_initial_values,
+        parameters=simple_parameters,
+        drivers=driver_settings,
+        method="euler",
+        dt=1e-2,
+        save_every=0.04,
+        duration=0.08,
+        settling_time=0.04,
+        output_types=["state", "time"],
+    )
+
+    spec = result.solve_settings
+    assert spec.save_every == pytest.approx(0.04)
+    assert spec.warmup == pytest.approx(0.04)
+    times = np.asarray(result.time)
+    times = times.reshape(times.shape[0], -1)[:, 0]
+    assert np.diff(times) == pytest.approx(0.04)
+
+
 def test_solver_with_different_algorithms(system, solver_settings):
     """Test solver with different algorithms."""
     algorithms = ["euler", "backwards_euler_pc"]

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -888,3 +888,24 @@ def test_duration_dependent_warning_on_solve(
             or "duration" in str(x.message).lower()
         ]
         assert len(timing_warns) >= 1
+
+
+# ── no-op selector updates keep buffer registration ───────────────────── #
+
+def test_update_same_selectors_still_builds(single_integrator_run_mutable):
+    """Re-supplying the current controller and algorithm names builds."""
+    run = single_integrator_run_mutable
+    run.update({
+        "step_controller": run.compile_settings.step_controller,
+        "algorithm": run.compile_settings.algorithm,
+    })
+    assert run.device_function is not None
+
+
+def test_update_controller_swap_builds(single_integrator_run_mutable):
+    """A genuine controller swap reconstructs and builds."""
+    run = single_integrator_run_mutable
+    target = "i" if run.compile_settings.step_controller != "i" else "pi"
+    run.update({"step_controller": target})
+    assert run.compile_settings.step_controller == target
+    assert run.device_function is not None


### PR DESCRIPTION
## Summary
Closes #525. `solve_ivp` with an adaptive controller died with `KeyError: 'Parent <AdaptivePIController...> has no registered buffer group'`. The issue's stated cause was inverted: the controller was *not* rebuilt on the update path — that was the bug. `_switch_controllers`/`_switch_algos` ran `buffer_registry.reset()` unconditionally whenever the selector key was present, wiping a buffer group that only controller *construction* (`register_buffers()` in `__init__`) would recreate; a same-name "switch" then skipped reconstruction and the next build crashed. The crash was reachable because `solve_ivp` forwarded its already-consumed constructor kwargs a second time into `Solver.solve -> update`.

## Fix
- `buffer_registry.reset()` now runs only when the controller/algorithm name actually changes (`SingleIntegratorRunCore`), making no-op selector updates idempotent on all entry points.
- `solve_ivp` applies configuration kwargs once, at construction, and forwards only solve-time options (`blocksize`, `stream`, `results_type`) to `solve()`.
- Verifying the reproducers uncovered two more forwarding defects, both fixed: `settling_time` was passed as an unrecognized `warmup=` kwarg (silently dropped), and `save_variables`/`summarise_variables` loose kwargs never reached output settings.
- Recognised-but-inapplicable controller parameters no longer warn when `silent=True`, removing the self-contradictory `Parameters {step_controller} are not recognized` warning on the update path.

`save_every` (issue item 2) was already fixed on main; a regression test now locks it in.

## Verification
- Issue reproducer (CUDASIM + GPU): adaptive `solve_ivp` returns status 0, y(1)=exp(-1), zero contradictory warnings; `save_every` and `settling_time` honoured.
- New tests: `solve_ivp` adaptive end-to-end, `save_every`/`settling_time` forwarding, and no-op selector update idempotency at the `SingleIntegratorRunCore` level (KeyError on main).
- Targeted suites (`test_solver.py`, `test_SingleIntegratorRunCore.py`, `step_control/`, `outputhandling`) on real GPU: 478 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)