### PR TITLE
fix: summary legends populate for summary-only solves; fused metrics report requested names

### DIFF
--- a/docs/source/user_guide/results.rst
+++ b/docs/source/user_guide/results.rst
@@ -127,6 +127,13 @@ Built-in Summary Metrics
    * - ``"mean_std_rms"``
      - Mean, standard deviation, and RMS combined.
 
+Requesting a full set of constituent metrics that share running sums
+(for example ``["max", "min"]`` or ``["mean", "std", "rms"]``) is
+automatically computed using the matching combined metric internally,
+but each result is still reported under its requested name (``"max"``,
+``"min"``, and so on) — the fusion is a transparent performance
+optimisation, not a change to the reported legend.
+
 Selecting Variables to Save
 ---------------------------
 

--- a/src/cubie/batchsolving/solveresult.py
+++ b/src/cubie/batchsolving/solveresult.py
@@ -692,8 +692,8 @@ class SolveResult:
         """
         singlevar_legend = solver.summary_legend_per_variable
         unit_modifications = solver.summary_unit_modifications
-        state_labels = solver.saved_states
-        obs_labels = solver.saved_observables
+        state_labels = solver.summarised_states
+        obs_labels = solver.summarised_observables
         summaries_legend = {}
 
         state_units = {}

--- a/src/cubie/outputhandling/summarymetrics/d2xdt2_extrema.py
+++ b/src/cubie/outputhandling/summarymetrics/d2xdt2_extrema.py
@@ -44,6 +44,7 @@ class D2xdt2Extrema(SummaryMetric):
             buffer_size=4,
             output_size=2,
             unit_modification="[unit]*s^-2",
+            output_names=["d2xdt2_max", "d2xdt2_min"],
         )
 
     def build(self) -> MetricFuncCache:

--- a/src/cubie/outputhandling/summarymetrics/dxdt_extrema.py
+++ b/src/cubie/outputhandling/summarymetrics/dxdt_extrema.py
@@ -43,6 +43,7 @@ class DxdtExtrema(SummaryMetric):
             buffer_size=3,
             output_size=2,
             unit_modification="[unit]*s^-1",
+            output_names=["dxdt_max", "dxdt_min"],
         )
 
     def build(self) -> MetricFuncCache:

--- a/src/cubie/outputhandling/summarymetrics/extrema.py
+++ b/src/cubie/outputhandling/summarymetrics/extrema.py
@@ -41,6 +41,7 @@ class Extrema(SummaryMetric):
             buffer_size=2,
             output_size=2,
             unit_modification="[unit]",
+            output_names=["max", "min"],
         )
 
     def build(self) -> MetricFuncCache:

--- a/src/cubie/outputhandling/summarymetrics/mean_std.py
+++ b/src/cubie/outputhandling/summarymetrics/mean_std.py
@@ -45,6 +45,7 @@ class MeanStd(SummaryMetric):
             buffer_size=3,
             output_size=2,
             unit_modification="[unit]",
+            output_names=["mean", "std"],
         )
 
     def build(self) -> MetricFuncCache:

--- a/src/cubie/outputhandling/summarymetrics/mean_std_rms.py
+++ b/src/cubie/outputhandling/summarymetrics/mean_std_rms.py
@@ -46,6 +46,7 @@ class MeanStdRms(SummaryMetric):
             buffer_size=3,
             output_size=3,
             unit_modification="[unit]",
+            output_names=["mean", "std", "rms"],
         )
 
     def build(self) -> MetricFuncCache:

--- a/src/cubie/outputhandling/summarymetrics/metrics.py
+++ b/src/cubie/outputhandling/summarymetrics/metrics.py
@@ -202,6 +202,16 @@ class SummaryMetric(CUDAFactory):
         self.output_size = output_size
         self.name = name
         self.unit_modification = unit_modification
+        if (
+            output_names is not None
+            and not callable(output_size)
+            and len(output_names) != output_size
+        ):
+            raise ValueError(
+                f"Metric '{name}': output_names has "
+                f"{len(output_names)} entries but output_size is "
+                f"{output_size}."
+            )
         self.output_names = output_names
 
         # Instantiate empty settings object for CUDAFactory compatibility

--- a/src/cubie/outputhandling/summarymetrics/metrics.py
+++ b/src/cubie/outputhandling/summarymetrics/metrics.py
@@ -137,6 +137,11 @@ class SummaryMetric(CUDAFactory):
         str. Identifier used in registries and configuration strings.
     unit_modification
         str. Format string for unit modification in legends.
+    output_names
+        Optional[list[str]]. Declared column headings for each output
+        element, in output order. ``None`` falls back to the registry's
+        default naming (the metric name for a single output, or
+        ``{name}_{i+1}`` for each element of a multi-output metric).
     update_device_func
         Callable. Compiled CUDA device update function for the metric.
     save_device_func
@@ -163,6 +168,7 @@ class SummaryMetric(CUDAFactory):
         precision: PrecisionDType,
         unit_modification: str = "[unit]",
         sample_summaries_every: float = 0.01,
+        output_names: Optional[list] = None,
     ) -> None:
         """Initialise core metadata for a summary metric.
 
