### PR TITLE
fix: negative tolerances rejected; sdirk_2_2 declared errorless

### DIFF
--- a/src/cubie/_utils.py
+++ b/src/cubie/_utils.py
@@ -302,6 +302,18 @@ def float_array_validator(instance, attribute, value):
         raise ValueError(f"{attribute} must not contain NaNs or infinities.")
 
 
+def nonnegative_float_array_validator(instance, attribute, value):
+    """Validate a finite float array with no negative elements.
+
+    Applies :func:`float_array_validator`, then raises a ValueError if
+    any element is negative. Used for tolerance arrays, where negative
+    values would corrupt the scaled error norm.
+    """
+    float_array_validator(instance, attribute, value)
+    if not np_all(value >= 0):
+        raise ValueError(f"{attribute} must not contain negative values.")
+
+
 def inrangetype_validator(dtype, min_, max_):
     """Return a composite attrs validator for type and range checks.
 

--- a/src/cubie/integrators/algorithms/generic_dirk_tableaus.py
+++ b/src/cubie/integrators/algorithms/generic_dirk_tableaus.py
@@ -155,16 +155,16 @@ SDIRK_2_2_TABLEAU = DIRKTableau(
         (1.0 - SDIRK2_GAMMA, SDIRK2_GAMMA),
     ),
     b=(1 - SDIRK2_GAMMA, SDIRK2_GAMMA),
-    # b_hat=(1.0, 0.0),
     c=(SDIRK2_GAMMA, 1.0),
     order=2,
 )
 """Two-stage, second-order SDIRK tableau by Alexander.
 
 The tableau is L-stable and singly diagonally implicit with diagonal
-coefficient :math:`1 - \\tfrac{1}{\\sqrt{2}}`. The embedded weights provide
-an error estimate suitable for adaptive step controllers. No natural 
-embedded pair exists - other implementations use a divided difference approach.
+coefficient :math:`1 - \\tfrac{1}{\\sqrt{2}}`. No natural embedded pair
+exists, so the method carries no error estimate and requires a fixed
+step controller; other implementations derive an estimate via divided
+differences.
 
 References
 ----------

--- a/src/cubie/integrators/norms.py
+++ b/src/cubie/integrators/norms.py
@@ -31,8 +31,8 @@ from attrs import define, field, Converter
 from cubie._utils import (
     PrecisionDType,
     build_config,
-    float_array_validator,
     getype_validator,
+    nonnegative_float_array_validator,
     is_device_validator,
     tol_converter,
 )
@@ -104,13 +104,13 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
     )
     atol: ndarray = field(
         default=asarray([1e-6]),
-        validator=float_array_validator,
+        validator=nonnegative_float_array_validator,
         converter=Converter(tol_converter, takes_self=True),
         metadata={"prefixed": True},
     )
     rtol: ndarray = field(
         default=asarray([1e-6]),
-        validator=float_array_validator,
+        validator=nonnegative_float_array_validator,
         converter=Converter(tol_converter, takes_self=True),
         metadata={"prefixed": True},
     )

--- a/src/cubie/integrators/step_control/adaptive_step_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_step_controller.py
@@ -32,8 +32,8 @@ from numpy.typing import ArrayLike
 from cubie._utils import (
     PrecisionDType,
     clamp_factory,
-    float_array_validator,
     getype_validator,
+    nonnegative_float_array_validator,
     inrangetype_validator,
     opt_getype_validator,
     tol_converter,
@@ -61,12 +61,12 @@ class AdaptiveStepControlConfig(BaseStepControllerConfig):
     )
     atol: ndarray = field(
         default=asarray([1e-6]),
-        validator=float_array_validator,
+        validator=nonnegative_float_array_validator,
         converter=Converter(tol_converter, takes_self=True),
     )
     rtol: ndarray = field(
         default=asarray([1e-6]),
-        validator=float_array_validator,
+        validator=nonnegative_float_array_validator,
         converter=Converter(tol_converter, takes_self=True),
     )
     algorithm_order: int = field(default=1, validator=getype_validator(int, 1))

