### PR TITLE
fix: package source edits invalidate compiled-kernel and codegen caches

### DIFF
--- a/src/cubie/_utils.py
+++ b/src/cubie/_utils.py
@@ -53,7 +53,9 @@ See Also
     ``buffer_dtype_validator``.
 """
 
-from typing import Any, Tuple, Union, Optional, Iterable, Set
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Dict, Tuple, Union, Optional, Iterable, Set
 from warnings import warn
 
 from numpy import (
@@ -92,6 +94,48 @@ ALLOWED_PRECISIONS = {
     np_dtype(np_float32),
     np_dtype(np_float64),
 }
+
+_package_source_hashes: Dict[str, str] = {}
+
+
+def package_source_hash(package_dir: Optional[Path] = None) -> str:
+    """Content hash of every Python source file under a package.
+
+    Both cache layers fold this digest into their keys so that any
+    edit to the installed cubie source invalidates compiled kernels
+    and generated code, which are otherwise keyed only on
+    configuration values and the system definition.
+
+    Parameters
+    ----------
+    package_dir
+        Directory whose ``**/*.py`` files are hashed. Defaults to the
+        installed ``cubie`` package directory.
+
+    Returns
+    -------
+    str
+        64-character SHA256 hex digest over the sorted relative paths
+        and file contents. Memoised per directory for the lifetime of
+        the process.
+    """
+    if package_dir is None:
+        package_dir = Path(__file__).parent
+    package_dir = Path(package_dir).resolve()
+    key = str(package_dir)
+    cached = _package_source_hashes.get(key)
+    if cached is not None:
+        return cached
+    digest = sha256()
+    for source_path in sorted(package_dir.rglob("*.py")):
+        relative = source_path.relative_to(package_dir).as_posix()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\x00")
+        digest.update(source_path.read_bytes())
+        digest.update(b"\x00")
+    result = digest.hexdigest()
+    _package_source_hashes[key] = result
+    return result
 
 ALLOWED_BUFFER_DTYPES = {
     np_dtype(np_float16),

--- a/src/cubie/cubie_cache.py
+++ b/src/cubie/cubie_cache.py
@@ -34,6 +34,7 @@ from numba.cuda.core.caching import (  # noqa: F401
 from cubie.cuda_simsafe import is_cudasim_enabled, CUDACache
 from cubie.odesystems.symbolic.odefile import GENERATED_DIR
 from cubie.time_logger import default_timelogger
+from cubie._utils import package_source_hash
 
 # Register compile timing event with custom messages
 default_timelogger.register_event(
@@ -412,13 +413,16 @@ class CUBIECache(CUDACache):
         Returns
         -------
         tuple
-            Composite cache key.
+            Composite cache key. Includes the cubie package source
+            hash so package edits invalidate cached kernels compiled
+            from earlier source.
         """
         return (
             sig,
             codegen.magic_tuple(),
             self._system_hash,
             self._compile_settings_hash,
+            package_source_hash(),
         )
 
     def load_overload(self, sig, target_context):

--- a/src/cubie/odesystems/symbolic/odefile.py
+++ b/src/cubie/odesystems/symbolic/odefile.py
@@ -30,10 +30,21 @@ from os import getcwd
 from pathlib import Path
 from typing import Callable, Optional, Tuple
 
+from cubie._utils import package_source_hash
 from cubie.time_logger import default_timelogger
 
 cwd = getcwd()
 GENERATED_DIR = Path(cwd) / "generated"
+
+
+def _salted_hash(fn_hash) -> str:
+    """Combine a system definition hash with the package source hash.
+
+    The stored file hash carries both, so generated source is
+    regenerated when the codegen machinery changes, not only when the
+    system definition does.
+    """
+    return f"{fn_hash}-{package_source_hash()[:16]}"
 
 HEADER = ("\n# This file was generated automatically by Cubie. Don't make "
           "changes in here - they'll just be overwritten! Instead, modify "
@@ -79,7 +90,7 @@ class ODEFile:
         """
         if not self.cached_file_valid(fn_hash):
             with open(self.file_path, "w", encoding="utf-8") as f:
-                f.write(f"#{fn_hash}")
+                f.write(f"#{_salted_hash(fn_hash)}")
                 f.write("\n")
                 f.write(HEADER)
             return True
@@ -96,12 +107,13 @@ class ODEFile:
         Returns
         -------
         bool
-            ``True`` when the stored hash matches ``fn_hash``.
+            ``True`` when the stored hash matches ``fn_hash`` combined
+            with the current package source hash.
         """
         if self.file_path.exists():
             with open(self.file_path, "r", encoding="utf-8") as f:
                 existing_hash = f.readline().strip().lstrip("#")
-                if existing_hash == str(fn_hash):
+                if existing_hash == _salted_hash(fn_hash):
                     return True
         return False
 

--- a/tests/odesystems/symbolic/test_odefile.py
+++ b/tests/odesystems/symbolic/test_odefile.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import uuid
-from pathlib import Path
 
 import pytest
 
-from cubie.odesystems.symbolic.odefile import HEADER, ODEFile
+from cubie.odesystems.symbolic.odefile import (
+    HEADER,
+    ODEFile,
+    _salted_hash,
+)
+from cubie._utils import package_source_hash
 
 
 def _simple_code(func_name: str) -> str:
@@ -39,12 +43,26 @@ def test_init_sets_file_path(codegen_dir):
 
 
 def test_init_calls_init_file(codegen_dir):
-    """__init__ writes the file with hash and header."""
+    """__init__ writes the file with the salted hash and header."""
     name = f"test_{uuid.uuid4().hex}"
     odf = ODEFile(name, 42)
     text = odf.file_path.read_text(encoding="utf-8")
-    assert text.startswith("#42")
+    assert text.startswith(f"#{_salted_hash(42)}\n")
     assert "# This file was generated automatically" in text
+
+
+def test_salted_hash_includes_package_source_hash():
+    """The stored hash combines fn_hash with the package source hash."""
+    assert _salted_hash(42) == f"42-{package_source_hash()[:16]}"
+
+
+def test_cached_file_valid_false_on_stale_package_salt(codegen_dir):
+    """A file written under different package source is invalid."""
+    name = f"test_{uuid.uuid4().hex}"
+    odf = ODEFile(name, 777)
+    stale = f"#777-{'0' * 16}\n{HEADER}"
+    odf.file_path.write_text(stale, encoding="utf-8")
+    assert odf.cached_file_valid(777) is False
 
 
 # ── _init_file ────────────────────────────────────────────────── #

--- a/tests/test_cubie_cache.py
+++ b/tests/test_cubie_cache.py
@@ -13,6 +13,7 @@ from cubie.cubie_cache import (
     CacheConfig,
     ALL_CACHE_PARAMETERS,
 )
+from cubie._utils import package_source_hash
 
 
 # --- Test fixtures (attrs classes for testing) ---
@@ -215,12 +216,13 @@ def test_cubie_cache_index_key():
 
     key = cache._index_key(sig, codegen)
 
-    # Key should be tuple of (sig, magic_tuple, system_hash, config_hash)
-    assert len(key) == 4
+    # Key is (sig, magic_tuple, system_hash, config_hash, package_hash)
+    assert len(key) == 5
     assert key[0] == sig
     assert key[1] == ("magic", "tuple")
     assert key[2] == "abc123"
     assert key[3] == config_hash
+    assert key[4] == package_source_hash()
 
 
 def test_cubie_cache_path():

--- a/tests/test_package_source_hash.py
+++ b/tests/test_package_source_hash.py
@@ -1,0 +1,62 @@
+"""Tests for the package source hash used to salt both cache layers."""
+
+import re
+
+from cubie._utils import package_source_hash
+
+
+def _make_package(root, files):
+    for relative, content in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+def test_default_hash_is_hex_digest():
+    result = package_source_hash()
+    assert re.fullmatch(r"[0-9a-f]{64}", result)
+
+
+def test_default_hash_is_memoised():
+    assert package_source_hash() == package_source_hash()
+
+
+def test_hash_is_deterministic_for_directory(tmp_path):
+    _make_package(tmp_path, {"a.py": "x = 1\n", "sub/b.py": "y = 2\n"})
+    first = package_source_hash(tmp_path)
+    assert re.fullmatch(r"[0-9a-f]{64}", first)
+
+
+def test_hash_changes_when_content_changes(tmp_path):
+    package_a = tmp_path / "a"
+    package_b = tmp_path / "b"
+    _make_package(package_a, {"mod.py": "x = 1\n"})
+    _make_package(package_b, {"mod.py": "x = 2\n"})
+    assert package_source_hash(package_a) != package_source_hash(package_b)
+
+
+def test_hash_changes_when_file_added(tmp_path):
+    package_a = tmp_path / "a"
+    package_b = tmp_path / "b"
+    _make_package(package_a, {"mod.py": "x = 1\n"})
+    _make_package(
+        package_b, {"mod.py": "x = 1\n", "extra.py": "y = 2\n"}
+    )
+    assert package_source_hash(package_a) != package_source_hash(package_b)
+
+
+def test_hash_changes_when_file_renamed(tmp_path):
+    package_a = tmp_path / "a"
+    package_b = tmp_path / "b"
+    _make_package(package_a, {"mod.py": "x = 1\n"})
+    _make_package(package_b, {"dom.py": "x = 1\n"})
+    assert package_source_hash(package_a) != package_source_hash(package_b)
+
+
+def test_hash_ignores_non_python_files(tmp_path):
+    package_a = tmp_path / "a"
+    package_b = tmp_path / "b"
+    _make_package(package_a, {"mod.py": "x = 1\n"})
+    _make_package(package_b, {"mod.py": "x = 1\n"})
+    (package_b / "notes.txt").write_text("irrelevant", encoding="utf-8")
+    assert package_source_hash(package_a) == package_source_hash(package_b)

--- a/tests/test_package_source_hash.py
+++ b/tests/test_package_source_hash.py
@@ -22,9 +22,16 @@ def test_default_hash_is_memoised():
 
 
 def test_hash_is_deterministic_for_directory(tmp_path):
-    _make_package(tmp_path, {"a.py": "x = 1\n", "sub/b.py": "y = 2\n"})
-    first = package_source_hash(tmp_path)
+    package_a = tmp_path / "a"
+    package_b = tmp_path / "b"
+    files = {"a.py": "x = 1\n", "sub/b.py": "y = 2\n"}
+    _make_package(package_a, files)
+    _make_package(package_b, files)
+    first = package_source_hash(package_a)
     assert re.fullmatch(r"[0-9a-f]{64}", first)
+    # Identical content at a different resolved path hashes the same,
+    # so the digest is content-driven rather than path- or run-local.
+    assert package_source_hash(package_b) == first
 
 
 def test_hash_changes_when_content_changes(tmp_path):


### PR DESCRIPTION
Fixes #521.

## Problem

Neither cache layer knew anything about cubie's own source. Device-function fields are `eq=False` so `config_hash` covers only configuration values; `CUBIECache._index_key` was `(sig, magic_tuple, system_hash, config_hash)` with `get_source_stamp()` returning the system hash; and the `generated/` source cache is keyed on `fn_hash` (equations + labels only). Editing the loop, an algorithm, a metric, or the codegen printer silently reused stale compiled kernels and stale generated source — this bit during #540 verification, where the loop fix was invisible on GPU until `generated/` was cleared manually.

## Fix

A single salt shared by both layers: `package_source_hash()` in `_utils.py` — a SHA256 over the sorted relative paths and contents of every `.py` under the installed `cubie` package, memoised per process (~28 ms cold over 135 files, ~0.2 µs after).

- **Kernel cache:** `CUBIECache._index_key` gains the digest as a fifth component.
- **Codegen cache:** `ODEFile` stores and validates `fn_hash` salted with the digest's first 16 hex digits, so a codegen/printer change regenerates the source file; the raw-hash public API is unchanged (both write and check paths salt consistently).

Issue #521 proposed pyfunc-code equality feeding the config hash; after discussion the package-content salt was chosen instead: it catches strictly more (module-level helpers, codegen machinery, vendored code) with none of the recursive-hash determinism risk, trading away only fine-grained invalidation (any package edit recompiles everything once — the desired behavior for editable installs, and a once-per-upgrade cost for released users).

## Verification

End-to-end on real GPU (fresh subprocess per run):
1. cold run compiles; 2. warm run reuses the cached kernel; 3. after appending a comment to `ode_loop.py`: kernel **recompiles** and the generated file's stored hash changes; 4. after reverting: the original cached kernel is reused without compiling and the stored hash returns to its original value.

Tests: `package_source_hash` sensitivity (content/add/rename changes it; non-`.py` ignored; memoised), `ODEFile` salted-header round-trip and stale-salt rejection, `_index_key` fifth component. CUDASIM: cache/odefile/config suites 104 passed; `tests/odesystems` + `tests/batchsolving` 915 passed with the single known `test_solve_info_property` ordering flake (pre-existing on the base, fixed by #541).

🤖 Generated with [Claude Code](https://claude.com/claude-code)