@@ -185,6 +191,10 @@ class SummaryMetric(CUDAFactory):
         precision
             PrecisionDType. Numerical precision for metric calculations.
             Defaults to np.float32.
+        output_names
+            Optional[list[str]]. Column headings for each output element,
+            in output order. ``None`` (the default) falls back to the
+            registry's default naming.
         """
 
         super().__init__()
@@ -192,6 +202,7 @@ class SummaryMetric(CUDAFactory):
         self.output_size = output_size
         self.name = name
         self.unit_modification = unit_modification
+        self.output_names = output_names
 
         # Instantiate empty settings object for CUDAFactory compatibility
         self.setup_compile_settings(
@@ -268,6 +279,9 @@ class SummaryMetrics:
         dict[str, int | Callable]. Buffer size requirements keyed by name.
     _output_sizes
         dict[str, int | Callable]. Output size requirements keyed by name.
+    _output_names
+        dict[str, Optional[list[str]]]. Declared output column headings
+        keyed by name, or ``None`` when a metric uses default naming.
     _metric_objects
         dict[str, SummaryMetric]. Registered metric instances.
     _params
@@ -291,6 +305,11 @@ class SummaryMetrics:
         init=False,
     )
     _output_sizes: dict[str, Union[int, Callable]] = field(
+        validator=instance_of(dict),
+        factory=dict,
+        init=False,
+    )
+    _output_names: dict[str, Optional[list]] = field(
         validator=instance_of(dict),
         factory=dict,
         init=False,
@@ -375,6 +394,7 @@ class SummaryMetrics:
         self._names.append(metric.name)
         self._buffer_sizes[metric.name] = metric.buffer_size
         self._output_sizes[metric.name] = metric.output_size
+        self._output_names[metric.name] = metric.output_names
         self._metric_objects[metric.name] = metric
         self._params[metric.name] = 0
 
@@ -657,7 +677,9 @@ class SummaryMetrics:
 
         Notes
         -----
-        Metrics with multi-element outputs produce numbered headings such as
+        Metrics that declare ``output_names`` use those headings directly.
+        Otherwise, a single-element output uses the metric name, and a
+        multi-element output produces numbered headings such as
         ``{name}_1`` and ``{name}_2``.
         """
         parsed_request = self.preprocess_request(output_types_requested)
@@ -665,8 +687,11 @@ class SummaryMetrics:
 
         for metric in parsed_request:
             output_size = self._get_size(metric, self._output_sizes)
+            declared_names = self._output_names.get(metric)
 
-            if output_size == 1:
+            if declared_names is not None:
+                headings.extend(declared_names)
+            elif output_size == 1:
                 headings.append(metric)
             else:
                 for i in range(output_size):

--- a/src/cubie/outputhandling/summarymetrics/metrics.py
+++ b/src/cubie/outputhandling/summarymetrics/metrics.py
@@ -40,7 +40,6 @@ from warnings import warn
 from abc import abstractmethod
 from attrs import define, field
 from attrs.validators import instance_of, optional as val_optional
-from numpy import floating
 
 from cubie._utils import (
     gttype_validator,

--- a/src/cubie/outputhandling/summarymetrics/std_rms.py
+++ b/src/cubie/outputhandling/summarymetrics/std_rms.py
@@ -46,6 +46,7 @@ class StdRms(SummaryMetric):
             buffer_size=3,
             output_size=2,
             unit_modification="[unit]",
+            output_names=["std", "rms"],
         )
 
     def build(self) -> MetricFuncCache:

--- a/tests/batchsolving/test_solveresult.py
+++ b/tests/batchsolving/test_solveresult.py
@@ -569,11 +569,10 @@ def solved_summary_only_solver(system, precision):
     """Solver run with a summary-only, fusing output configuration.
 
     No state or observable output is requested, and the requested
-    summary metrics (``mean``, ``max``, ``min``) fully cover the
-    ``extrema`` combined-metric substitution, so this fixture serves as
-    the regression case for both issue #546 (empty summaries legend on
-    summary-only solves) and issue #547 (fused metrics reporting under
-    ``extrema_1``/``extrema_2`` instead of their requested names).
+    summary metrics (``mean``, ``max``, ``min``) trigger the
+    ``extrema`` combined-metric substitution, so the result
+    exercises both the summary-only legend path and requested-name
+    reporting for fused metrics.
     """
     solver = Solver(system, save_every=0.01)
 
