### PR TITLE
fix: constant power exponents lower to multiplication chains

### DIFF
--- a/src/cubie/odesystems/symbolic/codegen/AGENTS.md
+++ b/src/cubie/odesystems/symbolic/codegen/AGENTS.md
@@ -97,6 +97,13 @@ set.
   exponents — the `_in_index`/`_in_pow` context flags suppress wrapping (so indices stay integer
   and the `x**2`→`x*x` / `x**3`→`x*x*x` rewrite can match). Set/restore them in any new `_print_*`
   that recurses into indices or exponents.
+- A symbol exponent naming a factory-scope constant (passed via the printer's `constant_names`)
+  prints as its integer-exponent alias (`sym_utils.EXPONENT_ALIAS_PREFIX + name`);
+  `render_constant_assignments` emits the alias per constant (`int(value)` when integral and in
+  int64 range, else the precision-cast value), so integral constant exponents lower to
+  multiplication chains instead of `pow` calls while the generated source stays independent of
+  constant values. Generators pass `constant_names=index_map.constants.symbol_map` to
+  `print_cuda_multiple`.
 - Function resolution: `CUDA_FUNCTIONS` → `symbol_map["__function_aliases__"]` → `d_`-prefixed
   derivative passthrough → plain-call fallback; it never raises `PrintMethodNotImplementedError`.
 - `Piecewise` emits as nested ternaries; scalar symbols remap to array refs via `symbol_map`.

--- a/src/cubie/odesystems/symbolic/codegen/dxdt.py
+++ b/src/cubie/odesystems/symbolic/codegen/dxdt.py
@@ -131,7 +131,11 @@ def generate_dxdt_lines(
                                              output_symbols=index_map.dxdt.ref_map.keys())
         symbol_map = index_map.all_arrayrefs
 
-    dxdt_lines = print_cuda_multiple(processed, symbol_map=symbol_map)
+    dxdt_lines = print_cuda_multiple(
+        processed,
+        symbol_map=symbol_map,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not dxdt_lines:
         dxdt_lines = ["pass"]
     return dxdt_lines
@@ -191,7 +195,9 @@ def generate_observables_lines(
     ]
     substituted = prune_unused_assignments(substituted, "observables")
     obs_lines = print_cuda_multiple(
-        substituted, symbol_map=index_map.all_arrayrefs
+        substituted,
+        symbol_map=index_map.all_arrayrefs,
+        constant_names=index_map.constants.symbol_map,
     )
     if not obs_lines:
         obs_lines = ["pass"]

--- a/src/cubie/odesystems/symbolic/codegen/linear_operators.py
+++ b/src/cubie/odesystems/symbolic/codegen/linear_operators.py
@@ -305,7 +305,11 @@ def _build_operator_body(
     exprs = mass_assigns + aux_assignments + out_updates
     exprs = prune_unused_assignments(exprs, outputsym_str='out')
 
-    lines = print_cuda_multiple(exprs, symbol_map=index_map.all_arrayrefs)
+    lines = print_cuda_multiple(
+        exprs,
+        symbol_map=index_map.all_arrayrefs,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not lines:
         return "        pass"
     return "\n".join("        " + ln for ln in lines)
@@ -340,7 +344,11 @@ def _build_cached_jvp_body(
     exprs = aux_assignments + out_updates
     exprs = prune_unused_assignments(exprs, outputsym_str='out')
 
-    lines = print_cuda_multiple(exprs, symbol_map=index_map.all_arrayrefs)
+    lines = print_cuda_multiple(
+        exprs,
+        symbol_map=index_map.all_arrayrefs,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not lines:
         return "        pass"
     return "\n".join("        " + ln for ln in lines)
@@ -368,7 +376,11 @@ def _build_prepare_body(
             exprs.append((cached[idx], lhs))
     exprs = prune_unused_assignments(exprs, outputsym_str='cached_aux')
 
-    lines = print_cuda_multiple(exprs, symbol_map=index_map.all_arrayrefs)
+    lines = print_cuda_multiple(
+        exprs,
+        symbol_map=index_map.all_arrayrefs,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not lines:
         return "        pass"
     return "\n".join("        " + ln for ln in lines)
@@ -752,7 +764,11 @@ def _build_n_stage_operator_lines(
     eval_exprs = prune_unused_assignments(eval_exprs,
                                           outputsym_str='out')
 
-    lines = print_cuda_multiple(eval_exprs, symbol_map=symbol_map)
+    lines = print_cuda_multiple(
+        eval_exprs,
+        symbol_map=symbol_map,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not lines:
         return "        pass"
     return "\n".join("        " + ln for ln in lines)

--- a/src/cubie/odesystems/symbolic/codegen/nonlinear_residuals.py
+++ b/src/cubie/odesystems/symbolic/codegen/nonlinear_residuals.py
@@ -193,7 +193,11 @@ def _build_residual_lines(
         eval_exprs = topological_sort(eval_exprs)
     eval_exprs = prune_unused_assignments(eval_exprs, outputsym_str='out')
 
-    lines = print_cuda_multiple(eval_exprs, symbol_map=symbol_map)
+    lines = print_cuda_multiple(
+        eval_exprs,
+        symbol_map=symbol_map,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not lines:
         return "        pass"
     return "\n".join("        " + ln for ln in lines)
@@ -316,7 +320,11 @@ def _build_n_stage_residual_lines(
     )
 
     eval_exprs = prune_unused_assignments(eval_exprs, outputsym_str='out')
-    lines = print_cuda_multiple(eval_exprs, symbol_map=symbol_map)
+    lines = print_cuda_multiple(
+        eval_exprs,
+        symbol_map=symbol_map,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not lines:
         return "        pass"
     return "\n".join("        " + ln for ln in lines)

--- a/src/cubie/odesystems/symbolic/codegen/numba_cuda_printer.py
+++ b/src/cubie/odesystems/symbolic/codegen/numba_cuda_printer.py
@@ -137,7 +137,7 @@ class CUDAPrinter(PythonCodePrinter):
         """
         super().__init__(*args, **kwargs)
         self.symbol_map: Dict[sp.Symbol, Any] = symbol_map or {}
-        self.constant_names: frozenset = frozenset(constant_names or ())
+        self.constant_names: frozenset[str] = frozenset(constant_names or ())
         self.cuda_functions: Dict[str, str] = CUDA_FUNCTIONS
         # User function alias mapping: underscored symbolic name -> original printable name
         self.func_aliases: Dict[str, str] = {}

--- a/src/cubie/odesystems/symbolic/codegen/numba_cuda_printer.py
+++ b/src/cubie/odesystems/symbolic/codegen/numba_cuda_printer.py
@@ -37,6 +37,8 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import sympy as sp
 from sympy.printing.pycode import PythonCodePrinter
 
+from cubie.odesystems.symbolic.sym_utils import EXPONENT_ALIAS_PREFIX
+
 __all__ = [
     "CUDAPrinter",
     "print_cuda",
@@ -112,6 +114,7 @@ class CUDAPrinter(PythonCodePrinter):
     def __init__(
         self,
         symbol_map: Optional[Dict[sp.Symbol, Any]] = None,
+        constant_names: Optional[Iterable[str]] = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -122,6 +125,11 @@ class CUDAPrinter(PythonCodePrinter):
         symbol_map
             Optional mapping from scalar symbols to indexed array references or
             other replacement nodes.
+        constant_names
+            Optional names of factory-scope constants. A constant used
+            as a power exponent prints as its integer-exponent alias
+            (``EXPONENT_ALIAS_PREFIX + name``) so integral values lower
+            to multiplication chains instead of ``pow`` calls.
         args
             Positional arguments forwarded to :class:`PythonCodePrinter`.
         kwargs
@@ -129,6 +137,7 @@ class CUDAPrinter(PythonCodePrinter):
         """
         super().__init__(*args, **kwargs)
         self.symbol_map: Dict[sp.Symbol, Any] = symbol_map or {}
+        self.constant_names: frozenset = frozenset(constant_names or ())
         self.cuda_functions: Dict[str, str] = CUDA_FUNCTIONS
         # User function alias mapping: underscored symbolic name -> original printable name
         self.func_aliases: Dict[str, str] = {}
@@ -265,6 +274,11 @@ class CUDAPrinter(PythonCodePrinter):
         remaining integer exponents are wrapped with precision() so
         the pow stays in the working precision.
 
+        A symbol exponent naming a factory-scope constant (listed in
+        ``constant_names``) prints as its integer-exponent alias so
+        integral constant values lower to multiplication chains
+        instead of pow calls (see render_constant_assignments).
+
         Parentheses are added around compound base expressions to ensure
         correct precedence (e.g., (a + b)**2 not a + b**2).
         """
@@ -287,6 +301,17 @@ class CUDAPrinter(PythonCodePrinter):
                 return f"(precision(1)/{denominator})"
             if exponent_value not in (2, 3):
                 return f"{base_str}**precision({exponent_value})"
+
+        if (
+            isinstance(exp_expr, sp.Symbol)
+            and exp_expr not in self.symbol_map
+            and exp_expr.name in self.constant_names
+        ):
+            # A constant exponent prints as its integer-exponent alias:
+            # integral values then lower to multiplication chains in the
+            # working precision instead of pow calls (see
+            # render_constant_assignments).
+            return f"{base_str}**{EXPONENT_ALIAS_PREFIX}{exp_expr.name}"
 
         # Let other print functions know we're in a power expression
         self._in_pow = True

--- a/src/cubie/odesystems/symbolic/codegen/preconditioners.py
+++ b/src/cubie/odesystems/symbolic/codegen/preconditioners.py
@@ -237,7 +237,11 @@ def _build_neumann_body_with_state_subs(
         (lhs, rhs.subs(state_subs)) for lhs, rhs in assignments
     ]
 
-    lines = print_cuda_multiple(substituted_assignments, symbol_map=index_map.all_arrayrefs)
+    lines = print_cuda_multiple(
+        substituted_assignments,
+        symbol_map=index_map.all_arrayrefs,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not lines:
         lines = ["pass"]
     else:
@@ -280,7 +284,11 @@ def _build_cached_neumann_body(
         exprs.append((sp.Symbol(f"jvp[{i}]"), rhs))
 
     exprs = prune_unused_assignments(exprs, outputsym_str='v')
-    lines = print_cuda_multiple(exprs, symbol_map=index_map.all_arrayrefs)
+    lines = print_cuda_multiple(
+        exprs,
+        symbol_map=index_map.all_arrayrefs,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not lines:
         return "            pass"
     replaced = [ln.replace("v[", "out[") for ln in lines]
@@ -443,7 +451,11 @@ def _build_n_stage_neumann_lines(
     )
     eval_exprs = prune_unused_assignments(eval_exprs, outputsym_str='jvp')
 
-    lines = print_cuda_multiple(eval_exprs, symbol_map=symbol_map)
+    lines = print_cuda_multiple(
+        eval_exprs,
+        symbol_map=symbol_map,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not lines:
         return "            pass"
     return "\n".join("            " + ln for ln in lines)
@@ -802,7 +814,11 @@ def _build_jacobi_body_with_state_subs(
     })
     eval_exprs = prune_unused_assignments(eval_exprs, outputsym_str='out')
 
-    lines = print_cuda_multiple(eval_exprs, symbol_map=symbol_map)
+    lines = print_cuda_multiple(
+        eval_exprs,
+        symbol_map=symbol_map,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not lines:
         return "        pass"
     return "\n".join("        " + ln for ln in lines)
@@ -897,7 +913,11 @@ def _build_cached_jacobi_body(
     })
     eval_exprs = prune_unused_assignments(eval_exprs, outputsym_str='out')
 
-    lines = print_cuda_multiple(eval_exprs, symbol_map=symbol_map)
+    lines = print_cuda_multiple(
+        eval_exprs,
+        symbol_map=symbol_map,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not lines:
         return "        pass"
     return "\n".join("        " + ln for ln in lines)
@@ -1234,7 +1254,9 @@ def _build_n_stage_jacobi_lines(
     )
 
     lines = print_cuda_multiple(
-        eval_exprs, symbol_map=symbol_map
+        eval_exprs,
+        symbol_map=symbol_map,
+        constant_names=index_map.constants.symbol_map,
     )
     if not lines:
         return "            pass"

--- a/src/cubie/odesystems/symbolic/codegen/time_derivative.py
+++ b/src/cubie/odesystems/symbolic/codegen/time_derivative.py
@@ -184,7 +184,11 @@ def generate_time_derivative_lines(
     symbol_map = dict(index_map.all_arrayrefs)
     symbol_map.update(final_symbol_map)
 
-    lines = print_cuda_multiple(processed, symbol_map=symbol_map)
+    lines = print_cuda_multiple(
+        processed,
+        symbol_map=symbol_map,
+        constant_names=index_map.constants.symbol_map,
+    )
     if not lines:
         lines = ["pass"]
     return lines

--- a/src/cubie/odesystems/symbolic/sym_utils.py
+++ b/src/cubie/odesystems/symbolic/sym_utils.py
@@ -28,10 +28,13 @@ Published Functions
     64
 
 :func:`render_constant_assignments`
-    Emit Python assignment lines that load constants into local scope.
+    Emit Python assignment lines that load constants into local scope,
+    plus an integer-exponent alias per constant (see the function
+    docstring).
 
-    >>> render_constant_assignments(["g", "k"])
-    "    g = precision(constants['g'])\\n    k = precision(constants['k'])\\n"
+    >>> print(render_constant_assignments(["g"]), end="")
+        g = precision(constants['g'])
+        _cubie_codegen_iexp_g = int(g) if float(g).is_integer() and abs(float(g)) < 9.2e18 else g
 
 :func:`prune_unused_assignments`
     Remove assignments that do not contribute to output symbols.
@@ -64,6 +67,13 @@ import sympy as sp
 
 if TYPE_CHECKING:
     from cubie.odesystems.symbolic.parsing import ParsedEquations
+
+# Prefix for the per-constant integer-exponent aliases emitted by
+# render_constant_assignments and referenced by the CUDA printer when a
+# constant appears as a power exponent. Underscored and namespaced so it
+# cannot collide with user-defined symbols (same scheme as the
+# _cubie_codegen_beta/_cubie_codegen_gamma renames).
+EXPONENT_ALIAS_PREFIX = "_cubie_codegen_iexp_"
 
 
 def topological_sort(
@@ -294,13 +304,29 @@ def render_constant_assignments(
     str
         Newline-joined assignment block, or empty string when
         ``constant_names`` is empty.
+
+    Notes
+    -----
+    Each constant also receives an integer-exponent alias
+    (``EXPONENT_ALIAS_PREFIX + name``) holding ``int(value)`` when the
+    value is integral and within int64 range, and the precision-cast
+    value otherwise. The printer emits the alias wherever the constant
+    appears as a power exponent: Numba lowers a frozen integer
+    exponent to a multiplication chain in the working precision, while
+    a float exponent compiles to a full ``pow`` call. The alias is
+    computed at factory run time, so the generated source stays
+    independent of constant values.
     """
 
     prefix = " " * indent
-    lines = [
-        f"{prefix}{name} = precision(constants['{name}'])"
-        for name in constant_names
-    ]
+    lines = []
+    for name in constant_names:
+        lines.append(f"{prefix}{name} = precision(constants['{name}'])")
+        lines.append(
+            f"{prefix}{EXPONENT_ALIAS_PREFIX}{name} = int({name}) if "
+            f"float({name}).is_integer() and abs(float({name})) < 9.2e18 "
+            f"else {name}"
+        )
     return "\n".join(lines) + ("\n" if lines else "")
 
 

--- a/tests/odesystems/symbolic/test_cuda_printer.py
+++ b/tests/odesystems/symbolic/test_cuda_printer.py
@@ -534,3 +534,47 @@ class TestNumericPrecisionWrapping:
         assert result == "precision(2)*x + precision(1)"
         # Verify no int32() usage
         assert "int32" not in result
+
+
+class TestConstantExponentAlias:
+    """Constant exponents print as their integer-exponent alias."""
+
+    def test_constant_exponent_prints_alias(self):
+        """A constant-symbol exponent prints the iexp alias."""
+        x, n = sp.symbols("x n")
+        printer = CUDAPrinter(constant_names={"n"})
+        result = printer.doprint(sp.Pow(x, n, evaluate=False))
+        assert result == "x**_cubie_codegen_iexp_n"
+
+    def test_non_constant_symbol_exponent_unchanged(self):
+        """A runtime-symbol exponent prints its plain name."""
+        x, n = sp.symbols("x n")
+        printer = CUDAPrinter()
+        result = printer.doprint(sp.Pow(x, n, evaluate=False))
+        assert result == "x**n"
+
+    def test_mapped_symbol_exponent_not_aliased(self):
+        """An array-mapped exponent keeps its array reference."""
+        x, n = sp.symbols("x n")
+        arr = sp.IndexedBase("parameters")
+        printer = CUDAPrinter(
+            symbol_map={n: arr[0]}, constant_names={"n"}
+        )
+        result = printer.doprint(sp.Pow(x, n, evaluate=False))
+        assert result == "x**parameters[0]"
+
+    def test_constant_base_not_aliased(self):
+        """A constant appearing as a base is printed normally."""
+        x, n = sp.symbols("x n")
+        printer = CUDAPrinter(constant_names={"n"})
+        result = printer.doprint(sp.Pow(n, x, evaluate=False))
+        assert result == "n**x"
+
+    def test_alias_used_via_print_cuda_multiple(self):
+        """print_cuda_multiple forwards constant_names to the printer."""
+        x, n, out = sp.symbols("x n out")
+        lines = print_cuda_multiple(
+            [(out, sp.Pow(x, n, evaluate=False))],
+            constant_names={"n"},
+        )
+        assert lines == ["out = x**_cubie_codegen_iexp_n"]

--- a/tests/odesystems/symbolic/test_sym_utils.py
+++ b/tests/odesystems/symbolic/test_sym_utils.py
@@ -1,3 +1,4 @@
+import textwrap
 import warnings
 
 import pytest
@@ -6,6 +7,7 @@ import sympy as sp
 from cubie.odesystems.symbolic.sym_utils import (
     cse_and_stack,
     hash_system_definition,
+    render_constant_assignments,
     topological_sort,
 )
 
@@ -521,3 +523,46 @@ class TestHashSystemDefinition:
         assert hash_full != hash_diff_eqs
         assert hash_full != hash_diff_const
         assert hash_full != hash_diff_obs
+
+
+class TestRenderConstantAssignments:
+    """Constant blocks load values and integer-exponent aliases."""
+
+    def _exec_block(self, block, constants):
+        namespace = {"constants": constants, "precision": float}
+        exec(textwrap.dedent(block), namespace)
+        return namespace
+
+    def test_renders_load_and_alias_lines(self):
+        block = render_constant_assignments(["g"])
+        lines = block.splitlines()
+        assert lines[0] == "    g = precision(constants['g'])"
+        assert lines[1].startswith("    _cubie_codegen_iexp_g = ")
+
+    def test_alias_is_int_for_integral_value(self):
+        block = render_constant_assignments(["g"])
+        namespace = self._exec_block(block, {"g": 4.0})
+        alias = namespace["_cubie_codegen_iexp_g"]
+        assert alias == 4
+        assert isinstance(alias, int)
+
+    def test_alias_keeps_fractional_value(self):
+        block = render_constant_assignments(["g"])
+        namespace = self._exec_block(block, {"g": 4.5})
+        assert namespace["_cubie_codegen_iexp_g"] == 4.5
+
+    def test_alias_keeps_huge_integral_value(self):
+        block = render_constant_assignments(["g"])
+        namespace = self._exec_block(block, {"g": 1.0e300})
+        assert namespace["_cubie_codegen_iexp_g"] == 1.0e300
+        assert not isinstance(namespace["_cubie_codegen_iexp_g"], int)
+
+    def test_alias_negative_integral_value(self):
+        block = render_constant_assignments(["g"])
+        namespace = self._exec_block(block, {"g": -3.0})
+        alias = namespace["_cubie_codegen_iexp_g"]
+        assert alias == -3
+        assert isinstance(alias, int)
+
+    def test_empty_input_renders_empty_string(self):
+        assert render_constant_assignments([]) == ""


### PR DESCRIPTION
## Summary
A constant used as a power exponent (e.g. `x**n` with `n` a factory-scope constant) previously printed as a float-exponent `pow` call, which Numba lowers to the full `pow` routine even when the runtime value is a small integer. `render_constant_assignments` now emits a per-constant integer-exponent alias (`_cubie_codegen_iexp_<name>` — `int(value)` when the value is integral and within int64 range, the precision-cast value otherwise), and the CUDA printer references the alias wherever a constant appears as an exponent. Numba then lowers frozen integral exponents to multiplication chains in the working precision.

The alias prefix is namespaced (same scheme as the `_cubie_codegen_beta`/`_cubie_codegen_gamma` renames) so it cannot collide with user symbols. All codegen entry points (dxdt, linear operators, nonlinear residuals, preconditioners, time derivative) thread `constant_names` through to the printer; the codegen AGENTS.md documents the mechanism.

Background: profiling in the MLIR-backend comparison showed pow-call lowering dominating kernels with integral constant exponents.

## Testing
- New printer and sym_utils tests cover the alias emission and the constant-exponent print path.
- `tests/odesystems/symbolic/test_cuda_printer.py` + `test_sym_utils.py`: 92 passed.
- Note for reviewers with existing `generated/` directories: the kernel cache key does not account for printer changes — clear `generated/` before comparing output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)