--- a/tests/integrators/step_control/test_adaptive_step_controller.py
+++ b/tests/integrators/step_control/test_adaptive_step_controller.py
@@ -39,6 +39,30 @@ def test_config_dt_min_validates_positive():
         AdaptiveStepControlConfig(precision=np.float64, dt_min=-1.0)
 
 
+def test_config_negative_atol_rejected():
+    """atol rejects arrays containing negative values."""
+    with pytest.raises(ValueError):
+        AdaptiveStepControlConfig(precision=np.float64, atol=-1e-6)
+
+
+def test_config_negative_rtol_rejected():
+    """rtol rejects arrays containing negative elements."""
+    with pytest.raises(ValueError):
+        AdaptiveStepControlConfig(
+            precision=np.float64,
+            rtol=np.asarray([1e-6, -1e-6]),
+        )
+
+
+def test_config_zero_tolerances_accepted():
+    """Zero tolerances are valid; the norm floors the combined value."""
+    cfg = AdaptiveStepControlConfig(
+        precision=np.float64, atol=0.0, rtol=0.0
+    )
+    assert_array_equal(cfg.atol, np.asarray([0.0]))
+    assert_array_equal(cfg.rtol, np.asarray([0.0]))
+
+
 def test_config_algorithm_order_validates_ge_1():
     """algorithm_order rejects values < 1."""
     with pytest.raises((ValueError, TypeError)):

--- a/tests/integrators/test_norms.py
+++ b/tests/integrators/test_norms.py
@@ -53,6 +53,26 @@ def test_config_scalar_tolerance_broadcast():
     assert_allclose(cfg.rtol, np.full(4, 1e-4))
 
 
+def test_config_negative_atol_rejected():
+    """atol rejects arrays containing negative values."""
+    with pytest.raises(ValueError):
+        ScaledNormConfig(precision=np.float64, n=2, atol=-1e-6)
+
+
+def test_config_negative_rtol_rejected():
+    """rtol rejects arrays containing negative elements."""
+    rtol = np.array([1e-4, -1e-4], dtype=np.float64)
+    with pytest.raises(ValueError):
+        ScaledNormConfig(precision=np.float64, n=2, rtol=rtol)
+
+
+def test_config_zero_tolerances_accepted():
+    """Zero tolerances are valid; tol_floor guards the division."""
+    cfg = ScaledNormConfig(precision=np.float64, n=2, atol=0.0, rtol=0.0)
+    assert_allclose(cfg.atol, np.zeros(2))
+    assert_allclose(cfg.rtol, np.zeros(2))
+
+
 def test_config_inv_n():
     """inv_n returns precision(1.0/n)."""
     cfg = ScaledNormConfig(precision=np.float32, n=5)


### PR DESCRIPTION
## Summary
- `atol`/`rtol` (adaptive step controllers) and the Newton/Krylov solver-norm tolerances are validated as non-negative via a new `nonnegative_float_array_validator`; negative values raise `ValueError`. Zero stays valid — `ScaledNorm` floors the combined tolerance, and scipy-style `atol=0` usage is legitimate.
- `SDIRK_2_2_TABLEAU`'s commented-out `b_hat` is removed and its docstring no longer claims an embedded error estimate (it contradicted itself: "embedded weights provide an error estimate ... no natural embedded pair exists"). The method is errorless and pairs with the fixed step controller.

Both surfaced from a docs-vs-code audit: the user guide claimed negative tolerances were rejected (they weren't) and listed `sdirk_2_2` as adaptive (it isn't).

## Testing
- 6 new tests: negative-`atol`/`rtol` rejection and zero-tolerance acceptance in `tests/integrators/test_norms.py` and `tests/integrators/step_control/test_adaptive_step_controller.py`.
- Regression: 79 tests (norms, adaptive-controller config, DIRK tableaus) under CUDASIM and 241 tests (norms, all of `step_control/` and `matrix_free_solvers/`, DIRK tableaus) on a real GPU — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)