### PR TITLE
fix: output schedules recomputed per event index; device event counts mirror host allocation

### DIFF
--- a/src/cubie/integrators/loops/ode_loop.py
+++ b/src/cubie/integrators/loops/ode_loop.py
@@ -465,6 +465,7 @@ class IVPLoop(CUDAFactory):
         # Timing values
         initial_dt = precision(config.dt)
         save_every = config.save_every
+        summarise_every = config.summarise_every
         sample_summaries_every = config.sample_summaries_every
         samples_per_summary = int32(config.samples_per_summary)
 
@@ -505,9 +506,11 @@ class IVPLoop(CUDAFactory):
         ):  # pragma: no cover - CUDA fns not marked in coverage
             """Advance an integration using a compiled CUDA device loop.
 
-            The loop terminates when the time of the next saved sample
-            exceeds the end time (t0 + settling_time + duration), or when
-            the maximum number of iterations is reached.
+            The loop terminates when every scheduled output slot has
+            been written — the slot counts mirror the host allocation
+            arithmetic in
+            :meth:`SingleIntegratorRun.output_length` — or when the run
+            fails irrecoverably.
 
             Parameters
             ----------
@@ -543,9 +546,43 @@ class IVPLoop(CUDAFactory):
             int
                 Status code aggregating errors and iteration counts.
             """
+            # Timing arguments participate in loop-precision schedule
+            # arithmetic that must match the host allocation
+            # arithmetic, so loop-precision copies are taken regardless
+            # of what the caller passed.
+            duration_prec = precision(duration)
+            settling_prec = precision(settling_time)
+            t0_prec = precision(t0)
+            schedule_base = precision(settling_prec + t0_prec)
+
             t = float64(t0)
             t_prec = precision(t)
-            t_end = precision(settling_time + t0 + duration)
+            t_end = precision(schedule_base + duration_prec)
+
+            # Scheduled event counts mirror the host allocation
+            # arithmetic (SingleIntegratorRun.output_length and
+            # summaries_length, both floor(duration / interval) in the
+            # loop precision) so device writes and host array heights
+            # cannot diverge.
+            saves_expected = int32(0)
+            if save_regularly:
+                saves_expected = (
+                    int32(duration_prec / save_every) + int32(1)
+                )
+            updates_expected = int32(0)
+            summaries_expected = int32(0)
+            if summarise_regularly:
+                # Update events run until every host-allocated summary
+                # window is complete; a window closes every
+                # samples_per_summary updates, so partial-window
+                # updates beyond the last full window never surface in
+                # the output.
+                summaries_expected = int32(
+                    duration_prec / summarise_every
+                )
+                updates_expected = (
+                    summaries_expected * samples_per_summary
+                )
 
             # Clear inherited arrays on entry
             persistent_local[:] = precision(0.0)
@@ -606,8 +643,9 @@ class IVPLoop(CUDAFactory):
             save_idx = int32(0)
             summary_idx = int32(0)
             update_idx = int32(0)
-            next_save = precision(settling_time + t0)
-            next_update_summary = precision(settling_time + t0)
+            n_summary_bumps = int32(0)
+            next_save = schedule_base
+            next_update_summary = schedule_base
             # --------------------------------------------------------------- #
             #                       Seed t=0 values                           #
             # --------------------------------------------------------------- #
@@ -637,10 +675,18 @@ class IVPLoop(CUDAFactory):
             if settling_time == 0.0:
                 # Save initial state at t0, then advance to first interval save
                 if save_regularly:
-                    next_save = precision(next_save + save_every)
+                    next_save = precision(
+                        min(precision(next_save + save_every), t_end)
+                    )
                 if summarise_regularly:
+                    n_summary_bumps = int32(1)
                     next_update_summary = precision(
-                        sample_summaries_every + next_update_summary
+                        min(
+                            precision(
+                                sample_summaries_every + next_update_summary
+                            ),
+                            t_end,
+                        )
                     )
 
                 save_state(
@@ -699,10 +745,12 @@ class IVPLoop(CUDAFactory):
                     # Loop continues until all scheduled outputs are complete
                     finished = True
                     if save_regularly:
-                        save_finished = bool_(next_save > t_end)
+                        save_finished = bool_(save_idx >= saves_expected)
                         finished &= save_finished
                     if summarise_regularly:
-                        summary_finished = bool_(next_update_summary > t_end)
+                        summary_finished = bool_(
+                            update_idx >= updates_expected
+                        )
                         finished &= summary_finished
                 else:
                     # No scheduled outputs; finish when time reaches t_end.
@@ -899,9 +947,25 @@ class IVPLoop(CUDAFactory):
                     do_update_summary &= accept
 
                     if do_save:
-                        # Increment next_save if it's in use
                         if save_regularly:
-                            next_save += save_every
+                            # The next save time is recomputed from the
+                            # slot index: repeated addition of
+                            # save_every accumulates rounding error in
+                            # reduced precision, drifting the schedule
+                            # off the host-allocated grid in either
+                            # direction.  The clamp keeps the final
+                            # slot reachable when its grid point rounds
+                            # past t_end.
+                            next_save = precision(
+                                min(
+                                    precision(
+                                        schedule_base
+                                        + precision(save_idx + int32(1))
+                                        * save_every
+                                    ),
+                                    t_end,
+                                )
+                            )
 
                         save_state(
                             state_buffer,
@@ -923,7 +987,21 @@ class IVPLoop(CUDAFactory):
 
                     if do_update_summary:
                         if summarise_regularly:
-                            next_update_summary += sample_summaries_every
+                            # Same drift-free recomputation as
+                            # next_save; the bump counter tracks
+                            # schedule advances because update_idx
+                            # skips the settling-free t0 bump.
+                            n_summary_bumps += int32(1)
+                            next_update_summary = precision(
+                                min(
+                                    precision(
+                                        schedule_base
+                                        + precision(n_summary_bumps)
+                                        * sample_summaries_every
+                                    ),
+                                    t_end,
+                                )
+                            )
 
                         if summarise:
                             statesumm_idx = summary_idx * summarise_state_bool
@@ -937,8 +1015,16 @@ class IVPLoop(CUDAFactory):
                             )
                             update_idx += int32(1)
 
-                            # Save summary when enough updates collected
-                            if update_idx % samples_per_summary == int32(0):
+                            # Save summary when enough updates
+                            # collected; the slot bound keeps rounding
+                            # disagreements between the update and
+                            # window cadences from writing past the
+                            # host-allocated summary height.
+                            if (
+                                update_idx % samples_per_summary
+                                == int32(0)
+                                and summary_idx < summaries_expected
+                            ):
                                 save_summaries(
                                     state_summary_buffer,
                                     observable_summary_buffer,

--- a/src/cubie/integrators/loops/ode_loop.py
+++ b/src/cubie/integrators/loops/ode_loop.py
@@ -570,18 +570,15 @@ class IVPLoop(CUDAFactory):
                     int32(duration_prec / save_every) + int32(1)
                 )
             updates_expected = int32(0)
-            summaries_expected = int32(0)
             if summarise_regularly:
                 # Update events run until every host-allocated summary
                 # window is complete; a window closes every
                 # samples_per_summary updates, so partial-window
                 # updates beyond the last full window never surface in
                 # the output.
-                summaries_expected = int32(
-                    duration_prec / summarise_every
-                )
                 updates_expected = (
-                    summaries_expected * samples_per_summary
+                    int32(duration_prec / summarise_every)
+                    * samples_per_summary
                 )
 
             # Clear inherited arrays on entry
@@ -643,7 +640,7 @@ class IVPLoop(CUDAFactory):
             save_idx = int32(0)
             summary_idx = int32(0)
             update_idx = int32(0)
-            n_summary_bumps = int32(0)
+            summary_bump_offset = int32(0)
             next_save = schedule_base
             next_update_summary = schedule_base
             # --------------------------------------------------------------- #
@@ -679,7 +676,7 @@ class IVPLoop(CUDAFactory):
                         min(precision(next_save + save_every), t_end)
                     )
                 if summarise_regularly:
-                    n_summary_bumps = int32(1)
+                    summary_bump_offset = int32(1)
                     next_update_summary = precision(
                         min(
                             precision(
@@ -988,15 +985,18 @@ class IVPLoop(CUDAFactory):
                     if do_update_summary:
                         if summarise_regularly:
                             # Same drift-free recomputation as
-                            # next_save; the bump counter tracks
-                            # schedule advances because update_idx
-                            # skips the settling-free t0 bump.
-                            n_summary_bumps += int32(1)
+                            # next_save; the loop-invariant offset
+                            # accounts for the settling-free t0 bump
+                            # that update_idx does not count.
                             next_update_summary = precision(
                                 min(
                                     precision(
                                         schedule_base
-                                        + precision(n_summary_bumps)
+                                        + precision(
+                                            update_idx
+                                            + int32(1)
+                                            + summary_bump_offset
+                                        )
                                         * sample_summaries_every
                                     ),
                                     t_end,
@@ -1019,11 +1019,14 @@ class IVPLoop(CUDAFactory):
                             # collected; the slot bound keeps rounding
                             # disagreements between the update and
                             # window cadences from writing past the
-                            # host-allocated summary height.
+                            # host-allocated summary height
+                            # (update_idx <= updates_expected is the
+                            # summary_idx bound scaled by
+                            # samples_per_summary).
                             if (
                                 update_idx % samples_per_summary
                                 == int32(0)
-                                and summary_idx < summaries_expected
+                                and update_idx <= updates_expected
                             ):
                                 save_summaries(
                                     state_summary_buffer,

--- a/src/cubie/integrators/loops/ode_loop.py
+++ b/src/cubie/integrators/loops/ode_loop.py
@@ -726,8 +726,11 @@ class IVPLoop(CUDAFactory):
             mask = activemask()
             irrecoverable = False
             at_end = False
-            save_finished = False
-            summary_finished = False
+            # Event-updated completion flags: the counts change only
+            # when an event fires, so the per-iteration checks reduce
+            # to the stored predicates.
+            save_finished = bool_(save_idx >= saves_expected)
+            summary_finished = bool_(update_idx >= updates_expected)
             # --------------------------------------------------------------- #
             #                        Main Loop                                #
             # --------------------------------------------------------------- #
@@ -742,12 +745,8 @@ class IVPLoop(CUDAFactory):
                     # Loop continues until all scheduled outputs are complete
                     finished = True
                     if save_regularly:
-                        save_finished = bool_(save_idx >= saves_expected)
                         finished &= save_finished
                     if summarise_regularly:
-                        summary_finished = bool_(
-                            update_idx >= updates_expected
-                        )
                         finished &= summary_finished
                 else:
                     # No scheduled outputs; finish when time reaches t_end.
@@ -976,6 +975,10 @@ class IVPLoop(CUDAFactory):
                             ],
                         )
                         save_idx += int32(1)
+                        if save_regularly:
+                            save_finished = bool_(
+                                save_idx >= saves_expected
+                            )
 
                         # Reset iteration counters after save
                         if save_counters_bool:
@@ -1014,6 +1017,9 @@ class IVPLoop(CUDAFactory):
                                 update_idx,
                             )
                             update_idx += int32(1)
+                            summary_finished = bool_(
+                                update_idx >= updates_expected
+                            )
 
                             # Save summary when enough updates
                             # collected; the slot bound keeps rounding

--- a/tests/integrated_numerical_tests/test_dt_min_hang.py
+++ b/tests/integrated_numerical_tests/test_dt_min_hang.py
@@ -1,15 +1,19 @@
-"""Regression tests for f32 save-event drift hang.
+"""Regression tests for f32 save-schedule drift.
 
-When ``save_every`` is not exactly representable in float32
-(e.g. 0.1), repeated f32 addition of ``next_save += save_every``
-accumulates rounding error.  After enough saves, ``next_save``
-drifts below its true value while the f64 time accumulator
-overshoots it.  This produces a negative ``dt_eff`` at the
-event-boundary adjustment, trapping the loop.
+The loop recomputes each save time from its slot index
+(``settling_time + t0 + k * save_every``) instead of accumulating
+``save_every`` additions, so a ``save_every`` that is inexact in
+float32 (e.g. 0.1) carries a single rounding per event rather than
+a growing drift.  These tests guard both historical failure modes
+of accumulation drift:
 
-The bug triggers when the solver is crawling at small dt near a
-save boundary whose f32 ``next_save`` has drifted behind the f64
-time.  With save_every=0.1, after ~80 saves the drift is ~5.2 µs.
+- downward drift left ``next_save`` behind the f64 time
+  accumulator, producing a negative ``dt_eff`` that trapped the
+  loop (with save_every=0.1, ~5.2 µs after ~80 saves);
+- upward drift pushed the final scheduled save past ``t_end``,
+  leaving the last host-allocated slot unwritten so the run
+  returned uninitialized memory as its final sample with a success
+  status (issue #554).
 """
 
 from __future__ import annotations
@@ -95,3 +99,46 @@ def test_f32_save_drift_does_not_hang(oscillator_system):
     # Should produce ~100 saves; any completion is a pass.
     n_saves = result.time_domain_array.shape[0]
     assert n_saves >= 80
+
+
+def test_final_save_slot_written_on_inexact_grid(oscillator_system):
+    """Every host-allocated save slot is written, including the last.
+
+    With duration=1.0 and save_every=0.1 in float32 the host counts
+    eleven samples (``floor(duration / save_every) + 1``) while an
+    accumulated schedule drifts to 1.0000001 > t_end after ten saves,
+    stranding the final slot as uninitialized memory (issue #554).
+    The saved time column exposes the slot regardless of what the
+    unwritten memory happens to contain.
+    """
+    n = 1
+    result = solve_ivp(
+        system=oscillator_system,
+        y0={
+            "x1": np.ones(n, dtype=np.float32),
+            "v1": np.zeros(n, dtype=np.float32),
+            "x2": np.full(n, -0.5, dtype=np.float32),
+            "v2": np.zeros(n, dtype=np.float32),
+        },
+        parameters={
+            "k": np.full(n, 3.0, dtype=np.float32),
+            "c_couple": np.full(n, 0.3, dtype=np.float32),
+            "omega": np.full(n, 2.5, dtype=np.float32),
+        },
+        method="dormand-prince-54",
+        duration=1.0,
+        dt_min=1e-6,
+        dt_max=1.0,
+        save_every=0.1,
+        output_types=["state", "time"],
+        grid_type="verbatim",
+    )
+
+    assert int(result.status_codes[0]) == 0, result.status_messages
+    times = result.time[:, 0]
+    assert times.shape[0] == 11
+    assert np.all(np.diff(times) > 0.0), (
+        f"saved times are not strictly increasing: {times}"
+    )
+    assert times[-1] == pytest.approx(1.0, abs=1e-6)
+    assert np.isfinite(result.time_domain_array).all()

--- a/tests/integrators/cpu_reference/loops.py
+++ b/tests/integrators/cpu_reference/loops.py
@@ -152,35 +152,57 @@ def run_reference_loop(
         t32,
     )
 
+    end_time = precision(warmup + t0 + duration)
+
+    # Event counts and schedule recomputation mirror the device loop
+    # in ode_loop.py: floor(duration / interval) in the loop precision,
+    # with each next-event time recomputed from its event index and
+    # clamped to end_time rather than accumulated.
+    saves_expected = max_save_samples
+    summaries_expected = int(
+        precision(duration) / precision(summarise_every)
+    )
+    # Update events run until every summary window is complete; a
+    # window closes every samples_per_summary updates, so
+    # partial-window updates beyond the last full window never
+    # surface in the output.
+    updates_expected = summaries_expected * samples_per_summary
+    summary_sample_count = 0
+
     if warmup > np.float64(0.0):
         next_save_time = precision(warmup + t0)
         next_summary_sample_time = precision(warmup + t0)
         save_idx = 0
+        summary_bumps = 0
     else:
-        next_save_time = precision(warmup + t0 + save_every)
+        next_save_time = precision(
+            min(precision(warmup + t0 + save_every), end_time)
+        )
         next_summary_sample_time = precision(
-            warmup + t0 + sample_summaries_every
+            min(precision(warmup + t0 + sample_summaries_every), end_time)
         )
         state_history = [state.copy()]
         observable_history.append(observables.copy())
         time_history = [precision(t)]
         save_idx = 1
-
-    end_time = precision(warmup + t0 + duration)
+        summary_bumps = 1
 
     status_flags = 0
 
     # Track when we need to sample for summaries vs save for output
-    while next_save_time <= end_time or next_summary_sample_time <= end_time:
+    while save_idx < saves_expected or summary_sample_count < updates_expected:
         dt = controller.dt
         do_save = False
         do_summary_sample = False
 
-        # Determine next event time
+        # Determine next event time; exhausted schedules are excluded
+        # by their event counts.
         next_event_time = min(
-            next_save_time if next_save_time <= end_time else end_time + 1,
+            next_save_time
+            if save_idx < saves_expected
+            else end_time + 1,
             next_summary_sample_time
-            if next_summary_sample_time <= end_time
+            if summary_sample_count < updates_expected
             else end_time + 1,
         )
         if next_event_time > end_time:
@@ -221,15 +243,32 @@ def run_reference_loop(
                 state_history.append(result.state.copy())
                 observable_history.append(result.observables.copy())
                 time_history.append(precision(t32 - warmup))
-            next_save_time = next_save_time + save_every
+            next_save_time = precision(
+                min(
+                    precision(
+                        precision(warmup + t0)
+                        + precision(save_idx + 1) * save_every
+                    ),
+                    end_time,
+                )
+            )
             save_idx += 1
 
         if do_summary_sample:
             if len(summary_state_history) < max_summary_samples:
                 summary_state_history.append(result.state.copy())
                 summary_observable_history.append(result.observables.copy())
-            next_summary_sample_time = (
-                next_summary_sample_time + sample_summaries_every
+            summary_sample_count += 1
+            summary_bumps += 1
+            next_summary_sample_time = precision(
+                min(
+                    precision(
+                        precision(warmup + t0)
+                        + precision(summary_bumps)
+                        * sample_summaries_every
+                    ),
+                    end_time,
+                )
             )
 
     state_output = _collect_saved_outputs(
@@ -246,8 +285,6 @@ def run_reference_loop(
         precision,
     )
     if save_time:
-        if len(time_history) < state_output.shape[0]:
-            time_history.append(precision(0))
         state_output = np.column_stack(
             (state_output, np.asarray(time_history))
         )


### PR DESCRIPTION
Closes #554.

## What

The device loop's save and summary-sample schedules are recomputed from their event index (`settling_time + t0 + k * interval`, clamped to `t_end`) instead of accumulating `next_save += save_every`, and the loop now terminates on event counts that mirror the host allocation arithmetic (`floor(duration / interval)` evaluated in the loop precision) rather than on a float comparison against `t_end`.

## Why

Repeated float32 addition of an inexact interval (e.g. `0.1`) drifts the schedule off the host-allocated grid in either direction:

- **Upward drift** pushed the final scheduled save past `t_end` (`10 × 0.1f` accumulates to `1.0000001 > 1.0`), so the loop exited without writing the last host-allocated slot. The run then returned uninitialized device memory as its final sample with `status == 0` — zeros on a fresh GPU allocation, denormals or NaN under CUDASIM depending on heap reuse. This is the source of the intermittent `test_recovered_transient_failure_reports_success` CI failures (#554).
- **Downward drift** previously produced the negative-`dt_eff` hang guarded by `test_f32_save_drift_does_not_hang`.

Index-based recomputation carries a single rounding per event instead of an accumulated one, which also lands saved timestamps on the exact grid (`0.1, 0.2, …, 1.0` rather than `…, 0.8000001, 0.9000001`).

## Details

- Count-based termination (`save_idx >= saves_expected`, `update_idx >= updates_expected`) makes the device write exactly the slots the host allocated; the counts reuse the same float32 division the host uses in `SingleIntegratorRun.output_length` / `summaries_length`, evaluated on loop-precision copies of the timing arguments so the arithmetic is identical regardless of caller argument dtype.
- `updates_expected` is derived as `summaries_expected * samples_per_summary`: a window closes every `samples_per_summary` updates, and partial-window updates beyond the last full window never surface in the output. Deriving it from `duration / sample_summaries_every` directly under-counts by one when the quantized sampling interval rounds the quotient down.
- The final scheduled event is clamped to `t_end`, so a grid point that rounds one ulp past the end time is delivered at `t_end` instead of stranding its slot.
- `save_summaries` is additionally bounded by `summary_idx < summaries_expected` so cadence rounding disagreements cannot write past the host-allocated summary height.
- The CPU reference loop (`tests/integrators/cpu_reference/loops.py`) mirrors the same scheduling, and its zero-padding of a missing final time sample — which had been masking this bug in device-vs-reference comparisons — is removed.
- New regression test `test_final_save_slot_written_on_inexact_grid` asserts via the saved time column (strictly increasing, ends at `t_end`) that every slot is written, independent of what unwritten memory happens to contain.

## Verification

- CUDASIM (`NUMBA_ENABLE_CUDASIM=1`, markers `not nocudasim and not cupy and not specific_algos`): `tests/integrated_numerical_tests`, `tests/integrators`, `tests/outputhandling`, `tests/batchsolving` — 1360 passed.
- Real GPU (markers `not specific_algos and not sim_only`), same suites — 1361 passed.
- The #554 reproduction now returns a finite final sample at `t = 1.0` exactly on both CUDASIM and real GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)