### PR TITLE
fix: driver dict inputs map to system driver slots by key name

### DIFF
--- a/src/cubie/array_interpolator.py
+++ b/src/cubie/array_interpolator.py
@@ -757,8 +757,15 @@ class ArrayInterpolator(CUDAFactory):
     def check_against_system_drivers(
         inputs_dict: Dict[str, Union[float, bool, FloatArray]],
         system: "SymbolicODE",
-    ) -> None:
-        """Validate that input dictionary keys match system driver symbols.
+    ) -> Dict[str, Union[float, bool, FloatArray]]:
+        """Validate input keys and order driver columns by declared order.
+
+        The interpolator stacks driver arrays into columns in dictionary
+        insertion order and the compiled kernel reads those columns
+        positionally against the system's declared driver order. A user
+        supplying drivers in a different key order would otherwise have the
+        columns silently transposed, so the driver entries are reordered to
+        match the system before the interpolator consumes them.
 
         Parameters
         ----------
@@ -766,6 +773,13 @@ class ArrayInterpolator(CUDAFactory):
             Dictionary of input arrays to validate against the system.
         system
             SymbolicODE instance defining the expected driver symbols.
+
+        Returns
+        -------
+        dict
+            Copy of ``inputs_dict`` with driver entries reordered to the
+            system's declared driver order, followed by the remaining
+            configuration and timing entries in their original order.
 
         Raises
         ------
@@ -781,7 +795,8 @@ class ArrayInterpolator(CUDAFactory):
                 ArrayInterpolator.config_keys + ArrayInterpolator.time_info
             )
         ]
-        system_driver_keys = set(system.indices.drivers.symbol_map.keys())
+        driver_order = list(system.indices.driver_names)
+        system_driver_keys = set(driver_order)
         if len(input_keys) != system.num_drivers:
             raise ValueError(
                 f"Number of inputs in inputs_dict "
@@ -794,6 +809,12 @@ class ArrayInterpolator(CUDAFactory):
                 f"{set(input_keys)}) do not match drivers "
                 f"symbols in system ({system_driver_keys})."
             )
+
+        ordered = {name: inputs_dict[name] for name in driver_order}
+        for key, value in inputs_dict.items():
+            if key not in ordered:
+                ordered[key] = value
+        return ordered
 
     # ---------------------------------------------------------------------- #
     # Spline coefficient generation

--- a/src/cubie/array_interpolator.py
+++ b/src/cubie/array_interpolator.py
@@ -762,10 +762,9 @@ class ArrayInterpolator(CUDAFactory):
 
         The interpolator stacks driver arrays into columns in dictionary
         insertion order and the compiled kernel reads those columns
-        positionally against the system's declared driver order. A user
-        supplying drivers in a different key order would otherwise have the
-        columns silently transposed, so the driver entries are reordered to
-        match the system before the interpolator consumes them.
+        positionally against the system's declared driver order, so the
+        driver entries are reordered to match the system before the
+        interpolator consumes them.
 
         Parameters
         ----------

--- a/src/cubie/batchsolving/solver.py
+++ b/src/cubie/batchsolving/solver.py
@@ -447,7 +447,7 @@ class Solver:
 
         fn_changed = False
         if drivers is not None:
-            ArrayInterpolator.check_against_system_drivers(
+            drivers = ArrayInterpolator.check_against_system_drivers(
                 drivers, self.system
             )
             fn_changed = self.driver_interpolator.update_from_dict(drivers)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ from tests.system_fixtures import (
     build_three_state_linear_system,
     build_three_state_nonlinear_system,
     build_three_state_very_stiff_system,
+    build_two_driver_system,
 )
 
 enable_tempdir = "1"
@@ -210,6 +211,8 @@ def system(
         return build_three_state_nonlinear_system(precision)
     if model_type in ["three_chamber", "threecm"]:
         return build_three_chamber_system(precision)
+    if model_type == "two_driver":
+        return build_two_driver_system(precision)
     if model_type == "stiff":
         return build_three_state_very_stiff_system(precision)
     if model_type == "large":

--- a/tests/system_fixtures.py
+++ b/tests/system_fixtures.py
@@ -311,7 +311,40 @@ def build_three_state_constant_deriv_system(precision: np_dtype) -> BaseODE:
     return system
 
 
+# ---------------------------------------------------------------------------
+# Two-driver linear system
+# ---------------------------------------------------------------------------
+
+TWO_DRIVER_EQUATIONS = [
+    "du0 = d_a",
+    "du1 = d_b",
+]
+
+TWO_DRIVER_STATES = {"u0": 0.0, "u1": 0.0}
+TWO_DRIVER_DRIVERS = ["d_a", "d_b"]
+
+
+def build_two_driver_system(precision: np_dtype) -> BaseODE:
+    """Return the symbolic two-driver linear system.
+
+    Each state derivative tracks a distinct driver, so driver-to-column
+    alignment is observable directly in the trajectories.
+    """
+
+    system = create_ODE_system(
+        dxdt=TWO_DRIVER_EQUATIONS,
+        states=TWO_DRIVER_STATES,
+        drivers=TWO_DRIVER_DRIVERS,
+        precision=precision,
+        name="two_driver_linear",
+        strict=True,
+    )
+
+    return system
+
+
 __all__ = [
+    "build_two_driver_system",
     "build_three_state_linear_system",
     "build_three_state_nonlinear_system",
     "build_three_chamber_system",

--- a/tests/test_array_interpolator.py
+++ b/tests/test_array_interpolator.py
@@ -948,25 +948,16 @@ def test_cubic_interpolation_matches_analytic(cubic_inputs, precision, tolerance
         )
 
 
-def _two_driver_system(precision) -> SymbolicODE:
-    """Two-state system whose derivatives track distinct drivers."""
-
-    return SymbolicODE.create(
-        dxdt=["du0 = d_a", "du1 = d_b"],
-        states={"u0": precision(0.0), "u1": precision(0.0)},
-        drivers=["d_a", "d_b"],
-        precision=precision,
-        strict=True,
-        name="two_driver_order_lockin",
-    )
-
-
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{"system_type": "two_driver"}],
+    indirect=True,
+)
 def test_check_against_system_drivers_orders_by_declared_order(
-    precision,
+    system, precision
 ) -> None:
     """Driver entries are reordered to the system's declared order."""
 
-    system = _two_driver_system(precision)
     samples_a = np.full(6, 2.0, dtype=precision)
     samples_b = np.full(6, 5.0, dtype=precision)
     shuffled = {
@@ -985,12 +976,16 @@ def test_check_against_system_drivers_orders_by_declared_order(
     assert ordered["wrap"] is False
 
 
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{"system_type": "two_driver"}],
+    indirect=True,
+)
 def test_interpolator_columns_track_declared_driver_order(
-    precision,
+    system, precision
 ) -> None:
     """Coefficient columns align with declared drivers for any key order."""
 
-    system = _two_driver_system(precision)
     samples_a = np.full(6, 2.0, dtype=precision)
     samples_b = np.full(6, 5.0, dtype=precision)
 

--- a/tests/test_array_interpolator.py
+++ b/tests/test_array_interpolator.py
@@ -947,3 +947,85 @@ def test_cubic_interpolation_matches_analytic(cubic_inputs, precision, tolerance
             f"expected: {np.array2string(expected)}")
         )
 
