### PR TITLE
fix: already-due output boundaries emit outputs instead of zero-length steps

### DIFF
--- a/src/cubie/integrators/loops/ode_loop.py
+++ b/src/cubie/integrators/loops/ode_loop.py
@@ -464,6 +464,7 @@ class IVPLoop(CUDAFactory):
 
         # Timing values
         initial_dt = precision(config.dt)
+        typed_zero = precision(0.0)
         save_every = config.save_every
         sample_summaries_every = config.sample_summaries_every
         samples_per_summary = int32(config.samples_per_summary)
@@ -742,8 +743,16 @@ class IVPLoop(CUDAFactory):
                     if save_last:
                         do_save |= at_end
 
-                    # Adjust step size to hit output boundaries exactly
+                    # Adjust step size to hit output boundaries exactly.
+                    # An accepted step can round t_prec onto an event
+                    # time without the event firing (the pre-step
+                    # prediction and the post-step time commit use
+                    # different arithmetic), leaving a zero-length gap
+                    # that no step can cross. When the gap is not
+                    # positive the event is already due: emit outputs
+                    # from the committed state without taking a step.
                     dt_eff = dt_raw
+                    event_due_now = False
                     if do_save or do_update_summary:
                         next_event = t_end
                         if do_save and save_regularly:
@@ -752,78 +761,91 @@ class IVPLoop(CUDAFactory):
                             next_event = precision(
                                 min(next_event, next_update_summary)
                             )
-                        dt_eff = precision(next_event - t_prec)
+                        gap = precision(next_event - t_prec)
+                        event_due_now = bool_(gap <= typed_zero)
+                        dt_eff = selp(event_due_now, typed_zero, gap)
 
                     # ----------------------------------------------------------- #
