### PR TITLE
fix: PI controller class defaults use the canonical predictive gain pair

### DIFF
--- a/src/cubie/integrators/step_control/AGENTS.md
+++ b/src/cubie/integrators/step_control/AGENTS.md
@@ -22,7 +22,7 @@ controllers.
 | `adaptive_step_controller.py` | `BaseAdaptiveStepController` + `AdaptiveStepControlConfig` (shared adaptive config: `dt_min/max`, `atol/rtol`, `algorithm_order`, gain limits, deadband, safety); `_ensure_sane_bounds`. |
 | `fixed_step_controller.py` | `FixedStepController` — unconditional accept, returns `0`; no history. |
 | `adaptive_I_controller.py` | `AdaptiveIController` — integral-only; gain `safety·norm^(-1/(2(1+order)))`; no history. |
-| `adaptive_PI_controller.py` | `AdaptivePIController` (`kp=1/18`, `ki=1/9`) — uses previous + current norm. |
+| `adaptive_PI_controller.py` | `AdaptivePIController` (`kp=0.7`, `ki=-0.4`) — uses previous + current norm. |
 | `adaptive_PID_controller.py` | `AdaptivePIDController` (`PIDStepControlConfig` extends PI with `kd=0.0`) — uses two previous norms. |
 | `gustafsson_controller.py` | `GustafssonController` (`gamma=0.9`, `newton_max_iters=20`) — min of a basic gain and a Newton-iteration-aware predictive gain; stores previous `dt` + norm. |
 

--- a/src/cubie/integrators/step_control/adaptive_PI_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_PI_controller.py
@@ -7,8 +7,8 @@ Published Classes
 
     >>> from numpy import float64
     >>> config = PIStepControlConfig(precision=float64)
-    >>> config.kp  # doctest: +ELLIPSIS
-    0.055...
+    >>> float(config.kp)
+    0.7
 
 :class:`AdaptivePIController`
     Proportional--integral step-size controller.
@@ -55,10 +55,10 @@ class PIStepControlConfig(AdaptiveStepControlConfig):
     """
 
     _kp: float = field(
-        default=1 / 18, validator=validators.instance_of(_expand_dtype(float))
+        default=0.7, validator=validators.instance_of(_expand_dtype(float))
     )
     _ki: float = field(
-        default=1 / 9, validator=validators.instance_of(_expand_dtype(float))
+        default=-0.4, validator=validators.instance_of(_expand_dtype(float))
     )
 
     def __attrs_post_init__(self):


### PR DESCRIPTION
## Summary
Follow-up to the #529 investigation, which flagged the Rosenbrock defaults' `ki=-0.4` as suspicious. A full audit of every step-controller gain default against the literature, in cubie's own convention, shows the opposite: the device PI gain is `safety * nrm2^(-kp/((order+1)*2)) * err_prev^(-ki/((order+1)*2))` with `nrm2` the *squared* RMS error, which collapses to `err_n^(-kp/(order+1)) * err_prev^(-ki/(order+1))`. Matching Hairer–Wanner's predictive PI (`h_new = h * err_n^(-0.7/(p+1)) * err_{n-1}^(+0.4/(p+1))`, Solving ODEs II §IV.2) gives exactly `kp=0.7, ki=-0.4` — a **negative** `ki` is the standard predictive term, and the per-algorithm defaults (Rosenbrock/FIRK `0.6/-0.4`, DIRK/ERK `0.7/-0.4`) are correct.

The genuinely wrong default was `PIStepControlConfig` itself: `kp=1/18, ki=+1/9` — anti-predictive sign (penalises instead of exploiting the previous error) and ~12x below canonical magnitude, inconsistent with every per-algorithm default and with the CPU reference controller (`kp=0.7, ki=-0.4`).

## Change
`PIStepControlConfig` defaults become `kp=0.7, ki=-0.4` (the canonical Hairer/SciML pair); docstring doctest and `AGENTS.md` reference updated. All other audited defaults (PID `kd=0`, deadbands, gain clamps, safety 0.9, Gustafsson gamma) are left unchanged as correct or defensible — audit table in the commit discussion below.

## Verification (real GPU)
- `tests/integrators/step_control` + `tests/integrated_numerical_tests/test_step_controllers.py`: 115 passed.
- `tests/batchsolving/test_config_plumbing.py`: 6 passed.
- End-to-end adaptive solve matches analytic decay to 6 decimals.

Note: `min_gain*max_gain == 1` (which closed #529's limit cycle) is defensible per the literature and left alone — the cycle itself is defused by #535's rejection cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)