### PR TITLE
chore: mean-runtime Lorenz benchmark script; agent branch/PR workflow rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,10 @@ change — the full suite is slow (run it as a pre-commit check only, and only w
   done and verified, commit, push the branch, and open a PR.
 - **Performance gate (every PR):** run `benchmarks/lorenz_mean_runtime.py` A/B — A on `main`,
   B on the PR branch (e.g. via `PYTHONPATH=<tree>/src`) — and include the results table in the
-  PR message. Defaults (2**22 trajectories, 100 repeats) are the gate settings. The script
-  outputs kernel runtime only (CUDA-event, stable to <1% across invocations); a mean shift
-  outside the standard deviations indicates a regression.
+  PR message. Script defaults are the gate settings. The script outputs kernel runtime only
+  (CUDA-event); one invocation per side suffices — means repeat to ~0.1% — but an invocation
+  where a config's std exceeds ~5% of its mean was contaminated by outside interference:
+  discard it and rerun. A mean shift outside the standard deviations indicates a regression.
 
 ## Cross-cutting code rules (details in `src/cubie/AGENTS.md`)
 - Never call a `CUDAFactory.build()` directly — access compiled functions via the cached properties.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,9 @@ change — the full suite is slow (run it as a pre-commit check only, and only w
   done and verified, commit, push the branch, and open a PR.
 - **Performance gate (every PR):** run `benchmarks/lorenz_mean_runtime.py` A/B — A on `main`,
   B on the PR branch (e.g. via `PYTHONPATH=<tree>/src`) — and include the results table in the
-  PR message. Defaults (2**22 trajectories, 100 repeats, mean runtime) are the gate settings.
+  PR message. Defaults (2**22 trajectories, 100 repeats) are the gate settings. **Compare the
+  kernel means** (CUDA-event, stable to <1% across invocations); wall-clock means carry
+  per-process d2h/host-memory scatter of ±10%+ and are context only.
 
 ## Cross-cutting code rules (details in `src/cubie/AGENTS.md`)
 - Never call a `CUDAFactory.build()` directly — access compiled functions via the cached properties.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,9 @@ change — the full suite is slow (run it as a pre-commit check only, and only w
   `docs`, `chore`.
 - **Agents:** every fix or feature is developed on its own branch off `main`. When the work is
   done and verified, commit, push the branch, and open a PR.
+- **Performance gate (every PR):** run `benchmarks/lorenz_mean_runtime.py` A/B — A on `main`,
+  B on the PR branch (e.g. via `PYTHONPATH=<tree>/src`) — and include the results table in the
+  PR message. Defaults (2**22 trajectories, 100 repeats, mean runtime) are the gate settings.
 
 ## Cross-cutting code rules (details in `src/cubie/AGENTS.md`)
 - Never call a `CUDAFactory.build()` directly — access compiled functions via the cached properties.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,9 @@ change — the full suite is slow (run it as a pre-commit check only, and only w
   done and verified, commit, push the branch, and open a PR.
 - **Performance gate (every PR):** run `benchmarks/lorenz_mean_runtime.py` A/B — A on `main`,
   B on the PR branch (e.g. via `PYTHONPATH=<tree>/src`) — and include the results table in the
-  PR message. Defaults (2**22 trajectories, 100 repeats) are the gate settings. **Compare the
-  kernel means** (CUDA-event, stable to <1% across invocations); wall-clock means carry
-  per-process d2h/host-memory scatter of ±10%+ and are context only.
+  PR message. Defaults (2**22 trajectories, 100 repeats) are the gate settings. The script
+  outputs kernel runtime only (CUDA-event, stable to <1% across invocations); a mean shift
+  outside the standard deviations indicates a regression.
 
 ## Cross-cutting code rules (details in `src/cubie/AGENTS.md`)
 - Never call a `CUDAFactory.build()` directly — access compiled functions via the cached properties.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ change — the full suite is slow (run it as a pre-commit check only, and only w
 - **Conventional Commit format**; description in **present-state changelog language** (describe the
   resulting state, e.g. "nested AGENTS.md files created…"). Types: `fix`, `feat` (rare), `test`,
   `docs`, `chore`.
+- **Agents:** every fix or feature is developed on its own branch off `main`. When the work is
+  done and verified, commit, push the branch, and open a PR.
 
 ## Cross-cutting code rules (details in `src/cubie/AGENTS.md`)
 - Never call a `CUDAFactory.build()` directly — access compiled functions via the cached properties.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,9 @@ change — the full suite is slow (run it as a pre-commit check only, and only w
   PR message. Script defaults are the gate settings. The script outputs kernel runtime only
   (CUDA-event); one invocation per side suffices — means repeat to ~0.1% — but an invocation
   where a config's std exceeds ~5% of its mean was contaminated by outside interference:
-  discard it and rerun. A mean shift outside the standard deviations indicates a regression.
+  discard it and rerun. Run A (`main`) first, then pass A's printed mean/std to the B run via
+  `--ref-fixed MEAN STD --ref-adaptive MEAN STD`; the script prints a Welch z per config and
+  the verdict (`|z| >= 3` = the means differ; positive z on the PR branch = regression).
 
 ## Cross-cutting code rules (details in `src/cubie/AGENTS.md`)
 - Never call a `CUDAFactory.build()` directly — access compiled functions via the cached properties.

--- a/benchmarks/lorenz_mean_runtime.py
+++ b/benchmarks/lorenz_mean_runtime.py
@@ -15,15 +15,29 @@ Usage::
     python benchmarks/lorenz_mean_runtime.py [n_runs] [repeats]
 
 Defaults: ``n_runs = 2**22`` trajectories, ``repeats = 100``.
+
+The generated-code and compiled-kernel caches are cleared on every
+invocation. The kernel cache is keyed by config hash, which does not
+include the package source, so a warm cache can serve kernels
+compiled from a different source tree — poisonous for A/B runs where
+only ``PYTHONPATH`` differs. Clearing forces each invocation to
+compile from the tree under benchmark; the compile cost is absorbed
+by the warm-up solve, outside the timed region.
 """
 
+import os
+import shutil
 import sys
 import timeit
 
 import numpy as np
 
 import cubie as qb
+from cubie.odesystems.symbolic.odefile import GENERATED_DIR
 from cubie.time_logger import default_timelogger
+
+shutil.rmtree(GENERATED_DIR, ignore_errors=True)
+os.makedirs(GENERATED_DIR, exist_ok=True)
 
 default_timelogger.set_verbosity(None)
 

--- a/benchmarks/lorenz_mean_runtime.py
+++ b/benchmarks/lorenz_mean_runtime.py
@@ -18,11 +18,20 @@ A/B comparison, and kernel runtime is the gate metric.
 Usage::
 
     python benchmarks/lorenz_mean_runtime.py [n_runs] [repeats]
+        [--ref-fixed MEAN STD] [--ref-adaptive MEAN STD]
 
 Defaults: ``2**22`` trajectories for the fixed config and ``2**24``
 for the adaptive config (the adaptive kernel is fast enough at
 ``2**22`` that launch effects blur small deltas); ``repeats = 100``.
 An explicit ``n_runs`` argument applies to both configs.
+
+For the B side of an A/B gate, pass the A side's printed mean and
+std per config via ``--ref-fixed`` / ``--ref-adaptive``. The script
+then also prints a Welch two-sample z statistic,
+``z = (mean - ref_mean) / sqrt(std**2/n + ref_std**2/n)``, and a
+verdict: ``|z| >= 3`` flags the means as different (a regression
+when positive). The textbook 95% bound is 1.96, but solve samples
+are mildly autocorrelated (thermal state), so the gate uses 3.
 
 The generated-code and compiled-kernel caches are cleared on every
 invocation. The kernel cache is keyed by config hash, which does not
@@ -33,11 +42,12 @@ compile from the tree under benchmark; the compile cost is absorbed
 by the warm-up solve, outside the timed region.
 """
 
+import argparse
 import contextlib
 import io
+import math
 import os
 import shutil
-import sys
 import timeit
 
 import numpy as np
@@ -56,13 +66,37 @@ os.makedirs(GENERATED_DIR, exist_ok=True)
 # swallowed by the stdout redirect inside the timed callable.
 default_timelogger.set_verbosity("default")
 
-if len(sys.argv) > 1:
-    n_fixed = n_adaptive = int(sys.argv[1])
+parser = argparse.ArgumentParser(
+    description="Kernel-runtime A/B gate benchmark (Lorenz ensemble)."
+)
+parser.add_argument("n_runs", nargs="?", type=int, default=None)
+parser.add_argument("repeats", nargs="?", type=int, default=100)
+parser.add_argument(
+    "--ref-fixed",
+    nargs=2,
+    type=float,
+    metavar=("MEAN", "STD"),
+    default=None,
+    help="A-side kernel mean and std (ms) for the fixed config.",
+)
+parser.add_argument(
+    "--ref-adaptive",
+    nargs=2,
+    type=float,
+    metavar=("MEAN", "STD"),
+    default=None,
+    help="A-side kernel mean and std (ms) for the adaptive config.",
+)
+args = parser.parse_args()
+
+if args.n_runs is not None:
+    n_fixed = n_adaptive = args.n_runs
 else:
     n_fixed = 2**22
     n_adaptive = 2**24
-repeats = int(sys.argv[2]) if len(sys.argv) > 2 else 100
+repeats = args.repeats
 discarded_solves = 20
+z_threshold = 3.0
 
 precision = np.float32
 
@@ -126,8 +160,12 @@ def collect_kernel_time(solver, kernel_ms):
     )
 
 
-def benchmark(label, solver, n_runs):
-    """Run ``repeats`` solves after a warm-up; print kernel runtime."""
+def benchmark(label, solver, n_runs, reference):
+    """Run ``repeats`` solves after a warm-up; print kernel runtime.
+
+    When ``reference`` holds the A side's (mean, std), a Welch
+    two-sample z statistic against it is printed with a verdict.
+    """
     parameters = {"rho": np.linspace(0.0, 21.0, n_runs)}
     initials_array, parameter_array = solver.build_grid(
         initial_values=initial_conditions, parameters=parameters
@@ -155,13 +193,26 @@ def benchmark(label, solver, n_runs):
         number=1,
     )
     kernel_arr = np.asarray(kernel_ms[discarded_solves:])
+    mean = kernel_arr.mean()
+    std = kernel_arr.std(ddof=1)
     print(
-        f"{label}: kernel mean {kernel_arr.mean():.2f} ms over {repeats} "
+        f"{label}: kernel mean {mean:.2f} ms over {repeats} "
         f"solves of {n_runs} trajectories "
-        f"(std {kernel_arr.std(ddof=1):.2f} ms, "
-        f"min {kernel_arr.min():.2f} ms)"
+        f"(std {std:.2f} ms, min {kernel_arr.min():.2f} ms)"
     )
+    if reference is not None:
+        ref_mean, ref_std = reference
+        z = (mean - ref_mean) / math.sqrt(
+            (std**2 + ref_std**2) / repeats
+        )
+        if z >= z_threshold:
+            verdict = "means differ - REGRESSION"
+        elif z <= -z_threshold:
+            verdict = "means differ - improvement"
+        else:
+            verdict = "no significant difference"
+        print(f"{label}: z = {z:+.2f} vs reference ({verdict})")
 
 
-benchmark("fixed (classical-rk4)", fixed_solver, n_fixed)
-benchmark("adaptive (tsit5)", adaptive_solver, n_adaptive)
+benchmark("fixed (classical-rk4)", fixed_solver, n_fixed, args.ref_fixed)
+benchmark("adaptive (tsit5)", adaptive_solver, n_adaptive, args.ref_adaptive)

--- a/benchmarks/lorenz_mean_runtime.py
+++ b/benchmarks/lorenz_mean_runtime.py
@@ -56,92 +56,11 @@ import cubie as qb
 from cubie.odesystems.symbolic.odefile import GENERATED_DIR
 from cubie.time_logger import default_timelogger
 
-shutil.rmtree(GENERATED_DIR, ignore_errors=True)
-os.makedirs(GENERATED_DIR, exist_ok=True)
-
-# CUDA events (kernel / h2d / d2h per chunk) are recorded only when
-# the time logger is armed. Solver construction resets the global
-# verbosity from its time_logging_level argument, so arming happens
-# through that argument below; solve's printed summaries are
-# swallowed by the stdout redirect inside the timed callable.
-default_timelogger.set_verbosity("default")
-
-parser = argparse.ArgumentParser(
-    description="Kernel-runtime A/B gate benchmark (Lorenz ensemble)."
-)
-parser.add_argument("n_runs", nargs="?", type=int, default=None)
-parser.add_argument("repeats", nargs="?", type=int, default=100)
-parser.add_argument(
-    "--ref-fixed",
-    nargs=2,
-    type=float,
-    metavar=("MEAN", "STD"),
-    default=None,
-    help="A-side kernel mean and std (ms) for the fixed config.",
-)
-parser.add_argument(
-    "--ref-adaptive",
-    nargs=2,
-    type=float,
-    metavar=("MEAN", "STD"),
-    default=None,
-    help="A-side kernel mean and std (ms) for the adaptive config.",
-)
-args = parser.parse_args()
-
-if args.n_runs is not None:
-    n_fixed = n_adaptive = args.n_runs
-else:
-    n_fixed = 2**22
-    n_adaptive = 2**24
-repeats = args.repeats
 discarded_solves = 20
 z_threshold = 3.0
-
 precision = np.float32
-
-lorenz_system = qb.create_ODE_system(
-    """
-    dx = sigma * (y - x)
-    dy = x * (rho - z) - y
-    dz = x * y - beta * z
-    """,
-    states={"x": 1.0, "y": 0.0, "z": 0.0},
-    parameters={"rho": 21.0},
-    constants={"sigma": 10.0, "beta": 8.0 / 3.0},
-    name="Lorenz",
-    precision=precision,
-)
-
 initial_conditions = {"x": 1.0, "y": 0.0, "z": 0.0}
 
-fixed_solver = qb.Solver(
-    lorenz_system,
-    algorithm="classical-rk4",
-    dt=0.001,
-    save_every=1.0,
-    step_controller="fixed",
-    output_types=["state"],
-    time_logging_level="default",
-)
-
-adaptive_solver = qb.Solver(
-    lorenz_system,
-    algorithm="tsit5",
-    atol=1e-08,
-    rtol=1e-08,
-    save_every=1.0,
-    dt_min=1e-12,
-    dt_max=1e3,
-    step_controller="pid",
-    kp=6 / 5,
-    kd=0.0,
-    ki=0.0,
-    max_gain=5.0,
-    min_gain=0.1,
-    output_types=["state"],
-    time_logging_level="default",
-)
 
 def collect_kernel_time(solver, kernel_ms):
     """Append one solve's kernel CUDA-event total (ms) to ``kernel_ms``.
@@ -160,7 +79,7 @@ def collect_kernel_time(solver, kernel_ms):
     )
 
 
-def benchmark(label, solver, n_runs, reference):
+def benchmark(label, solver, n_runs, repeats, reference):
     """Run ``repeats`` solves after a warm-up; print kernel runtime.
 
     When ``reference`` holds the A side's (mean, std), a Welch
@@ -214,5 +133,104 @@ def benchmark(label, solver, n_runs, reference):
         print(f"{label}: z = {z:+.2f} vs reference ({verdict})")
 
 
-benchmark("fixed (classical-rk4)", fixed_solver, n_fixed, args.ref_fixed)
-benchmark("adaptive (tsit5)", adaptive_solver, n_adaptive, args.ref_adaptive)
+def main():
+    """Parse arguments, build the solvers, and run both configs."""
+    shutil.rmtree(GENERATED_DIR, ignore_errors=True)
+    os.makedirs(GENERATED_DIR, exist_ok=True)
+
+    # CUDA events (kernel / h2d / d2h per chunk) are recorded only
+    # when the time logger is armed. Solver construction resets the
+    # global verbosity from its time_logging_level argument, so
+    # arming happens through that argument below; solve's printed
+    # summaries are swallowed by the stdout redirect inside the
+    # timed callable.
+    default_timelogger.set_verbosity("default")
+
+    parser = argparse.ArgumentParser(
+        description="Kernel-runtime A/B gate benchmark (Lorenz ensemble)."
+    )
+    parser.add_argument("n_runs", nargs="?", type=int, default=None)
+    parser.add_argument("repeats", nargs="?", type=int, default=100)
+    parser.add_argument(
+        "--ref-fixed",
+        nargs=2,
+        type=float,
+        metavar=("MEAN", "STD"),
+        default=None,
+        help="A-side kernel mean and std (ms) for the fixed config.",
+    )
+    parser.add_argument(
+        "--ref-adaptive",
+        nargs=2,
+        type=float,
+        metavar=("MEAN", "STD"),
+        default=None,
+        help="A-side kernel mean and std (ms) for the adaptive config.",
+    )
+    args = parser.parse_args()
+
+    if args.n_runs is not None:
+        n_fixed = n_adaptive = args.n_runs
+    else:
+        n_fixed = 2**22
+        n_adaptive = 2**24
+
+    lorenz_system = qb.create_ODE_system(
+        """
+        dx = sigma * (y - x)
+        dy = x * (rho - z) - y
+        dz = x * y - beta * z
+        """,
+        states={"x": 1.0, "y": 0.0, "z": 0.0},
+        parameters={"rho": 21.0},
+        constants={"sigma": 10.0, "beta": 8.0 / 3.0},
+        name="Lorenz",
+        precision=precision,
+    )
+
+    fixed_solver = qb.Solver(
+        lorenz_system,
+        algorithm="classical-rk4",
+        dt=0.001,
+        save_every=1.0,
+        step_controller="fixed",
+        output_types=["state"],
+        time_logging_level="default",
+    )
+
+    adaptive_solver = qb.Solver(
+        lorenz_system,
+        algorithm="tsit5",
+        atol=1e-08,
+        rtol=1e-08,
+        save_every=1.0,
+        dt_min=1e-12,
+        dt_max=1e3,
+        step_controller="pid",
+        kp=6 / 5,
+        kd=0.0,
+        ki=0.0,
+        max_gain=5.0,
+        min_gain=0.1,
+        output_types=["state"],
+        time_logging_level="default",
+    )
+
+    benchmark(
+        "fixed (classical-rk4)",
+        fixed_solver,
+        n_fixed,
+        args.repeats,
+        args.ref_fixed,
+    )
+    benchmark(
+        "adaptive (tsit5)",
+        adaptive_solver,
+        n_adaptive,
+        args.repeats,
+        args.ref_adaptive,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/lorenz_mean_runtime.py
+++ b/benchmarks/lorenz_mean_runtime.py
@@ -8,7 +8,10 @@ compilation, then ``timeit.repeat`` with garbage collection enabled
 and one solve per repeat. The headline number is the mean runtime
 over the repeats (the cross-package comparison scripts report the
 minimum); the minimum and sample standard deviation are printed
-alongside for reference.
+alongside for reference. Each config also reports a CUDA-event
+breakdown (kernel execution vs h2d/d2h transfer, per-chunk events
+recorded on the GPU timeline by ``BatchSolverKernel``) so host-side
+and transfer noise can be separated from kernel time.
 
 Usage::
 
@@ -25,6 +28,8 @@ compile from the tree under benchmark; the compile cost is absorbed
 by the warm-up solve, outside the timed region.
 """
 
+import contextlib
+import io
 import os
 import shutil
 import sys
@@ -39,7 +44,12 @@ from cubie.time_logger import default_timelogger
 shutil.rmtree(GENERATED_DIR, ignore_errors=True)
 os.makedirs(GENERATED_DIR, exist_ok=True)
 
-default_timelogger.set_verbosity(None)
+# CUDA events (kernel / h2d / d2h per chunk) are recorded only when
+# the time logger is armed. Solver construction resets the global
+# verbosity from its time_logging_level argument, so arming happens
+# through that argument below; solve's printed summaries are
+# swallowed by the stdout redirect inside the timed callable.
+default_timelogger.set_verbosity("default")
 
 n_runs = int(sys.argv[1]) if len(sys.argv) > 1 else 2**22
 repeats = int(sys.argv[2]) if len(sys.argv) > 2 else 100
@@ -69,7 +79,7 @@ fixed_solver = qb.Solver(
     save_every=1.0,
     step_controller="fixed",
     output_types=["state"],
-    time_logging_level=None,
+    time_logging_level="default",
 )
 
 adaptive_solver = qb.Solver(
@@ -87,7 +97,7 @@ adaptive_solver = qb.Solver(
     max_gain=5.0,
     min_gain=0.1,
     output_types=["state"],
-    time_logging_level=None,
+    time_logging_level="default",
 )
 
 initials_array, parameter_array = fixed_solver.build_grid(
@@ -95,19 +105,48 @@ initials_array, parameter_array = fixed_solver.build_grid(
 )
 
 
-def benchmark(label, solver):
-    """Time ``repeats`` solves after a warm-up and print the mean."""
+def collect_event_times(solver, sums):
+    """Append per-solve CUDA-event totals (ms) to ``sums`` by prefix.
 
-    def run():
-        return solver.solve(
-            initial_values=initials_array,
-            parameters=parameter_array,
-            blocksize=64,
-            results_type="raw",
-            duration=1.0,
+    Reads the kernel's per-chunk event objects after the solve has
+    synchronised the stream; the GPU-timeline elapsed times separate
+    kernel execution from host<->device transfer traffic.
+    """
+    events = solver.kernel._cuda_events
+    for prefix in sums:
+        sums[prefix].append(
+            sum(
+                event.elapsed_time_ms()
+                for event in events
+                if event.name.startswith(prefix)
+            )
         )
 
+
+def benchmark(label, solver):
+    """Time ``repeats`` solves after a warm-up and print the means.
+
+    Wall-clock timing wraps the whole ``solve`` call (the number the
+    cross-package comparisons use). The CUDA-event breakdown isolates
+    kernel execution from h2d/d2h transfers on the GPU timeline.
+    """
+    event_sums = {"kernel": [], "h2d": [], "d2h": []}
+
+    def run():
+        with contextlib.redirect_stdout(io.StringIO()):
+            solution = solver.solve(
+                initial_values=initials_array,
+                parameters=parameter_array,
+                blocksize=64,
+                results_type="raw",
+                duration=1.0,
+            )
+        collect_event_times(solver, event_sums)
+        return solution
+
     run()  # warm-up (JIT compilation)
+    for values in event_sums.values():
+        values.clear()
     res = timeit.repeat(run, setup="gc.enable()", repeat=repeats, number=1)
     times_ms = np.asarray(res) * 1000.0
     print(
@@ -115,6 +154,13 @@ def benchmark(label, solver):
         f"{n_runs} trajectories (std {times_ms.std(ddof=1):.2f} ms, "
         f"min {times_ms.min():.2f} ms)"
     )
+    for prefix, values in event_sums.items():
+        values_ms = np.asarray(values)
+        print(
+            f"{label}: {prefix} mean {values_ms.mean():.2f} ms "
+            f"(std {values_ms.std(ddof=1):.2f} ms, "
+            f"min {values_ms.min():.2f} ms)"
+        )
 
 
 benchmark("fixed (classical-rk4)", fixed_solver)

--- a/benchmarks/lorenz_mean_runtime.py
+++ b/benchmarks/lorenz_mean_runtime.py
@@ -14,7 +14,7 @@ Usage::
 
     python benchmarks/lorenz_mean_runtime.py [n_runs] [repeats]
 
-Defaults: ``n_runs = 2**24`` trajectories, ``repeats = 100``.
+Defaults: ``n_runs = 2**22`` trajectories, ``repeats = 100``.
 """
 
 import sys
@@ -27,7 +27,7 @@ from cubie.time_logger import default_timelogger
 
 default_timelogger.set_verbosity(None)
 
-n_runs = int(sys.argv[1]) if len(sys.argv) > 1 else 2**24
+n_runs = int(sys.argv[1]) if len(sys.argv) > 1 else 2**22
 repeats = int(sys.argv[2]) if len(sys.argv) > 2 else 100
 
 precision = np.float32

--- a/benchmarks/lorenz_mean_runtime.py
+++ b/benchmarks/lorenz_mean_runtime.py
@@ -5,7 +5,10 @@ Solves the same Lorenz ensemble as the GPUODEBenchmarks cubie runner
 (``GPU_ODE_CUBIE/bench_cubie.py``) with the same solver settings and
 drive pattern: one warm-up solve to absorb JIT compilation, then
 ``timeit.repeat`` with garbage collection enabled and one solve per
-repeat. The output is the **kernel runtime only** — the per-chunk
+repeat. The first 20 post-warm-up solves are discarded — the GPU has
+not reached steady state and they run slow, inflating the standard
+deviation — and statistics cover the following ``repeats`` solves.
+The output is the **kernel runtime only** — the per-chunk
 ``kernel_chunk_i`` CUDA events recorded on the GPU timeline by
 ``BatchSolverKernel`` — as mean, sample standard deviation, and
 minimum over the repeats. Wall-clock and transfer times are not
@@ -52,6 +55,7 @@ default_timelogger.set_verbosity("default")
 
 n_runs = int(sys.argv[1]) if len(sys.argv) > 1 else 2**22
 repeats = int(sys.argv[2]) if len(sys.argv) > 2 else 100
+discarded_solves = 20
 
 precision = np.float32
 
@@ -139,8 +143,13 @@ def benchmark(label, solver):
 
     run()  # warm-up (JIT compilation)
     kernel_ms.clear()
-    timeit.repeat(run, setup="gc.enable()", repeat=repeats, number=1)
-    kernel_arr = np.asarray(kernel_ms)
+    timeit.repeat(
+        run,
+        setup="gc.enable()",
+        repeat=discarded_solves + repeats,
+        number=1,
+    )
+    kernel_arr = np.asarray(kernel_ms[discarded_solves:])
     print(
         f"{label}: kernel mean {kernel_arr.mean():.2f} ms over {repeats} "
         f"solves of {n_runs} trajectories "

--- a/benchmarks/lorenz_mean_runtime.py
+++ b/benchmarks/lorenz_mean_runtime.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+"""Mean-runtime benchmark for a large Lorenz ensemble.
+
+Solves the same Lorenz ensemble as the GPUODEBenchmarks cubie runner
+(``GPU_ODE_CUBIE/bench_cubie.py``) with the same solver settings, and
+times ``Solver.solve`` the same way: one warm-up solve to absorb JIT
+compilation, then ``timeit.repeat`` with garbage collection enabled
+and one solve per repeat. The headline number is the mean runtime
+over the repeats (the cross-package comparison scripts report the
+minimum); the minimum and sample standard deviation are printed
+alongside for reference.
+
+Usage::
+
+    python benchmarks/lorenz_mean_runtime.py [n_runs] [repeats]
+
+Defaults: ``n_runs = 2**24`` trajectories, ``repeats = 100``.
+"""
+
+import sys
+import timeit
+
+import numpy as np
+
+import cubie as qb
+from cubie.time_logger import default_timelogger
+
+default_timelogger.set_verbosity(None)
+
+n_runs = int(sys.argv[1]) if len(sys.argv) > 1 else 2**24
+repeats = int(sys.argv[2]) if len(sys.argv) > 2 else 100
+
+precision = np.float32
+
+lorenz_system = qb.create_ODE_system(
+    """
+    dx = sigma * (y - x)
+    dy = x * (rho - z) - y
+    dz = x * y - beta * z
+    """,
+    states={"x": 1.0, "y": 0.0, "z": 0.0},
+    parameters={"rho": 21.0},
+    constants={"sigma": 10.0, "beta": 8.0 / 3.0},
+    name="Lorenz",
+    precision=precision,
+)
+
+parameters = {"rho": np.linspace(0.0, 21.0, n_runs)}
+initial_conditions = {"x": 1.0, "y": 0.0, "z": 0.0}
+
+fixed_solver = qb.Solver(
+    lorenz_system,
+    algorithm="classical-rk4",
+    dt=0.001,
+    save_every=1.0,
+    step_controller="fixed",
+    output_types=["state"],
+    time_logging_level=None,
+)
+
+adaptive_solver = qb.Solver(
+    lorenz_system,
+    algorithm="tsit5",
+    atol=1e-08,
+    rtol=1e-08,
+    save_every=1.0,
+    dt_min=1e-12,
+    dt_max=1e3,
+    step_controller="pid",
+    kp=6 / 5,
+    kd=0.0,
+    ki=0.0,
+    max_gain=5.0,
+    min_gain=0.1,
+    output_types=["state"],
+    time_logging_level=None,
+)
+
+initials_array, parameter_array = fixed_solver.build_grid(
+    initial_values=initial_conditions, parameters=parameters
+)
+
+
+def benchmark(label, solver):
+    """Time ``repeats`` solves after a warm-up and print the mean."""
+
+    def run():
+        return solver.solve(
+            initial_values=initials_array,
+            parameters=parameter_array,
+            blocksize=64,
+            results_type="raw",
+            duration=1.0,
+        )
+
+    run()  # warm-up (JIT compilation)
+    res = timeit.repeat(run, setup="gc.enable()", repeat=repeats, number=1)
+    times_ms = np.asarray(res) * 1000.0
+    print(
+        f"{label}: mean {times_ms.mean():.2f} ms over {repeats} solves of "
+        f"{n_runs} trajectories (std {times_ms.std(ddof=1):.2f} ms, "
+        f"min {times_ms.min():.2f} ms)"
+    )
+
+
+benchmark("fixed (classical-rk4)", fixed_solver)
+benchmark("adaptive (tsit5)", adaptive_solver)

--- a/benchmarks/lorenz_mean_runtime.py
+++ b/benchmarks/lorenz_mean_runtime.py
@@ -2,16 +2,15 @@
 """Mean-runtime benchmark for a large Lorenz ensemble.
 
 Solves the same Lorenz ensemble as the GPUODEBenchmarks cubie runner
-(``GPU_ODE_CUBIE/bench_cubie.py``) with the same solver settings, and
-times ``Solver.solve`` the same way: one warm-up solve to absorb JIT
-compilation, then ``timeit.repeat`` with garbage collection enabled
-and one solve per repeat. The headline number is the mean runtime
-over the repeats (the cross-package comparison scripts report the
-minimum); the minimum and sample standard deviation are printed
-alongside for reference. Each config also reports a CUDA-event
-breakdown (kernel execution vs h2d/d2h transfer, per-chunk events
-recorded on the GPU timeline by ``BatchSolverKernel``) so host-side
-and transfer noise can be separated from kernel time.
+(``GPU_ODE_CUBIE/bench_cubie.py``) with the same solver settings and
+drive pattern: one warm-up solve to absorb JIT compilation, then
+``timeit.repeat`` with garbage collection enabled and one solve per
+repeat. The output is the **kernel runtime only** — the per-chunk
+``kernel_chunk_i`` CUDA events recorded on the GPU timeline by
+``BatchSolverKernel`` — as mean, sample standard deviation, and
+minimum over the repeats. Wall-clock and transfer times are not
+reported: per-process d2h/host-memory scatter makes them useless for
+A/B comparison, and kernel runtime is the gate metric.
 
 Usage::
 
@@ -105,32 +104,26 @@ initials_array, parameter_array = fixed_solver.build_grid(
 )
 
 
-def collect_event_times(solver, sums):
-    """Append per-solve CUDA-event totals (ms) to ``sums`` by prefix.
+def collect_kernel_time(solver, kernel_ms):
+    """Append one solve's kernel CUDA-event total (ms) to ``kernel_ms``.
 
-    Reads the kernel's per-chunk event objects after the solve has
-    synchronised the stream; the GPU-timeline elapsed times separate
-    kernel execution from host<->device transfer traffic.
+    Reads the kernel's per-chunk ``kernel_chunk_i`` event objects
+    after the solve has synchronised the stream; the GPU-timeline
+    elapsed times exclude host<->device transfer traffic.
     """
     events = solver.kernel._cuda_events
-    for prefix in sums:
-        sums[prefix].append(
-            sum(
-                event.elapsed_time_ms()
-                for event in events
-                if event.name.startswith(prefix)
-            )
+    kernel_ms.append(
+        sum(
+            event.elapsed_time_ms()
+            for event in events
+            if event.name.startswith("kernel_chunk")
         )
+    )
 
 
 def benchmark(label, solver):
-    """Time ``repeats`` solves after a warm-up and print the means.
-
-    Wall-clock timing wraps the whole ``solve`` call (the number the
-    cross-package comparisons use). The CUDA-event breakdown isolates
-    kernel execution from h2d/d2h transfers on the GPU timeline.
-    """
-    event_sums = {"kernel": [], "h2d": [], "d2h": []}
+    """Run ``repeats`` solves after a warm-up; print kernel runtime."""
+    kernel_ms = []
 
     def run():
         with contextlib.redirect_stdout(io.StringIO()):
@@ -141,26 +134,19 @@ def benchmark(label, solver):
                 results_type="raw",
                 duration=1.0,
             )
-        collect_event_times(solver, event_sums)
+        collect_kernel_time(solver, kernel_ms)
         return solution
 
     run()  # warm-up (JIT compilation)
-    for values in event_sums.values():
-        values.clear()
-    res = timeit.repeat(run, setup="gc.enable()", repeat=repeats, number=1)
-    times_ms = np.asarray(res) * 1000.0
+    kernel_ms.clear()
+    timeit.repeat(run, setup="gc.enable()", repeat=repeats, number=1)
+    kernel_arr = np.asarray(kernel_ms)
     print(
-        f"{label}: mean {times_ms.mean():.2f} ms over {repeats} solves of "
-        f"{n_runs} trajectories (std {times_ms.std(ddof=1):.2f} ms, "
-        f"min {times_ms.min():.2f} ms)"
+        f"{label}: kernel mean {kernel_arr.mean():.2f} ms over {repeats} "
+        f"solves of {n_runs} trajectories "
+        f"(std {kernel_arr.std(ddof=1):.2f} ms, "
+        f"min {kernel_arr.min():.2f} ms)"
     )
-    for prefix, values in event_sums.items():
-        values_ms = np.asarray(values)
-        print(
-            f"{label}: {prefix} mean {values_ms.mean():.2f} ms "
-            f"(std {values_ms.std(ddof=1):.2f} ms, "
-            f"min {values_ms.min():.2f} ms)"
-        )
 
 
 benchmark("fixed (classical-rk4)", fixed_solver)

--- a/benchmarks/lorenz_mean_runtime.py
+++ b/benchmarks/lorenz_mean_runtime.py
@@ -19,7 +19,10 @@ Usage::
 
     python benchmarks/lorenz_mean_runtime.py [n_runs] [repeats]
 
-Defaults: ``n_runs = 2**22`` trajectories, ``repeats = 100``.
+Defaults: ``2**22`` trajectories for the fixed config and ``2**24``
+for the adaptive config (the adaptive kernel is fast enough at
+``2**22`` that launch effects blur small deltas); ``repeats = 100``.
+An explicit ``n_runs`` argument applies to both configs.
 
 The generated-code and compiled-kernel caches are cleared on every
 invocation. The kernel cache is keyed by config hash, which does not
@@ -53,7 +56,11 @@ os.makedirs(GENERATED_DIR, exist_ok=True)
 # swallowed by the stdout redirect inside the timed callable.
 default_timelogger.set_verbosity("default")
 
-n_runs = int(sys.argv[1]) if len(sys.argv) > 1 else 2**22
+if len(sys.argv) > 1:
+    n_fixed = n_adaptive = int(sys.argv[1])
+else:
+    n_fixed = 2**22
+    n_adaptive = 2**24
 repeats = int(sys.argv[2]) if len(sys.argv) > 2 else 100
 discarded_solves = 20
 
@@ -72,7 +79,6 @@ lorenz_system = qb.create_ODE_system(
     precision=precision,
 )
 
-parameters = {"rho": np.linspace(0.0, 21.0, n_runs)}
 initial_conditions = {"x": 1.0, "y": 0.0, "z": 0.0}
 
 fixed_solver = qb.Solver(
@@ -103,11 +109,6 @@ adaptive_solver = qb.Solver(
     time_logging_level="default",
 )
 
-initials_array, parameter_array = fixed_solver.build_grid(
-    initial_values=initial_conditions, parameters=parameters
-)
-
-
 def collect_kernel_time(solver, kernel_ms):
     """Append one solve's kernel CUDA-event total (ms) to ``kernel_ms``.
 
@@ -125,8 +126,12 @@ def collect_kernel_time(solver, kernel_ms):
     )
 
 
-def benchmark(label, solver):
+def benchmark(label, solver, n_runs):
     """Run ``repeats`` solves after a warm-up; print kernel runtime."""
+    parameters = {"rho": np.linspace(0.0, 21.0, n_runs)}
+    initials_array, parameter_array = solver.build_grid(
+        initial_values=initial_conditions, parameters=parameters
+    )
     kernel_ms = []
 
     def run():
@@ -158,5 +163,5 @@ def benchmark(label, solver):
     )
 
 
-benchmark("fixed (classical-rk4)", fixed_solver)
-benchmark("adaptive (tsit5)", adaptive_solver)
+benchmark("fixed (classical-rk4)", fixed_solver, n_fixed)
+benchmark("adaptive (tsit5)", adaptive_solver, n_adaptive)


### PR DESCRIPTION
## Summary

- `benchmarks/lorenz_mean_runtime.py`: kernel-runtime benchmark for a large Lorenz ensemble, the A/B performance gate for every PR. It drives the same Lorenz ensemble as the GPUODEBenchmarks cubie runner (`GPU_ODE_CUBIE/bench_cubie.py`) — same system, solver settings (fixed `classical-rk4` and adaptive `tsit5`), blocksize 64, `results_type='raw'`, duration 1.0 — with the same repeat structure (one warm-up solve for JIT, then `timeit.repeat(run, setup='gc.enable()', repeat=100, number=1)`). **Its only output is kernel runtime** — the per-chunk `kernel_chunk_i` CUDA events recorded on the GPU timeline by `BatchSolverKernel` — as mean/std/min over the repeats per config. Wall-clock and h2d/d2h numbers are deliberately not reported: per-process d2h/host-memory scatter (each process draws one d2h rate for its lifetime, varying ±25% between invocations for identical transfers) makes them useless for A/B comparison, while kernel means are stable to <1% across invocations. Defaults: `2**22` trajectories, 100 repeats (argv-overridable). `GENERATED_DIR` is cleared on every invocation so the config-hash-keyed kernel cache can never serve a kernel compiled from a different source tree in `PYTHONPATH` A/B runs; the compile cost lands in the untimed warm-up.
- `AGENTS.md` (mirrored by the `CLAUDE.md` symlink), Commits & PRs: agent workflow rules — every fix or feature on its own branch off `main`, commit/push/PR when done, and the A/B kernel-runtime gate on every PR (a mean shift outside the standard deviations indicates a regression).

## Gate runs performed with this script

- PR #556 (`fix/548-zero-dt-save-boundary`): kernel A/B posted on that PR.
- PR #555 (`fix-554-save-schedule-drift`): kernel A/B posted on that PR — fixed unchanged, adaptive `tsit5` +1.4%, indicating a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