-                    # Take a step
-                    step_status = int32(
-                        step_function(
-                            state_buffer,
-                            state_proposal_buffer,
-                            parameters_buffer,
-                            driver_coefficients,
-                            drivers_buffer,
-                            drivers_proposal_buffer,
-                            observables_buffer,
-                            observables_proposal_buffer,
-                            error,
-                            dt_eff,
-                            t_prec,
-                            first_step_flag,
-                            prev_step_accepted_flag,
-                            algo_shared,
-                            algo_persistent,
-                            proposed_counters,
-                        )
-                    )
-
-                    first_step_flag = False
-                    niters = proposed_counters[0]
-                    iteration_status = int32(iteration_status | step_status)
-
-                    # A nonzero step status indicates step failure (e.g., solver
-                    # convergence failure). In adaptive mode this should reject the
-                    # step and trigger a timestep reduction; in fixed mode it is
-                    # irrecoverable.
-                    step_failed = bool_(step_status != int32(0))
-                    irrecoverable = bool_(
-                        irrecoverable or (fixed_mode and step_failed)
-                    )
-                    for i in range(n_error):
-                        error[i] = selp(step_failed, precision(1e16), error[i])
-
-                    # Adjust dt based on calculated error if adaptive
-                    if not fixed_mode:
-                        controller_status = step_controller(
-                            dt,
-                            state_proposal_buffer,
-                            state_buffer,
-                            error,
-                            niters,
-                            accept_step,
-                            ctrl_shared,
-                            ctrl_persistent,
+                    # Take a step. An already-due event skips the step:
+                    # the committed state is the boundary state, so the
+                    # iteration only emits outputs and advances the
+                    # event schedule.
+                    accept = True
+                    if not event_due_now:
+                        step_status = int32(
+                            step_function(
+                                state_buffer,
+                                state_proposal_buffer,
+                                parameters_buffer,
+                                driver_coefficients,
+                                drivers_buffer,
+                                drivers_proposal_buffer,
+                                observables_buffer,
+                                observables_proposal_buffer,
+                                error,
+                                dt_eff,
+                                t_prec,
+                                first_step_flag,
+                                prev_step_accepted_flag,
+                                algo_shared,
+                                algo_persistent,
+                                proposed_counters,
+                            )
                         )
 
-                        accept = bool_(accept_step[0] != int32(0))
-                        accept = bool_(accept and (not step_failed))
+                        first_step_flag = False
+                        niters = proposed_counters[0]
                         iteration_status = int32(
-                            iteration_status | controller_status
+                            iteration_status | step_status
                         )
 
-                        # Controller may signal irrecoverable error via status bit
+                        # A nonzero step status indicates step failure
+                        # (e.g., solver convergence failure). In adaptive
+                        # mode this should reject the step and trigger a
+                        # timestep reduction; in fixed mode it is
+                        # irrecoverable.
+                        step_failed = bool_(step_status != int32(0))
                         irrecoverable = bool_(
-                            irrecoverable
-                            or ((controller_status & step_too_small)
-                                != success)
+                            irrecoverable or (fixed_mode and step_failed)
                         )
-                    else:
-                        accept = bool_(not step_failed)
+                        for i in range(n_error):
+                            error[i] = selp(
+                                step_failed, precision(1e16), error[i]
+                            )
+
+                        # Adjust dt based on calculated error if adaptive
+                        if not fixed_mode:
+                            controller_status = step_controller(
+                                dt,
+                                state_proposal_buffer,
+                                state_buffer,
+                                error,
+                                niters,
+                                accept_step,
+                                ctrl_shared,
+                                ctrl_persistent,
+                            )
+
+                            accept = bool_(accept_step[0] != int32(0))
+                            accept = bool_(accept and (not step_failed))
+                            iteration_status = int32(
+                                iteration_status | controller_status
+                            )
+
+                            # Controller may signal irrecoverable error
+                            # via status bit
+                            irrecoverable = bool_(
+                                irrecoverable
+                                or ((controller_status & step_too_small)
+                                    != success)
+                            )
+                        else:
+                            accept = bool_(not step_failed)
 
                     dt_raw = dt[0]
 
                     # Accumulate iteration counters if active
-                    if save_counters_bool:
+                    if save_counters_bool and (not event_due_now):
                         for i in range(n_counters):
                             if i < int32(2):
                                 # Write newton, krylov iterations from buffer
@@ -840,10 +862,13 @@ class IVPLoop(CUDAFactory):
                     # test for stagnation - we might have one small step
                     # which doesn't nudge t if we're right up against a save
                     # boundary, so we call 2 stale t values in a row "stagnant"
-                    if t_proposal == t:
-                        stagnant_counts += int32(1)
-                    else:
-                        stagnant_counts = int32(0)
+                    # An output-only iteration is not a step attempt and
+                    # is excluded from the count.
+                    if not event_due_now:
+                        if t_proposal == t:
+                            stagnant_counts += int32(1)
+                        else:
+                            stagnant_counts = int32(0)
 
                     stagnant = bool_(stagnant_counts >= int32(2))
                     iteration_status = selp(
@@ -869,29 +894,37 @@ class IVPLoop(CUDAFactory):
                     if accept:
                         iteration_status = int32(0)
 
-                    t = selp(accept, t_proposal, t)
+                    # Commit only real accepted steps; an output-only
+                    # iteration has stale proposal buffers and no step
+                    # outcome to record.
+                    commit_step = bool_(accept and (not event_due_now))
+
+                    t = selp(commit_step, t_proposal, t)
                     t_prec = precision(t)
 
                     for i in range(n_states):
                         newv = state_proposal_buffer[i]
                         oldv = state_buffer[i]
-                        state_buffer[i] = selp(accept, newv, oldv)
+                        state_buffer[i] = selp(commit_step, newv, oldv)
 
                     for i in range(n_drivers):
                         new_drv = drivers_proposal_buffer[i]
                         old_drv = drivers_buffer[i]
-                        drivers_buffer[i] = selp(accept, new_drv, old_drv)
+                        drivers_buffer[i] = selp(commit_step, new_drv, old_drv)
 
                     for i in range(n_observables):
                         new_obs = observables_proposal_buffer[i]
                         old_obs = observables_buffer[i]
-                        observables_buffer[i] = selp(accept, new_obs, old_obs)
+                        observables_buffer[i] = selp(
+                            commit_step, new_obs, old_obs
+                        )
 
-                    prev_step_accepted_flag = selp(
-                        accept,
-                        int32(1),
-                        int32(0),
-                    )
+                    if not event_due_now:
+                        prev_step_accepted_flag = selp(
+                            accept,
+                            int32(1),
+                            int32(0),
+                        )
 
                     # Predicated output execution: only perform outputs
                     # if step was accepted (avoids warp divergence)

--- a/src/cubie/integrators/loops/ode_loop.py
+++ b/src/cubie/integrators/loops/ode_loop.py
@@ -744,15 +744,14 @@ class IVPLoop(CUDAFactory):
                         do_save |= at_end
 
                     # Adjust step size to hit output boundaries exactly.
-                    # An accepted step can round t_prec onto an event
-                    # time without the event firing (the pre-step
+                    # A prior accepted step can round t_prec onto an
+                    # event time without the event firing (the pre-step
                     # prediction and the post-step time commit use
-                    # different arithmetic), leaving a zero-length gap
-                    # that no step can cross. When the gap is not
-                    # positive the event is already due: emit outputs
-                    # from the committed state without taking a step.
+                    # different arithmetic), leaving a non-positive gap
+                    # that no step can cross. Only positive gaps clamp
+                    # the step; an already-reached event keeps dt_raw
+                    # and is emitted at the next accepted step.
                     dt_eff = dt_raw
-                    event_due_now = False
                     if do_save or do_update_summary:
                         next_event = t_end
                         if do_save and save_regularly:
@@ -762,90 +761,78 @@ class IVPLoop(CUDAFactory):
                                 min(next_event, next_update_summary)
                             )
                         gap = precision(next_event - t_prec)
-                        event_due_now = bool_(gap <= typed_zero)
-                        dt_eff = selp(event_due_now, typed_zero, gap)
+                        dt_eff = selp(gap > typed_zero, gap, dt_raw)
 
                     # ----------------------------------------------------------- #
-                    # Take a step. An already-due event skips the step:
-                    # the committed state is the boundary state, so the
-                    # iteration only emits outputs and advances the
-                    # event schedule.
-                    accept = True
-                    if not event_due_now:
-                        step_status = int32(
-                            step_function(
-                                state_buffer,
-                                state_proposal_buffer,
-                                parameters_buffer,
-                                driver_coefficients,
-                                drivers_buffer,
-                                drivers_proposal_buffer,
-                                observables_buffer,
-                                observables_proposal_buffer,
-                                error,
-                                dt_eff,
-                                t_prec,
-                                first_step_flag,
-                                prev_step_accepted_flag,
-                                algo_shared,
-                                algo_persistent,
-                                proposed_counters,
-                            )
+                    # Take a step
+                    step_status = int32(
+                        step_function(
+                            state_buffer,
+                            state_proposal_buffer,
+                            parameters_buffer,
+                            driver_coefficients,
+                            drivers_buffer,
+                            drivers_proposal_buffer,
+                            observables_buffer,
+                            observables_proposal_buffer,
+                            error,
+                            dt_eff,
+                            t_prec,
+                            first_step_flag,
+                            prev_step_accepted_flag,
+                            algo_shared,
+                            algo_persistent,
+                            proposed_counters,
+                        )
+                    )
+
+                    first_step_flag = False
+                    niters = proposed_counters[0]
+                    iteration_status = int32(iteration_status | step_status)
+
+                    # A nonzero step status indicates step failure (e.g., solver
+                    # convergence failure). In adaptive mode this should reject the
+                    # step and trigger a timestep reduction; in fixed mode it is
+                    # irrecoverable.
+                    step_failed = bool_(step_status != int32(0))
+                    irrecoverable = bool_(
+                        irrecoverable or (fixed_mode and step_failed)
+                    )
+                    for i in range(n_error):
+                        error[i] = selp(step_failed, precision(1e16), error[i])
+
+                    # Adjust dt based on calculated error if adaptive
+                    if not fixed_mode:
+                        controller_status = step_controller(
+                            dt,
+                            state_proposal_buffer,
+                            state_buffer,
+                            error,
+                            niters,
+                            accept_step,
+                            ctrl_shared,
+                            ctrl_persistent,
                         )
 
-                        first_step_flag = False
-                        niters = proposed_counters[0]
+                        accept = bool_(accept_step[0] != int32(0))
+                        accept = bool_(accept and (not step_failed))
                         iteration_status = int32(
-                            iteration_status | step_status
+                            iteration_status | controller_status
                         )
 
-                        # A nonzero step status indicates step failure
-                        # (e.g., solver convergence failure). In adaptive
-                        # mode this should reject the step and trigger a
-                        # timestep reduction; in fixed mode it is
-                        # irrecoverable.
-                        step_failed = bool_(step_status != int32(0))
+                        # Controller may signal irrecoverable error via status bit
                         irrecoverable = bool_(
-                            irrecoverable or (fixed_mode and step_failed)
+                            irrecoverable
+                            or ((controller_status & step_too_small)
+                                != success)
                         )
-                        for i in range(n_error):
-                            error[i] = selp(
-                                step_failed, precision(1e16), error[i]
-                            )
-
-                        # Adjust dt based on calculated error if adaptive
-                        if not fixed_mode:
-                            controller_status = step_controller(
-                                dt,
-                                state_proposal_buffer,
-                                state_buffer,
-                                error,
-                                niters,
-                                accept_step,
-                                ctrl_shared,
-                                ctrl_persistent,
-                            )
-
-                            accept = bool_(accept_step[0] != int32(0))
-                            accept = bool_(accept and (not step_failed))
-                            iteration_status = int32(
-                                iteration_status | controller_status
-                            )
-
-                            # Controller may signal irrecoverable error
-                            # via status bit
-                            irrecoverable = bool_(
-                                irrecoverable
-                                or ((controller_status & step_too_small)
-                                    != success)
-                            )
-                        else:
-                            accept = bool_(not step_failed)
+                    else:
+                        accept = bool_(not step_failed)
 
                     dt_raw = dt[0]
 
                     # Accumulate iteration counters if active
-                    if save_counters_bool and (not event_due_now):
+                    if save_counters_bool:
                         for i in range(n_counters):
                             if i < int32(2):
                                 # Write newton, krylov iterations from buffer
@@ -862,13 +849,10 @@ class IVPLoop(CUDAFactory):
                     # test for stagnation - we might have one small step
                     # which doesn't nudge t if we're right up against a save
                     # boundary, so we call 2 stale t values in a row "stagnant"
-                    # An output-only iteration is not a step attempt and
-                    # is excluded from the count.
-                    if not event_due_now:
-                        if t_proposal == t:
-                            stagnant_counts += int32(1)
-                        else:
-                            stagnant_counts = int32(0)
+                    if t_proposal == t:
+                        stagnant_counts += int32(1)
+                    else:
+                        stagnant_counts = int32(0)
 
                     stagnant = bool_(stagnant_counts >= int32(2))
                     iteration_status = selp(
@@ -894,37 +878,29 @@ class IVPLoop(CUDAFactory):
                     if accept:
                         iteration_status = int32(0)
 
-                    # Commit only real accepted steps; an output-only
-                    # iteration has stale proposal buffers and no step
-                    # outcome to record.
-                    commit_step = bool_(accept and (not event_due_now))
-
-                    t = selp(commit_step, t_proposal, t)
+                    t = selp(accept, t_proposal, t)
                     t_prec = precision(t)
 
                     for i in range(n_states):
                         newv = state_proposal_buffer[i]
                         oldv = state_buffer[i]
-                        state_buffer[i] = selp(commit_step, newv, oldv)
+                        state_buffer[i] = selp(accept, newv, oldv)
 
                     for i in range(n_drivers):
                         new_drv = drivers_proposal_buffer[i]
                         old_drv = drivers_buffer[i]
-                        drivers_buffer[i] = selp(commit_step, new_drv, old_drv)
+                        drivers_buffer[i] = selp(accept, new_drv, old_drv)
 
                     for i in range(n_observables):
                         new_obs = observables_proposal_buffer[i]
                         old_obs = observables_buffer[i]
-                        observables_buffer[i] = selp(
-                            commit_step, new_obs, old_obs
-                        )
+                        observables_buffer[i] = selp(accept, new_obs, old_obs)
 
-                    if not event_due_now:
-                        prev_step_accepted_flag = selp(
-                            accept,
-                            int32(1),
-                            int32(0),
-                        )
+                    prev_step_accepted_flag = selp(
+                        accept,
+                        int32(1),
+                        int32(0),
+                    )
 
                     # Predicated output execution: only perform outputs
                     # if step was accepted (avoids warp divergence)

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -1288,3 +1288,41 @@ def test_regular_saves_fill_allocation_at_fp_endpoints(
     final_states = states[-1, : len(simple_initial_values), :]
     assert np.all(np.isfinite(final_states))
     assert np.any(final_states != 0.0)
+
+
+@pytest.mark.nocudasim
+def test_save_boundary_zero_gap_run_completes():
+    """A driven stiff Rosenbrock run survives t rounding onto a save
+    boundary.
+
+    Float32 time accumulation can land the committed time exactly on
+    ``next_save`` without the save firing, because the pre-step save
+    prediction and the post-step time commit use different arithmetic.
+    The step clamped to that boundary then has length zero, which the
+    step function cannot integrate; the loop must emit the due save
+    from the committed state instead of stagnating (issue #548).
+    """
+    forced = create_ODE_system(
+        "dx = v\ndv = mu * (1 - x*x) * v - x + forcing",
+        parameters={"mu": 50.0},
+        states={"x": 2.0, "v": 0.0},
+        drivers=["forcing"],
+        precision=np.float32,
+        name="ForcedVanDerPol548",
+    )
+    time = np.linspace(0.0, 20.0, 400)
+    signal = 5.0 * np.sin(2.0 * np.pi * 0.25 * time)
+
+    result = solve_ivp(
+        forced,
+        y0={"x": np.array([2.0]), "v": np.array([0.0])},
+        parameters={"mu": np.array([64.0])},
+        drivers={"forcing": signal, "time": time},
+        method="rosenbrock",
+        duration=20.0,
+        save_every=0.05,
+    )
+
+    assert result.status_messages == {}
+    states = np.asarray(result.time_domain_array)
+    assert np.all(np.isfinite(states))


### PR DESCRIPTION
## Summary

Fixes #548 (`MAX_LINEAR_ITERATIONS_EXCEEDED | STAGNATION` on a driven stiff Rosenbrock run at default `dt_max`).

## Root cause (confirmed on real GPU with an instrumented loop)

The save prediction and the time commit use different arithmetic: `do_save` is predicted from `end_of_step = t_prec + dt_raw` (working-precision add), while the accepted time advances as `t += float64(dt_eff)` and is then cast down to `t_prec`. In float32 these can straddle a save boundary: an accepted step predicted *not* to reach `next_save` lands, after rounding, with `t_prec == next_save` — and the save does not fire.

On the next iteration the boundary clamp `dt_eff = precision(next_event - t_prec)` is exactly **0.0**. A zero-length step is un-integrable (the Rosenbrock step computes `inv_dt = 1/dt`, producing NaN stage systems), so the linear solver exhausts its iterations (`MAX_LINEAR_ITERATIONS_EXCEEDED`), the step is rejected, `next_save` never advances, and `dt_eff` stays pinned at 0 no matter how far the controller shrinks `dt_raw`. Two such iterations trip `STAGNATION`. Instrumented trace at the failure (mu = 64, t = 18.8):

```
ZERODT t= 18.799998 dt_raw= 0.005356 dt_eff= 0.000000 next_save= 18.799999
STEPFAIL t= 18.799998 dt_eff= 0.000000 status= 4
ZERODT t= 18.799998 dt_raw= 0.002678 dt_eff= 0.000000 next_save= 18.799999
STEPFAIL t= 18.799998 dt_eff= 0.000000 status= 4
```

This answers the issue's open questions: linear-solve failure already rejects the step and shrinks dt (the loop inflates the error vector to 1e16), and the shrink cascade works — but it could never help here because the attempted step length was pinned to the zero boundary gap, not to `dt_raw`. The `dt_max` dependence is indirect: it changes the step sequence so the rounding collision does or does not occur. No driver-aware `dt_max` default is needed for this failure.

## Fix

One predicated select in the existing boundary-clamp path:

```python
gap = precision(next_event - t_prec)
dt_eff = selp(gap > typed_zero, gap, dt_raw)
```

A positive gap clamps the step to the event boundary exactly as before. A non-positive gap (the event time already reached via rounding) leaves `dt_raw` unclamped: the step integrates normally and the already-flagged output fires at the next accepted step with its honest timestamp, advancing the schedule. No zero-length step can reach the algorithm, no loop-carried state is added, and the hot path is otherwise byte-identical to `main`. (An earlier revision handled this with an output-only iteration that skipped the step; it cost 5–7% adaptive kernel time and was replaced.)

## Verification (RTX 4070 SUPER, real GPU)

- Issue repro (16-run mu sweep, default `dt_max`): `status_messages` was `{11: ['MAX_LINEAR_ITERATIONS_EXCEEDED', 'STAGNATION']}`, now `{}`.
- New regression test `test_save_boundary_zero_gap_run_completes` fails on unfixed main and passes with the fix (red/green checked by pointing PYTHONPATH at each tree).
- `tests/integrators/loops`, `tests/batchsolving/test_solver.py`, `tests/batchsolving/test_SolverKernel.py`: 162 passed.
- Performance gate: kernel A/B vs `main` at parity (see gate comment).
- `ruff` and the flake8 blocking gate pass on the touched files.

## Note for the docs overhaul

The stiff-systems tutorial referenced in the issue (`docs/source/tutorials/stiff_systems.rst`, not yet on main) explains the default-`dt_max` failure as expected behaviour and works around it with `dt_max=0.05`; that note should be revised when that branch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