+
+def _two_driver_system(precision) -> SymbolicODE:
+    """Two-state system whose derivatives track distinct drivers."""
+
+    return SymbolicODE.create(
+        dxdt=["du0 = d_a", "du1 = d_b"],
+        states={"u0": precision(0.0), "u1": precision(0.0)},
+        drivers=["d_a", "d_b"],
+        precision=precision,
+        strict=True,
+        name="two_driver_order_lockin",
+    )
+
+
+def test_check_against_system_drivers_orders_by_declared_order(
+    precision,
+) -> None:
+    """Driver entries are reordered to the system's declared order."""
+
+    system = _two_driver_system(precision)
+    samples_a = np.full(6, 2.0, dtype=precision)
+    samples_b = np.full(6, 5.0, dtype=precision)
+    shuffled = {
+        "d_b": samples_b,
+        "d_a": samples_a,
+        "dt": precision(0.1),
+        "wrap": False,
+    }
+
+    ordered = ArrayInterpolator.check_against_system_drivers(shuffled, system)
+
+    driver_keys = [key for key in ordered if key in ("d_a", "d_b")]
+    assert driver_keys == list(system.indices.driver_names)
+    # Non-driver configuration/timing entries are preserved.
+    assert ordered["dt"] == precision(0.1)
+    assert ordered["wrap"] is False
+
+
+def test_interpolator_columns_track_declared_driver_order(
+    precision,
+) -> None:
+    """Coefficient columns align with declared drivers for any key order."""
+
+    system = _two_driver_system(precision)
+    samples_a = np.full(6, 2.0, dtype=precision)
+    samples_b = np.full(6, 5.0, dtype=precision)
+
+    forward = {
+        "d_a": samples_a,
+        "d_b": samples_b,
+        "dt": precision(0.1),
+    }
+    reversed_dict = {
+        "d_b": samples_b,
+        "d_a": samples_a,
+        "dt": precision(0.1),
+    }
+
+    forward_interp = ArrayInterpolator(
+        precision=precision,
+        input_dict=ArrayInterpolator.check_against_system_drivers(
+            forward, system
+        ),
+    )
+    reversed_interp = ArrayInterpolator(
+        precision=precision,
+        input_dict=ArrayInterpolator.check_against_system_drivers(
+            reversed_dict, system
+        ),
+    )
+
+    # Column 0 holds d_a (constant 2.0), column 1 holds d_b (constant 5.0)
+    # regardless of the caller's insertion order.
+    np.testing.assert_array_equal(
+        forward_interp.coefficients[0, :, 0],
+        np.array([2.0, 5.0], dtype=precision),
+    )
+    np.testing.assert_array_equal(
+        reversed_interp.coefficients[0, :, 0],
+        forward_interp.coefficients[0, :, 0],
+    )
+


### PR DESCRIPTION
## Summary
Sibling of #530, on the driver path (found while fixing #530; PR #532 covers states/parameters). Driver dicts were stacked into interpolator columns in dict insertion order (`_normalise_input_array` uses `list(input_dict.values())`), while the compiled kernel reads driver columns positionally against the system's *declared* driver order (`IndexedBaseMap` assigns indices by declaration). `check_against_system_drivers` validated only the key set, so `drivers={"d_b": ..., "d_a": ...}` silently transposed the drivers with status 0.

Empirical demonstration (2-driver system, `du0 = d_a` const 2.0 / `du1 = d_b` const 5.0): before the fix, reversed insertion order returned `[5, 2]` instead of `[2, 5]`.

## Fix
`check_against_system_drivers` now returns the input dict with driver entries reordered to the system's declared driver order (config/timing keys preserved), and `Solver.solve` consumes the returned dict — the one chokepoint where system context exists. Full-dict validation and error behaviour are unchanged.

## Verification (real GPU)
- New lock-in tests: reordering by declared order, and coefficient columns identical across insertion orders (fail on main).
- `tests/test_array_interpolator.py`: 25 passed; `tests/batchsolving/test_solver.py`: 56 passed; `tests/integrators/loops/test_interp_vs_symbolic.py`: 1 passed.

None of the shared test fixtures use 2+ drivers, which is why this was never caught — worth a follow-up fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)