@@ -595,12 +594,12 @@ def solved_summary_only_solver(system, precision):
 
 
 class TestSummaryOnlyRegression:
-    """Regression coverage for issues #546 and #547."""
+    """Summary-only legends and fused-metric output naming."""
 
     def test_summary_only_solve_populates_legend(
         self, solved_summary_only_solver
     ):
-        """#546: a summary-only solve still produces a non-empty
+        """A summary-only solve produces a non-empty
         summaries_legend whose row count matches the variable dimension
         of summaries_array."""
         result = SolveResult.from_solver(solved_summary_only_solver)
@@ -615,7 +614,7 @@ class TestSummaryOnlyRegression:
     def test_fused_extrema_reports_requested_names(
         self, solved_summary_only_solver
     ):
-        """#547: the fused max/min metric reports its outputs under the
+        """The fused max/min metric reports its outputs under the
         requested names, not extrema_1/extrema_2, with max >= min
         elementwise."""
         per_summary = SolveResult.from_solver(

--- a/tests/batchsolving/test_solveresult.py
+++ b/tests/batchsolving/test_solveresult.py
@@ -564,6 +564,71 @@ class TestNaNProcessing:
             status_array[2] = original_values[2]
 
 
+@pytest.fixture(scope="session")
+def solved_summary_only_solver(system, precision):
+    """Solver run with a summary-only, fusing output configuration.
+
+    No state or observable output is requested, and the requested
+    summary metrics (``mean``, ``max``, ``min``) fully cover the
+    ``extrema`` combined-metric substitution, so this fixture serves as
+    the regression case for both issue #546 (empty summaries legend on
+    summary-only solves) and issue #547 (fused metrics reporting under
+    ``extrema_1``/``extrema_2`` instead of their requested names).
+    """
+    solver = Solver(system, save_every=0.01)
+
+    solver.solve(
+        initial_values={
+            "x0": [1.0, 2.0, 3.0],
+            "x1": [0.0, 0.0, 0.0],
+            "x2": [0.0, 0.0, 0.0],
+        },
+        parameters={
+            "p0": [0.1, 0.2, 0.3],
+            "p1": [0.1, 0.2, 0.3],
+            "p2": [0.1, 0.2, 0.3],
+        },
+        duration=0.1,
+        output_types=["mean", "max", "min"],
+    )
+    return solver
+
+
+class TestSummaryOnlyRegression:
+    """Regression coverage for issues #546 and #547."""
+
+    def test_summary_only_solve_populates_legend(
+        self, solved_summary_only_solver
+    ):
+        """#546: a summary-only solve still produces a non-empty
+        summaries_legend whose row count matches the variable dimension
+        of summaries_array."""
+        result = SolveResult.from_solver(solved_summary_only_solver)
+
+        assert result.summaries_legend != {}
+        variable_index = result._stride_order.index("variable")
+        assert (
+            len(result.summaries_legend)
+            == result.summaries_array.shape[variable_index]
+        )
+
+    def test_fused_extrema_reports_requested_names(
+        self, solved_summary_only_solver
+    ):
+        """#547: the fused max/min metric reports its outputs under the
+        requested names, not extrema_1/extrema_2, with max >= min
+        elementwise."""
+        per_summary = SolveResult.from_solver(
+            solved_summary_only_solver, results_type="numpy_per_summary"
+        )
+
+        assert "max" in per_summary
+        assert "min" in per_summary
+        assert "extrema_1" not in per_summary
+        assert "extrema_2" not in per_summary
+        assert np.all(per_summary["max"] >= per_summary["min"])
+
+
 class TestSolveSpecFields:
     """Test SolveSpec field attributes."""
 

--- a/tests/outputhandling/summarymetrics/test_summary_metrics.py
+++ b/tests/outputhandling/summarymetrics/test_summary_metrics.py
@@ -794,12 +794,42 @@ def test_real_registry_offsets():
 
 
 def test_legend_combined_metric():
-    """Combined mean_std_rms produces 3 numbered headings."""
+    """Combined mean_std_rms reports its declared constituent names."""
     headings = global_registry.legend(["mean", "std", "rms"])
-    assert headings == ["mean_std_rms_1", "mean_std_rms_2", "mean_std_rms_3"]
+    assert headings == ["mean", "std", "rms"]
 
 
 def test_legend_single_output_metrics():
     """Single-output metrics produce their name as heading."""
     headings = global_registry.legend(["mean", "max", "rms"])
     assert headings == ["mean", "max", "rms"]
+
+
+def test_legend_extrema_combined_metric():
+    """Combined extrema reports max/min under their requested names."""
+    headings = global_registry.legend(["max", "min"])
+    assert headings == ["max", "min"]
+
+
+def test_legend_dxdt_extrema_combined_metric():
+    """Combined dxdt_extrema reports dxdt_max/dxdt_min names."""
+    headings = global_registry.legend(["dxdt_max", "dxdt_min"])
+    assert headings == ["dxdt_max", "dxdt_min"]
+
+
+def test_legend_d2xdt2_extrema_combined_metric():
+    """Combined d2xdt2_extrema reports d2xdt2_max/d2xdt2_min names."""
+    headings = global_registry.legend(["d2xdt2_max", "d2xdt2_min"])
+    assert headings == ["d2xdt2_max", "d2xdt2_min"]
+
+
+def test_legend_std_rms_combined_metric():
+    """Combined std_rms reports std/rms names."""
+    headings = global_registry.legend(["std", "rms"])
+    assert headings == ["std", "rms"]
+
+
+def test_legend_mean_std_combined_metric():
+    """Combined mean_std reports mean/std names."""
+    headings = global_registry.legend(["mean", "std"])
+    assert headings == ["mean", "std"]

--- a/tests/outputhandling/test_output_config.py
+++ b/tests/outputhandling/test_output_config.py
@@ -753,6 +753,26 @@ def test_summary_legend_maps_indices():
     assert legend == expected
 
 
+def test_summary_legend_maps_indices_fused_extrema():
+    """Fused max/min legend reports the requested metric names."""
+    cfg = OutputConfig(
+        max_states=3, max_observables=2,
+        output_types=["max", "min"], precision=np.float32,
+    )
+    legend = cfg.summary_legend_per_variable
+    assert legend == {0: "max", 1: "min"}
+
+
+def test_summary_legend_maps_indices_fused_mean_std_rms():
+    """Fused mean/std/rms legend reports the requested metric names."""
+    cfg = OutputConfig(
+        max_states=3, max_observables=2,
+        output_types=["mean", "std", "rms"], precision=np.float32,
+    )
+    legend = cfg.summary_legend_per_variable
+    assert legend == {0: "mean", 1: "std", 2: "rms"}
+
+
 # -- summary_unit_modifications ------------------------------------------- #
 
 


### PR DESCRIPTION
Closes #546, closes #547.

## Root causes

- **#546** — `SolveResult.summary_legend_from_solver` iterated the verbatim-saved variable lists (`solver.saved_states`/`saved_observables`), which are empty whenever `save_state`/`save_observables` is `False`, so summary-only solves produced `summaries_legend == {}` while `summaries_array` was populated. The legend now iterates `solver.summarised_states`/`summarised_observables`, which align one-to-one with the variable rows of `summaries_array`.
- **#547** — when a full constituent set is requested, `SummaryMetrics._apply_combined_metrics` substitutes the fused metric (`["max","min"]` → `["extrema"]`), and `SummaryMetrics.legend` named multi-output columns `f"{metric}_{i+1}"`, yielding `extrema_1`/`extrema_2` keys in `as_numpy_per_summary`.

## Fix (metric-declared legend, per the design direction in #547)

- `SummaryMetric` accepts an `output_names` declaration; the registry captures it and `SummaryMetrics.legend` draws headings from declared names, falling back to the previous single-name/numbered behaviour for undeclared and parameterized metrics (`peaks`, `negative_peaks`).
- All six fused metrics declare names verified against their device `save()` write order: `extrema` → `max, min`; `dxdt_extrema` → `dxdt_max, dxdt_min`; `d2xdt2_extrema` → `d2xdt2_max, d2xdt2_min`; `mean_std` → `mean, std`; `std_rms` → `std, rms`; `mean_std_rms` → `mean, std, rms`.
- `per_summary_arrays`/`as_numpy_per_summary` key off the legend, so `result.as_numpy_per_summary["max"]` works when `min` is also requested.

## Tests & verification

- Regression tests for both issues in `tests/batchsolving/test_solveresult.py` (summary-only solve → populated legend; fused solve → `max`/`min` keys with `max >= min` elementwise), plus fused-legend cases in `test_summary_metrics.py` and `test_output_config.py`.
- Real GPU (CUDASIM off): 320 passed across `tests/outputhandling` + `tests/batchsolving/test_solveresult.py`; independent verifier re-run: 226 passed on the targeted subset, write-order of all six fused metrics audited.

## Docs

- `docs/source/user_guide/results.rst` states fused computation is a transparent optimisation reported under the requested names. Note: `docs/source/tutorials/extracting_summaries.rst` (mentioned in #547) exists only on the open `docs/tutorials` branch (#551) — its "one quirk to know" paragraph should be dropped when that PR rebases onto this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)