### PR TITLE
docs: solve() configuration reference and per-algorithm defaults

### DIFF
--- a/docs/source/API_reference/integrators/algorithms.rst
+++ b/docs/source/API_reference/integrators/algorithms.rst
@@ -38,6 +38,115 @@ satisfy nonlinear solves. Precision handling is central: every factory
 propagates the configured precision through compiled device helpers and the
 shared linear and nonlinear solver stack.
 
+.. _algorithm-defaults:
+
+Default settings
+----------------
+
+Each algorithm ships with a default scheme and a default step
+controller. Requesting an algorithm by family name
+(``algorithm="erk"``) uses the defaults below; requesting a specific
+tableau alias (``algorithm="radau"``) selects that scheme within the
+same family.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 36 10 34
+
+   * - Name
+     - Default scheme
+     - Order
+     - Default step control
+   * - ``euler``
+     - Forward Euler (explicit, single stage)
+     - 1
+     - Fixed step
+   * - ``backwards_euler``
+     - Backward Euler (implicit, single stage)
+     - 1
+     - Fixed step
+   * - ``backwards_euler_pc``
+     - Backward Euler with a forward-Euler predictor
+     - 1
+     - Fixed step
+   * - ``crank_nicolson``
+     - Crank–Nicolson with an embedded backward-Euler error
+       estimate
+     - 2
+     - PID: ``kp=0.7``, ``ki=-0.4``, gain clamp 0.5–2.0
+   * - ``erk``
+     - ``dormand-prince-54`` (explicit, seven stages)
+     - 5(4)
+     - PID: ``kp=0.7``, ``ki=-0.4``, gain clamp 0.1–5.0
+   * - ``dirk``
+     - ``lobatto_iiic_3`` (diagonally implicit, three stages)
+     - 4
+     - Fixed step — the default tableau has no error estimate
+   * - ``firk``
+     - ``firk_gauss_legendre_2`` (fully implicit, two coupled
+       stages)
+     - 4
+     - Fixed step — the default tableau has no error estimate
+   * - ``rosenbrock``
+     - ``ros3p`` (linearly implicit, three stages)
+     - 3
+     - PID: ``kp=0.6``, ``ki=-0.4``, gain clamp 0.5–2.0
+
+How the step controller is chosen
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Adaptive step control needs an embedded error estimate. When an
+algorithm or tableau is named without setting ``step_controller``,
+CuBIE selects the family's tuned PID controller if the scheme
+provides an estimate, and a fixed-step controller if it does not.
+This is why ``dirk`` and ``firk`` run fixed-step out of the box:
+their default tableaus carry no embedded estimate. Aliases that do
+(``radau``, for example) enable the family's adaptive defaults
+automatically. Explicitly pairing an adaptive controller with an
+estimate-free scheme falls back to fixed stepping with a
+``UserWarning``.
+
+The adaptive family defaults all use a 1.0–1.1 deadband (step-size
+changes smaller than 10% are skipped). Every value can be overridden
+per solve — see :doc:`/user_guide/configuration` for how kwargs
+reach the controller and :doc:`/user_guide/optional_arguments` for
+the full parameter list.
+
+Implicit solver defaults
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Implicit algorithms (``backwards_euler``, ``backwards_euler_pc``,
+``crank_nicolson``, ``dirk``, ``firk``) solve their stage equations
+with a matrix-free Newton–Krylov iteration. ``rosenbrock`` is
+linearly implicit: it performs one linear solve per stage, so only
+the Krylov and preconditioner settings below apply to it and the
+``newton_*`` parameters do not.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Parameter
+     - Default
+   * - ``newton_atol`` / ``newton_rtol``
+     - ``1e-6``
+   * - ``newton_max_iters``
+     - ``100``
+   * - ``newton_damping``
+     - ``0.5``
+   * - ``newton_max_backtracks``
+     - ``8``
+   * - ``krylov_atol`` / ``krylov_rtol``
+     - ``1e-6``
+   * - ``krylov_max_iters``
+     - ``100``
+   * - ``linear_correction_type``
+     - ``"minimal_residual"``
+   * - ``preconditioner_type``
+     - ``"neumann"``
+   * - ``preconditioner_order``
+     - ``2``
+
 Base infrastructure
 -------------------
 

--- a/docs/source/API_reference/integrators/algorithms.rst
+++ b/docs/source/API_reference/integrators/algorithms.rst
@@ -106,8 +106,8 @@ automatically. Explicitly pairing an adaptive controller with an
 estimate-free scheme falls back to fixed stepping with a
 ``UserWarning``.
 
-The adaptive family defaults all use a 1.0–1.1 deadband (step-size
-changes smaller than 10% are skipped). Every value can be overridden
+The adaptive family defaults all use a 1.0–1.2 deadband (step-size
+increases smaller than 20% are skipped; decreases always apply). Every value can be overridden
 per solve — see :doc:`/user_guide/configuration` for how kwargs
 reach the controller and :doc:`/user_guide/optional_arguments` for
 the full parameter list.

--- a/docs/source/API_reference/integrators/algorithms/backwards_euler_pc_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/backwards_euler_pc_step.rst
@@ -6,27 +6,11 @@ BackwardsEulerPCStep
 Defaults
 --------
 
-:class:`BackwardsEulerPCStep` subclasses
-:class:`~cubie.integrators.algorithms.backwards_euler.BackwardsEulerStep`
-(``backwards_euler_predict_correct.py``) and inherits its configuration
-unchanged, adding only an explicit forward-Euler predictor evaluated
-before the implicit Newton–Krylov corrector runs.
-
-* No Butcher tableau — a single-stage, implicit, order-1 update, same
-  as backward Euler.
-* Step controller: ``"fixed"`` (inherited ``BE_DEFAULTS``,
-  ``backwards_euler.py:58-62``); the algorithm reports no embedded
-  error estimate, so ``check_compatibility``
-  (``SingleIntegratorRunCore.py:394-457``) silently replaces any
-  adaptive controller with ``FixedStepController``.
-* Nonlinear/linear solver defaults: identical to
-  :doc:`BackwardsEulerStep <backwards_euler_step>` — ``newton_atol``/
-  ``newton_rtol=1e-6``, ``newton_max_iters=100``,
-  ``newton_damping=0.5``, ``newton_max_backtracks=8``,
-  ``krylov_atol``/``krylov_rtol=1e-6``, ``krylov_max_iters=100``,
-  ``linear_correction_type="minimal_residual"``,
-  ``preconditioner_type="neumann"``, ``preconditioner_order=2``
-  (``ode_implicitstep.py:52-124``).
+``algorithm="backwards_euler_pc"`` inherits every default from
+:doc:`BackwardsEulerStep <backwards_euler_step>` — order 1,
+fixed-step control, and the shared Newton–Krylov solver settings
+(:ref:`algorithm-defaults`) — adding only an explicit forward-Euler
+predictor evaluated before the implicit corrector runs.
 
 .. autoclass:: BackwardsEulerPCStep
     :members:

--- a/docs/source/API_reference/integrators/algorithms/backwards_euler_pc_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/backwards_euler_pc_step.rst
@@ -3,6 +3,31 @@ BackwardsEulerPCStep
 
 .. currentmodule:: cubie.integrators
 
+Defaults
+--------
+
+:class:`BackwardsEulerPCStep` subclasses
+:class:`~cubie.integrators.algorithms.backwards_euler.BackwardsEulerStep`
+(``backwards_euler_predict_correct.py``) and inherits its configuration
+unchanged, adding only an explicit forward-Euler predictor evaluated
+before the implicit Newton–Krylov corrector runs.
+
+* No Butcher tableau — a single-stage, implicit, order-1 update, same
+  as backward Euler.
+* Step controller: ``"fixed"`` (inherited ``BE_DEFAULTS``,
+  ``backwards_euler.py:58-62``); the algorithm reports no embedded
+  error estimate, so ``check_compatibility``
+  (``SingleIntegratorRunCore.py:394-457``) silently replaces any
+  adaptive controller with ``FixedStepController``.
+* Nonlinear/linear solver defaults: identical to
+  :doc:`BackwardsEulerStep <backwards_euler_step>` — ``newton_atol``/
+  ``newton_rtol=1e-6``, ``newton_max_iters=100``,
+  ``newton_damping=0.5``, ``newton_max_backtracks=8``,
+  ``krylov_atol``/``krylov_rtol=1e-6``, ``krylov_max_iters=100``,
+  ``linear_correction_type="minimal_residual"``,
+  ``preconditioner_type="neumann"``, ``preconditioner_order=2``
+  (``ode_implicitstep.py:52-124``).
+
 .. autoclass:: BackwardsEulerPCStep
     :members:
     :show-inheritance:

--- a/docs/source/API_reference/integrators/algorithms/backwards_euler_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/backwards_euler_step.rst
@@ -3,6 +3,48 @@ BackwardsEulerStep
 
 .. currentmodule:: cubie.integrators
 
+Defaults
+--------
+
+* No Butcher tableau — a single-stage, implicit, order-1 backward-Euler
+  update (``beta=1.0``, ``gamma=1.0``, ``M=eye`` — ``ALGO_CONSTANTS``,
+  ``backwards_euler.py:54-56``).
+* Step controller: ``"fixed"`` (``BE_DEFAULTS``,
+  ``backwards_euler.py:58-62``). Backward Euler has no embedded error
+  estimate, so an adaptive controller can never be selected: an
+  algorithm with ``is_adaptive == False`` paired with an adaptive
+  controller is silently replaced with ``FixedStepController`` and a
+  ``UserWarning`` is raised by ``check_compatibility``
+  (``SingleIntegratorRunCore.py:394-457``).
+* Nonlinear/linear solver defaults (Newton–Krylov,
+  ``ode_implicitstep.py:52-124``), shared by every implicit algorithm
+  except Rosenbrock-W:
+
+  .. list-table::
+     :header-rows: 1
+     :widths: 45 55
+
+     * - Parameter
+       - Default
+     * - ``newton_atol`` / ``newton_rtol``
+       - ``1e-6``
+     * - ``newton_max_iters``
+       - ``100``
+     * - ``newton_damping``
+       - ``0.5``
+     * - ``newton_max_backtracks``
+       - ``8``
+     * - ``krylov_atol`` / ``krylov_rtol``
+       - ``1e-6``
+     * - ``krylov_max_iters``
+       - ``100``
+     * - ``linear_correction_type``
+       - ``"minimal_residual"``
+     * - ``preconditioner_type``
+       - ``"neumann"``
+     * - ``preconditioner_order``
+       - ``2``
+
 .. autoclass:: BackwardsEulerStep
     :members:
     :show-inheritance:

--- a/docs/source/API_reference/integrators/algorithms/backwards_euler_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/backwards_euler_step.rst
@@ -6,44 +6,11 @@ BackwardsEulerStep
 Defaults
 --------
 
-* No Butcher tableau — a single-stage, implicit, order-1 backward-Euler
-  update (``beta=1.0``, ``gamma=1.0``, ``M=eye`` — ``ALGO_CONSTANTS``,
-  ``backwards_euler.py:54-56``).
-* Step controller: ``"fixed"`` (``BE_DEFAULTS``,
-  ``backwards_euler.py:58-62``). Backward Euler has no embedded error
-  estimate, so an adaptive controller can never be selected: an
-  algorithm with ``is_adaptive == False`` paired with an adaptive
-  controller is silently replaced with ``FixedStepController`` and a
-  ``UserWarning`` is raised by ``check_compatibility``
-  (``SingleIntegratorRunCore.py:394-457``).
-* Nonlinear/linear solver defaults (Newton–Krylov,
-  ``ode_implicitstep.py:52-124``), shared by every implicit algorithm
-  except Rosenbrock-W:
-
-  .. list-table::
-     :header-rows: 1
-     :widths: 45 55
-
-     * - Parameter
-       - Default
-     * - ``newton_atol`` / ``newton_rtol``
-       - ``1e-6``
-     * - ``newton_max_iters``
-       - ``100``
-     * - ``newton_damping``
-       - ``0.5``
-     * - ``newton_max_backtracks``
-       - ``8``
-     * - ``krylov_atol`` / ``krylov_rtol``
-       - ``1e-6``
-     * - ``krylov_max_iters``
-       - ``100``
-     * - ``linear_correction_type``
-       - ``"minimal_residual"``
-     * - ``preconditioner_type``
-       - ``"neumann"``
-     * - ``preconditioner_order``
-       - ``2``
+``algorithm="backwards_euler"`` performs a single-stage, order-1
+backward-Euler update under fixed-step control; the method carries
+no embedded error estimate, so adaptive control is unavailable. Each
+step solves the implicit stage equation with the shared
+Newton–Krylov defaults listed in :ref:`algorithm-defaults`.
 
 .. autoclass:: BackwardsEulerStep
     :members:

--- a/docs/source/API_reference/integrators/algorithms/crank_nicolson_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/crank_nicolson_step.rst
@@ -3,6 +3,47 @@ CrankNicolsonStep
 
 .. currentmodule:: cubie.integrators
 
+Defaults
+--------
+
+* No Butcher tableau — a single-stage, implicit, order-2 update
+  (``beta=1.0``, ``gamma=1.0``, ``M=eye`` — ``ALGO_CONSTANTS``,
+  ``crank_nicolson.py:39-41``). Two implicit solves run per step (the
+  Crank–Nicolson update and a backward-Euler update); their difference
+  supplies the embedded error estimate, so the algorithm reports
+  ``is_adaptive == True`` (``crank_nicolson.py:356-360``).
+* Step controller: ``"pid"`` with ``kp=0.7``, ``ki=-0.4``,
+  ``deadband_min=1.0``, ``deadband_max=1.1``, ``min_gain=0.5``,
+  ``max_gain=2.0`` (``CN_DEFAULTS``, ``crank_nicolson.py:43-53``).
+* Nonlinear/linear solver defaults (Newton–Krylov,
+  ``ode_implicitstep.py:52-124``), shared by every implicit algorithm
+  except Rosenbrock-W:
+
+  .. list-table::
+     :header-rows: 1
+     :widths: 45 55
+
+     * - Parameter
+       - Default
+     * - ``newton_atol`` / ``newton_rtol``
+       - ``1e-6``
+     * - ``newton_max_iters``
+       - ``100``
+     * - ``newton_damping``
+       - ``0.5``
+     * - ``newton_max_backtracks``
+       - ``8``
+     * - ``krylov_atol`` / ``krylov_rtol``
+       - ``1e-6``
+     * - ``krylov_max_iters``
+       - ``100``
+     * - ``linear_correction_type``
+       - ``"minimal_residual"``
+     * - ``preconditioner_type``
+       - ``"neumann"``
+     * - ``preconditioner_order``
+       - ``2``
+
 .. autoclass:: CrankNicolsonStep
     :members:
     :show-inheritance:

--- a/docs/source/API_reference/integrators/algorithms/crank_nicolson_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/crank_nicolson_step.rst
@@ -6,43 +6,13 @@ CrankNicolsonStep
 Defaults
 --------
 
-* No Butcher tableau — a single-stage, implicit, order-2 update
-  (``beta=1.0``, ``gamma=1.0``, ``M=eye`` — ``ALGO_CONSTANTS``,
-  ``crank_nicolson.py:39-41``). Two implicit solves run per step (the
-  Crank–Nicolson update and a backward-Euler update); their difference
-  supplies the embedded error estimate, so the algorithm reports
-  ``is_adaptive == True`` (``crank_nicolson.py:356-360``).
-* Step controller: ``"pid"`` with ``kp=0.7``, ``ki=-0.4``,
-  ``deadband_min=1.0``, ``deadband_max=1.1``, ``min_gain=0.5``,
-  ``max_gain=2.0`` (``CN_DEFAULTS``, ``crank_nicolson.py:43-53``).
-* Nonlinear/linear solver defaults (Newton–Krylov,
-  ``ode_implicitstep.py:52-124``), shared by every implicit algorithm
-  except Rosenbrock-W:
-
-  .. list-table::
-     :header-rows: 1
-     :widths: 45 55
-
-     * - Parameter
-       - Default
-     * - ``newton_atol`` / ``newton_rtol``
-       - ``1e-6``
-     * - ``newton_max_iters``
-       - ``100``
-     * - ``newton_damping``
-       - ``0.5``
-     * - ``newton_max_backtracks``
-       - ``8``
-     * - ``krylov_atol`` / ``krylov_rtol``
-       - ``1e-6``
-     * - ``krylov_max_iters``
-       - ``100``
-     * - ``linear_correction_type``
-       - ``"minimal_residual"``
-     * - ``preconditioner_type``
-       - ``"neumann"``
-     * - ``preconditioner_order``
-       - ``2``
+``algorithm="crank_nicolson"`` performs a single-stage, order-2
+update and runs a backward-Euler companion solve each step; the
+difference between the two supplies an embedded error estimate, so
+the method defaults to adaptive PID control (``kp=0.7``,
+``ki=-0.4``, step-size growth clamped to 0.5–2.0×). Both implicit
+solves use the shared Newton–Krylov defaults listed in
+:ref:`algorithm-defaults`.
 
 .. autoclass:: CrankNicolsonStep
     :members:

--- a/docs/source/API_reference/integrators/algorithms/explicit_euler_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/explicit_euler_step.rst
@@ -6,17 +6,11 @@ ExplicitEulerStep
 Defaults
 --------
 
-* No Butcher tableau — a single-stage, explicit, order-1 forward-Euler
-  update (``explicit_euler.py``).
-* Step controller: ``"fixed"`` (``EE_DEFAULTS``,
-  ``explicit_euler.py:41-45``). Forward Euler has no embedded error
-  estimate, so an adaptive controller can never be selected: an
-  algorithm with ``is_adaptive == False`` paired with an adaptive
-  controller is silently replaced with ``FixedStepController`` and a
-  ``UserWarning`` is raised by ``check_compatibility``
-  (``SingleIntegratorRunCore.py:394-457``).
-* No nonlinear or linear solver — explicit methods evaluate the RHS
-  directly.
+``algorithm="euler"`` performs a single-stage, order-1 forward-Euler
+update under fixed-step control. Forward Euler carries no embedded
+error estimate, so adaptive control is unavailable, and as an
+explicit method it needs no nonlinear or linear solver. See
+:ref:`algorithm-defaults` for the defaults shared across algorithms.
 
 .. autoclass:: ExplicitEulerStep
     :members:

--- a/docs/source/API_reference/integrators/algorithms/explicit_euler_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/explicit_euler_step.rst
@@ -3,6 +3,21 @@ ExplicitEulerStep
 
 .. currentmodule:: cubie.integrators
 
+Defaults
+--------
+
+* No Butcher tableau — a single-stage, explicit, order-1 forward-Euler
+  update (``explicit_euler.py``).
+* Step controller: ``"fixed"`` (``EE_DEFAULTS``,
+  ``explicit_euler.py:41-45``). Forward Euler has no embedded error
+  estimate, so an adaptive controller can never be selected: an
+  algorithm with ``is_adaptive == False`` paired with an adaptive
+  controller is silently replaced with ``FixedStepController`` and a
+  ``UserWarning`` is raised by ``check_compatibility``
+  (``SingleIntegratorRunCore.py:394-457``).
+* No nonlinear or linear solver — explicit methods evaluate the RHS
+  directly.
+
 .. autoclass:: ExplicitEulerStep
     :members:
     :show-inheritance:

--- a/docs/source/API_reference/integrators/algorithms/generic_dirk_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_dirk_step.rst
@@ -10,6 +10,60 @@ solves stage systems with the cached Newton--Krylov helpers supplied by
 exposing L-stable SDIRK and ESDIRK schemes for stiff problems while preserving
 adaptive error control through embedded weights.
 
+Defaults
+--------
+
+* Default tableau: ``lobatto_iiic_3`` (three-stage Lobatto IIIC,
+  order 4; ``DEFAULT_DIRK_TABLEAU``,
+  ``generic_dirk_tableaus.py:127-136,290-291``). Implicit — each
+  stage runs one Newton–Krylov solve.
+* Selection rule: when the resolved tableau carries an embedded error
+  estimate the step controller defaults to ``DIRK_ADAPTIVE_DEFAULTS``;
+  errorless tableaus default to ``DIRK_FIXED_DEFAULTS``
+  (``generic_dirk.py:210-212``). ``check_compatibility``
+  (``SingleIntegratorRunCore.py:394-457``) additionally forces
+  ``FixedStepController`` (with a ``UserWarning``) whenever an
+  adaptive controller is paired with an errorless tableau.
+* ``DIRK_ADAPTIVE_DEFAULTS`` (``generic_dirk.py:64-74``): ``"pid"``
+  controller, ``kp=0.7``, ``ki=-0.4``, ``deadband_min=1.0``,
+  ``deadband_max=1.1``, ``min_gain=0.1``, ``max_gain=5.0``.
+* ``DIRK_FIXED_DEFAULTS`` (``generic_dirk.py:91-95``): ``"fixed"``
+  controller.
+* Nonlinear/linear solver defaults (Newton–Krylov,
+  ``ode_implicitstep.py:52-124``), shared by every implicit algorithm
+  except Rosenbrock-W:
+
+  .. list-table::
+     :header-rows: 1
+     :widths: 45 55
+
+     * - Parameter
+       - Default
+     * - ``newton_atol`` / ``newton_rtol``
+       - ``1e-6``
+     * - ``newton_max_iters``
+       - ``100``
+     * - ``newton_damping``
+       - ``0.5``
+     * - ``newton_max_backtracks``
+       - ``8``
+     * - ``krylov_atol`` / ``krylov_rtol``
+       - ``1e-6``
+     * - ``krylov_max_iters``
+       - ``100``
+     * - ``linear_correction_type``
+       - ``"minimal_residual"``
+     * - ``preconditioner_type``
+       - ``"neumann"``
+     * - ``preconditioner_order``
+       - ``2``
+
+* Tableau aliases resolving to :class:`DIRKStep`: every entry in
+  ``DIRK_TABLEAU_REGISTRY`` (``algorithms/__init__.py:73-74``),
+  including the implicit-midpoint, SDIRK, and Hairer–Wanner L-stable
+  schemes documented on the
+  :doc:`DIRK tableau registry <generic_dirk_tableaus>` page.
+
 .. autoclass:: DIRKStep
     :members:
     :show-inheritance:

--- a/docs/source/API_reference/integrators/algorithms/generic_dirk_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_dirk_step.rst
@@ -13,56 +13,17 @@ adaptive error control through embedded weights.
 Defaults
 --------
 
-* Default tableau: ``lobatto_iiic_3`` (three-stage Lobatto IIIC,
-  order 4; ``DEFAULT_DIRK_TABLEAU``,
-  ``generic_dirk_tableaus.py:127-136,290-291``). Implicit — each
-  stage runs one Newton–Krylov solve.
-* Selection rule: when the resolved tableau carries an embedded error
-  estimate the step controller defaults to ``DIRK_ADAPTIVE_DEFAULTS``;
-  errorless tableaus default to ``DIRK_FIXED_DEFAULTS``
-  (``generic_dirk.py:210-212``). ``check_compatibility``
-  (``SingleIntegratorRunCore.py:394-457``) additionally forces
-  ``FixedStepController`` (with a ``UserWarning``) whenever an
-  adaptive controller is paired with an errorless tableau.
-* ``DIRK_ADAPTIVE_DEFAULTS`` (``generic_dirk.py:64-74``): ``"pid"``
-  controller, ``kp=0.7``, ``ki=-0.4``, ``deadband_min=1.0``,
-  ``deadband_max=1.1``, ``min_gain=0.1``, ``max_gain=5.0``.
-* ``DIRK_FIXED_DEFAULTS`` (``generic_dirk.py:91-95``): ``"fixed"``
-  controller.
-* Nonlinear/linear solver defaults (Newton–Krylov,
-  ``ode_implicitstep.py:52-124``), shared by every implicit algorithm
-  except Rosenbrock-W:
-
-  .. list-table::
-     :header-rows: 1
-     :widths: 45 55
-
-     * - Parameter
-       - Default
-     * - ``newton_atol`` / ``newton_rtol``
-       - ``1e-6``
-     * - ``newton_max_iters``
-       - ``100``
-     * - ``newton_damping``
-       - ``0.5``
-     * - ``newton_max_backtracks``
-       - ``8``
-     * - ``krylov_atol`` / ``krylov_rtol``
-       - ``1e-6``
-     * - ``krylov_max_iters``
-       - ``100``
-     * - ``linear_correction_type``
-       - ``"minimal_residual"``
-     * - ``preconditioner_type``
-       - ``"neumann"``
-     * - ``preconditioner_order``
-       - ``2``
-
-* Tableau aliases resolving to :class:`DIRKStep`: every entry in
-  ``DIRK_TABLEAU_REGISTRY`` (``algorithms/__init__.py:73-74``),
-  including the implicit-midpoint, SDIRK, and Hairer–Wanner L-stable
-  schemes documented on the
-  :doc:`DIRK tableau registry <generic_dirk_tableaus>` page.
+``algorithm="dirk"`` integrates with the ``lobatto_iiic_3`` tableau
+(L-stable Lobatto IIIC, three stages, order 4). That tableau has no
+embedded error estimate, so the default is fixed-step control;
+choosing a DIRK tableau that provides an estimate enables the
+family's adaptive PID defaults (``kp=0.7``, ``ki=-0.4``, step-size
+growth clamped to 0.1–5.0×). Each stage runs one Newton–Krylov
+solve with the shared defaults listed in
+:ref:`algorithm-defaults`. The implicit-midpoint, SDIRK, and
+Hairer–Wanner L-stable schemes on the
+:doc:`DIRK tableau registry <generic_dirk_tableaus>` page resolve
+to this class.
 
 .. autoclass:: DIRKStep
     :members:

--- a/docs/source/API_reference/integrators/algorithms/generic_erk_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_erk_step.rst
@@ -9,6 +9,32 @@ and ships with PI step-control defaults tuned for the embedded Dormand--Prince
 pair. The factory performs staged right-hand-side evaluations on the GPU and
 supports optional driver and observable callbacks.
 
+Defaults
+--------
+
+* Default tableau: ``dormand-prince-54`` (Dormand–Prince 5(4), 7-stage,
+  order 5 with an order-4 embedded estimate;
+  ``DEFAULT_ERK_TABLEAU``, ``generic_erk_tableaus.py:99-169,748``).
+  Explicit, so it needs no nonlinear or linear solver.
+* Selection rule: when the resolved tableau carries an embedded error
+  estimate (``tableau.has_error_estimate``, true for
+  Dormand–Prince 5(4)) the step controller defaults to
+  ``ERK_ADAPTIVE_DEFAULTS``; tableaus without one default to
+  ``ERK_FIXED_DEFAULTS`` (``generic_erk.py:240-243``).
+  ``check_compatibility`` (``SingleIntegratorRunCore.py:394-457``)
+  additionally forces ``FixedStepController`` (with a ``UserWarning``)
+  whenever an adaptive controller is paired with an errorless tableau.
+* ``ERK_ADAPTIVE_DEFAULTS`` (``generic_erk.py:77-88``): ``"pid"``
+  controller, ``kp=0.7``, ``ki=-0.4``, ``deadband_min=1.0``,
+  ``deadband_max=1.1``, ``min_gain=0.1``, ``max_gain=5.0``,
+  ``safety=0.9``.
+* ``ERK_FIXED_DEFAULTS`` (``generic_erk.py:96-100``): ``"fixed"``
+  controller.
+* Tableau aliases resolving to :class:`ERKStep`: every entry in
+  ``ERK_TABLEAU_REGISTRY`` (``algorithms/__init__.py:70-71``) — e.g.
+  ``"dopri54"``, ``"rk45"``, ``"ode45"`` are aliases for
+  ``dormand-prince-54``.
+
 .. autoclass:: ERKStep
     :members:
     :show-inheritance:

--- a/docs/source/API_reference/integrators/algorithms/generic_erk_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_erk_step.rst
@@ -12,28 +12,16 @@ supports optional driver and observable callbacks.
 Defaults
 --------
 
-* Default tableau: ``dormand-prince-54`` (Dormand–Prince 5(4), 7-stage,
-  order 5 with an order-4 embedded estimate;
-  ``DEFAULT_ERK_TABLEAU``, ``generic_erk_tableaus.py:99-169,748``).
-  Explicit, so it needs no nonlinear or linear solver.
-* Selection rule: when the resolved tableau carries an embedded error
-  estimate (``tableau.has_error_estimate``, true for
-  Dormand–Prince 5(4)) the step controller defaults to
-  ``ERK_ADAPTIVE_DEFAULTS``; tableaus without one default to
-  ``ERK_FIXED_DEFAULTS`` (``generic_erk.py:240-243``).
-  ``check_compatibility`` (``SingleIntegratorRunCore.py:394-457``)
-  additionally forces ``FixedStepController`` (with a ``UserWarning``)
-  whenever an adaptive controller is paired with an errorless tableau.
-* ``ERK_ADAPTIVE_DEFAULTS`` (``generic_erk.py:77-88``): ``"pid"``
-  controller, ``kp=0.7``, ``ki=-0.4``, ``deadband_min=1.0``,
-  ``deadband_max=1.1``, ``min_gain=0.1``, ``max_gain=5.0``,
-  ``safety=0.9``.
-* ``ERK_FIXED_DEFAULTS`` (``generic_erk.py:96-100``): ``"fixed"``
-  controller.
-* Tableau aliases resolving to :class:`ERKStep`: every entry in
-  ``ERK_TABLEAU_REGISTRY`` (``algorithms/__init__.py:70-71``) — e.g.
-  ``"dopri54"``, ``"rk45"``, ``"ode45"`` are aliases for
-  ``dormand-prince-54``.
+``algorithm="erk"`` integrates with the ``dormand-prince-54``
+tableau — explicit Dormand–Prince 5(4), seven stages, with an
+embedded fourth-order error estimate — under adaptive PID control
+(``kp=0.7``, ``ki=-0.4``, ``safety=0.9``, step-size growth clamped
+to 0.1–5.0×). ``dopri54``, ``rk45``, and ``ode45`` are aliases for
+the same scheme; the other named schemes in the
+:doc:`ERK tableau registry <generic_erk_tableaus>` resolve to this
+class too, falling back to fixed-step control when a tableau has no
+error estimate (:ref:`algorithm-defaults`). Explicit methods need no
+nonlinear or linear solver.
 
 .. autoclass:: ERKStep
     :members:

--- a/docs/source/API_reference/integrators/algorithms/generic_firk_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_firk_step.rst
@@ -10,6 +10,59 @@ coupled stage systems with the cached Newton--Krylov helpers supplied by
 instances, exposing high-order Gauss--Legendre and Radau IIA schemes for stiff
 problems while preserving adaptive error control through embedded weights.
 
+Defaults
+--------
+
+* Default tableau: ``firk_gauss_legendre_2`` (two-stage
+  Gauss–Legendre, order 4; ``DEFAULT_FIRK_TABLEAU``,
+  ``generic_firk_tableaus.py:64-72,149``). Implicit — all stages are
+  solved together as one coupled ``n * stages`` Newton–Krylov system.
+* Selection rule: when the resolved tableau carries an embedded error
+  estimate the step controller defaults to ``FIRK_ADAPTIVE_DEFAULTS``;
+  errorless tableaus default to ``FIRK_FIXED_DEFAULTS``
+  (``generic_firk.py:220-222``). ``check_compatibility``
+  (``SingleIntegratorRunCore.py:394-457``) additionally forces
+  ``FixedStepController`` (with a ``UserWarning``) whenever an
+  adaptive controller is paired with an errorless tableau.
+* ``FIRK_ADAPTIVE_DEFAULTS`` (``generic_firk.py:62-72``): ``"pid"``
+  controller, ``kp=0.6``, ``ki=-0.4``, ``deadband_min=1.0``,
+  ``deadband_max=1.1``, ``min_gain=0.5``, ``max_gain=2.0``.
+* ``FIRK_FIXED_DEFAULTS`` (``generic_firk.py:89-93``): ``"fixed"``
+  controller.
+* Nonlinear/linear solver defaults (Newton–Krylov,
+  ``ode_implicitstep.py:52-124``), shared by every implicit algorithm
+  except Rosenbrock-W:
+
+  .. list-table::
+     :header-rows: 1
+     :widths: 45 55
+
+     * - Parameter
+       - Default
+     * - ``newton_atol`` / ``newton_rtol``
+       - ``1e-6``
+     * - ``newton_max_iters``
+       - ``100``
+     * - ``newton_damping``
+       - ``0.5``
+     * - ``newton_max_backtracks``
+       - ``8``
+     * - ``krylov_atol`` / ``krylov_rtol``
+       - ``1e-6``
+     * - ``krylov_max_iters``
+       - ``100``
+     * - ``linear_correction_type``
+       - ``"minimal_residual"``
+     * - ``preconditioner_type``
+       - ``"neumann"``
+     * - ``preconditioner_order``
+       - ``2``
+
+* Tableau aliases resolving to :class:`FIRKStep`: every entry in
+  ``FIRK_TABLEAU_REGISTRY`` (``algorithms/__init__.py:76-77``),
+  including the Radau IIA-5 scheme documented on the
+  :doc:`FIRK tableau registry <generic_firk_tableaus>` page.
+
 .. autoclass:: FIRKStep
     :members:
     :show-inheritance:

--- a/docs/source/API_reference/integrators/algorithms/generic_firk_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_firk_step.rst
@@ -13,55 +13,16 @@ problems while preserving adaptive error control through embedded weights.
 Defaults
 --------
 
-* Default tableau: ``firk_gauss_legendre_2`` (two-stage
-  Gauss–Legendre, order 4; ``DEFAULT_FIRK_TABLEAU``,
-  ``generic_firk_tableaus.py:64-72,149``). Implicit — all stages are
-  solved together as one coupled ``n * stages`` Newton–Krylov system.
-* Selection rule: when the resolved tableau carries an embedded error
-  estimate the step controller defaults to ``FIRK_ADAPTIVE_DEFAULTS``;
-  errorless tableaus default to ``FIRK_FIXED_DEFAULTS``
-  (``generic_firk.py:220-222``). ``check_compatibility``
-  (``SingleIntegratorRunCore.py:394-457``) additionally forces
-  ``FixedStepController`` (with a ``UserWarning``) whenever an
-  adaptive controller is paired with an errorless tableau.
-* ``FIRK_ADAPTIVE_DEFAULTS`` (``generic_firk.py:62-72``): ``"pid"``
-  controller, ``kp=0.6``, ``ki=-0.4``, ``deadband_min=1.0``,
-  ``deadband_max=1.1``, ``min_gain=0.5``, ``max_gain=2.0``.
-* ``FIRK_FIXED_DEFAULTS`` (``generic_firk.py:89-93``): ``"fixed"``
-  controller.
-* Nonlinear/linear solver defaults (Newton–Krylov,
-  ``ode_implicitstep.py:52-124``), shared by every implicit algorithm
-  except Rosenbrock-W:
-
-  .. list-table::
-     :header-rows: 1
-     :widths: 45 55
-
-     * - Parameter
-       - Default
-     * - ``newton_atol`` / ``newton_rtol``
-       - ``1e-6``
-     * - ``newton_max_iters``
-       - ``100``
-     * - ``newton_damping``
-       - ``0.5``
-     * - ``newton_max_backtracks``
-       - ``8``
-     * - ``krylov_atol`` / ``krylov_rtol``
-       - ``1e-6``
-     * - ``krylov_max_iters``
-       - ``100``
-     * - ``linear_correction_type``
-       - ``"minimal_residual"``
-     * - ``preconditioner_type``
-       - ``"neumann"``
-     * - ``preconditioner_order``
-       - ``2``
-
-* Tableau aliases resolving to :class:`FIRKStep`: every entry in
-  ``FIRK_TABLEAU_REGISTRY`` (``algorithms/__init__.py:76-77``),
-  including the Radau IIA-5 scheme documented on the
-  :doc:`FIRK tableau registry <generic_firk_tableaus>` page.
+``algorithm="firk"`` integrates with the ``firk_gauss_legendre_2``
+tableau (two-stage Gauss–Legendre, order 4), solving all stages
+together as one coupled Newton–Krylov system with the shared
+defaults listed in :ref:`algorithm-defaults`. The default tableau
+has no embedded error estimate, so it runs under fixed-step
+control; tableaus that provide one — ``radau`` (Radau IIA-5), for
+example — enable the family's adaptive PID defaults (``kp=0.6``,
+``ki=-0.4``, step-size growth clamped to 0.5–2.0×). Named schemes
+are listed on the
+:doc:`FIRK tableau registry <generic_firk_tableaus>` page.
 
 .. autoclass:: FIRKStep
     :members:

--- a/docs/source/API_reference/integrators/algorithms/generic_rosenbrock_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_rosenbrock_step.rst
@@ -13,33 +13,17 @@ solves from :mod:`cubie.integrators.matrix_free_solvers`.
 Defaults
 --------
 
-* Default tableau: ``ros3p`` (three-stage ROS3P, order 3;
-  ``DEFAULT_ROSENBROCK_TABLEAU``,
-  ``generic_rosenbrockw_tableaus.py:87-132,426-428``). Rosenbrock-W is
-  **linearly implicit**: each stage solves one linear system with a
-  cached Jacobian factorisation, never a Newton iteration.
-* Selection rule: when the resolved tableau carries an embedded error
-  estimate the step controller defaults to
-  ``ROSENBROCK_ADAPTIVE_DEFAULTS``; errorless tableaus default to
-  ``ROSENBROCK_FIXED_DEFAULTS`` (``generic_rosenbrock_w.py:235-238``).
-  ``check_compatibility`` (``SingleIntegratorRunCore.py:394-457``)
-  additionally forces ``FixedStepController`` (with a
-  ``UserWarning``) whenever an adaptive controller is paired with an
-  errorless tableau.
-* ``ROSENBROCK_ADAPTIVE_DEFAULTS`` (``generic_rosenbrock_w.py:67-77``):
-  ``"pid"`` controller, ``kp=0.6``, ``ki=-0.4``, ``deadband_min=1.0``,
-  ``deadband_max=1.1``, ``min_gain=0.5``, ``max_gain=2.0``.
-* Because Rosenbrock-W is linearly implicit, only the **linear**
-  solver defaults apply (no ``newton_*`` parameters):
-  ``krylov_atol``/``krylov_rtol=1e-6``, ``krylov_max_iters=100``,
-  ``linear_correction_type="minimal_residual"``,
-  ``preconditioner_type="neumann"``, ``preconditioner_order=2``
-  (``ode_implicitstep.py:52-124``).
-* Tableau aliases resolving to :class:`GenericRosenbrockWStep`: every
-  entry in ``ROSENBROCK_TABLEAUS``
-  (``algorithms/__init__.py:79-83``), documented on the
-  :doc:`Rosenbrock tableau registry <generic_rosenbrock_tableaus>`
-  page.
+``algorithm="rosenbrock"`` integrates with the ``ros3p`` tableau
+(three stages, order 3, with an embedded error estimate) under
+adaptive PID control (``kp=0.6``, ``ki=-0.4``, step-size growth
+clamped to 0.5–2.0×). Rosenbrock-W methods are linearly implicit —
+each stage performs one linear solve rather than a Newton
+iteration — so of the solver settings in
+:ref:`algorithm-defaults` only the Krylov and preconditioner
+defaults apply; the ``newton_*`` parameters do not. Named schemes
+are listed on the
+:doc:`Rosenbrock tableau registry <generic_rosenbrock_tableaus>`
+page.
 
 .. autoclass:: GenericRosenbrockWStep
     :members:

--- a/docs/source/API_reference/integrators/algorithms/generic_rosenbrock_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_rosenbrock_step.rst
@@ -10,6 +10,37 @@ consumes
 instances and couples user-supplied device callbacks with matrix-free linear
 solves from :mod:`cubie.integrators.matrix_free_solvers`.
 
+Defaults
+--------
+
+* Default tableau: ``ros3p`` (three-stage ROS3P, order 3;
+  ``DEFAULT_ROSENBROCK_TABLEAU``,
+  ``generic_rosenbrockw_tableaus.py:87-132,426-428``). Rosenbrock-W is
+  **linearly implicit**: each stage solves one linear system with a
+  cached Jacobian factorisation, never a Newton iteration.
+* Selection rule: when the resolved tableau carries an embedded error
+  estimate the step controller defaults to
+  ``ROSENBROCK_ADAPTIVE_DEFAULTS``; errorless tableaus default to
+  ``ROSENBROCK_FIXED_DEFAULTS`` (``generic_rosenbrock_w.py:235-238``).
+  ``check_compatibility`` (``SingleIntegratorRunCore.py:394-457``)
+  additionally forces ``FixedStepController`` (with a
+  ``UserWarning``) whenever an adaptive controller is paired with an
+  errorless tableau.
+* ``ROSENBROCK_ADAPTIVE_DEFAULTS`` (``generic_rosenbrock_w.py:67-77``):
+  ``"pid"`` controller, ``kp=0.6``, ``ki=-0.4``, ``deadband_min=1.0``,
+  ``deadband_max=1.1``, ``min_gain=0.5``, ``max_gain=2.0``.
+* Because Rosenbrock-W is linearly implicit, only the **linear**
+  solver defaults apply (no ``newton_*`` parameters):
+  ``krylov_atol``/``krylov_rtol=1e-6``, ``krylov_max_iters=100``,
+  ``linear_correction_type="minimal_residual"``,
+  ``preconditioner_type="neumann"``, ``preconditioner_order=2``
+  (``ode_implicitstep.py:52-124``).
+* Tableau aliases resolving to :class:`GenericRosenbrockWStep`: every
+  entry in ``ROSENBROCK_TABLEAUS``
+  (``algorithms/__init__.py:79-83``), documented on the
+  :doc:`Rosenbrock tableau registry <generic_rosenbrock_tableaus>`
+  page.
+
 .. autoclass:: GenericRosenbrockWStep
     :members:
     :show-inheritance:

--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -1,0 +1,210 @@
+Configuration Reference
+========================
+
+This page is the single index of every entry-point keyword argument for a
+solve: the explicit parameters of :func:`~cubie.solve_ivp` and
+:class:`~cubie.Solver` (:meth:`~cubie.Solver.__init__` and
+:meth:`~cubie.Solver.solve`), plus how the remaining loose keyword arguments
+are routed to the six underlying settings groups. Deep-dive pages for each
+group are linked at the end of each section.
+
+Entry-point signatures
+-----------------------
+
+``solve_ivp()``
+~~~~~~~~~~~~~~~
+
+:func:`~cubie.solve_ivp` (``src/cubie/batchsolving/solver.py:116-131``)
+builds a :class:`~cubie.Solver` and runs a single batch solve.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Argument
+     - Default
+     - Effect
+   * - ``method``
+     - ``"euler"``
+     - Integration algorithm name (see :doc:`choosing_algorithms`).
+   * - ``duration``
+     - ``1.0``
+     - Total integration time.
+   * - ``settling_time``
+     - ``0.0``
+     - Warm-up period before outputs are recorded.
+   * - ``t0``
+     - ``0.0``
+     - Initial integration time.
+   * - ``save_variables``
+     - ``None``
+     - State/observable names to save; ``None`` saves all, ``[]`` saves
+       none.
+   * - ``summarise_variables``
+     - ``None``
+     - State/observable names to summarise; ``None`` mirrors
+       ``save_variables``.
+   * - ``grid_type``
+     - ``"combinatorial"``
+     - ``"combinatorial"`` takes every combination of the supplied
+       inputs; ``"verbatim"`` pairs them run-for-run. **This default
+       differs from** ``Solver.solve`` **below.**
+   * - ``time_logging_level``
+     - ``None``
+     - Timing verbosity: ``'default'``, ``'verbose'``, ``'debug'``, or
+       ``None``/``'None'`` to disable.
+   * - ``nan_error_trajectories``
+     - ``True``
+     - Trajectories with a nonzero status code are NaN-masked in the
+       output.
+
+Any other keyword argument is forwarded to :class:`~cubie.Solver`.
+
+``Solver.__init__()``
+~~~~~~~~~~~~~~~~~~~~~
+
+(``src/cubie/batchsolving/solver.py:278-291``)
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Argument
+     - Default
+     - Effect
+   * - ``algorithm``
+     - ``"euler"``
+     - Integration algorithm name or a supplied
+       :class:`~cubie.integrators.algorithms.ButcherTableau`.
+   * - ``profileCUDA``
+     - ``False``
+     - Enables CUDA profiling of the compiled kernel.
+   * - ``cache``
+     - ``True``
+     - Compiled-kernel disk caching; accepts ``bool``, a cache-mode
+       string, or a ``Path``. See :doc:`caching`.
+   * - ``time_logging_level``
+     - ``None``
+     - Same options as above.
+
+``step_control_settings``, ``algorithm_settings``, ``output_settings``,
+``memory_settings``, and ``loop_settings`` are explicit dictionaries that
+override the per-group defaults; any of their keys may also be supplied as
+loose keyword arguments (see "Kwarg routing" below).
+
+``Solver.solve()``
+~~~~~~~~~~~~~~~~~~
+
+(``src/cubie/batchsolving/solver.py:422-436``)
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Argument
+     - Default
+     - Effect
+   * - ``duration``
+     - ``1.0``
+     - Total integration time.
+   * - ``settling_time``
+     - ``0.0``
+     - Warm-up period before outputs are recorded.
+   * - ``t0``
+     - ``0.0``
+     - Initial integration time.
+   * - ``blocksize``
+     - ``256``
+     - CUDA threads per block for the kernel launch.
+   * - ``stream``
+     - ``None``
+     - CUDA stream to launch on; ``None`` uses the solver's default
+       stream.
+   * - ``grid_type``
+     - ``"verbatim"``
+     - **Differs from** ``solve_ivp``'s default of
+       ``"combinatorial"`` above — only relevant when dict inputs
+       trigger grid construction.
+   * - ``results_type``
+     - ``"full"``
+     - Shape of the returned result (e.g. ``"full"`` for a
+       :class:`~cubie.batchsolving.solveresult.SolveResult`, ``"raw"``
+       for a plain dict). See :doc:`results`.
+   * - ``nan_error_trajectories``
+     - ``True``
+     - Same behaviour as above; ignored when ``results_type="raw"``.
+
+Any other keyword argument is forwarded to :meth:`~cubie.Solver.update`,
+routing through the same six settings groups described next.
+
+Kwarg routing
+-------------
+
+Beyond the explicit parameters above, ``Solver`` accepts loose keyword
+arguments that are merged into six settings groups by
+``merge_kwargs_into_settings`` (``src/cubie/batchsolving/solver.py:325-399``):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 55
+
+   * - Group
+     - Recognised-key set
+     - Deep-dive page
+   * - Step control
+     - ``ALL_STEP_CONTROLLER_PARAMETERS``
+     - :doc:`optional_arguments`
+   * - Algorithm
+     - ``ALL_ALGORITHM_STEP_PARAMETERS``
+     - :doc:`optional_arguments`, :doc:`choosing_algorithms`
+   * - Output
+     - ``ALL_OUTPUT_FUNCTION_PARAMETERS``
+     - :doc:`results`
+   * - Memory
+     - ``ALL_MEMORY_MANAGER_PARAMETERS``
+     - :doc:`memory`
+   * - Loop
+     - ``ALL_LOOP_SETTINGS``
+     - :doc:`timing`
+   * - Cache
+     - ``ALL_CACHE_PARAMETERS``
+     - :doc:`caching`
+   * - Kernel
+     - ``ALL_KERNEL_PARAMETERS``
+     - :doc:`speed`
+
+A kwarg matching none of the six sets raises ``KeyError`` at
+``Solver.__init__`` (``solver.py:395-399``). Legacy timing spellings
+(``dt_save``, ``dt_summarise``, ``dt_update_summaries``) also raise
+``KeyError`` with a rename hint rather than being silently accepted.
+
+Previously undocumented kwargs
+-------------------------------
+
+**blocksize**
+    CUDA threads per block for the kernel launch, passed to
+    :meth:`Solver.solve`. Default ``256``.
+
+**max_registers**
+    Per-thread register cap forwarded to ``cuda.jit`` via
+    ``BatchSolverConfig`` (``src/cubie/batchsolving/BatchSolverConfig.py``,
+    part of ``ALL_KERNEL_PARAMETERS``). Default ``None``, which leaves
+    register allocation to ``ptxas``; capping trades spill traffic for
+    more resident warps. See :doc:`speed`.
+
+**step_controller**
+    Selects the step-size controller by name: ``"fixed"``, ``"i"``,
+    ``"pi"``, ``"pid"``, or ``"gustafsson"``
+    (``src/cubie/integrators/step_control/base_step_controller.py:94-97``).
+    When omitted, the chosen algorithm's own default controller is used
+    (fixed for errorless tableaus, otherwise an algorithm-tuned PID — see
+    :doc:`choosing_algorithms` and the per-algorithm "Defaults" sections
+    in the API reference).
+
+**mem_proportion**
+    Proportion of VRAM (0.0-1.0) reserved for this solver's allocations
+    (``src/cubie/memory/mem_manager.py:383,395-397``, part of
+    ``ALL_MEMORY_MANAGER_PARAMETERS``). Default ``None``, which places
+    the solver in the automatic pool and sizes its allocation from an
+    equal share of the VRAM remaining after manually-proportioned
+    instances are accounted for. See :doc:`memory`.

--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -14,8 +14,8 @@ Entry-point signatures
 ``solve_ivp()``
 ~~~~~~~~~~~~~~~
 
-:func:`~cubie.solve_ivp` (``src/cubie/batchsolving/solver.py:116-131``)
-builds a :class:`~cubie.Solver` and runs a single batch solve.
+:func:`~cubie.solve_ivp` builds a :class:`~cubie.Solver` and runs a
+single batch solve.
 
 .. list-table::
    :header-rows: 1
@@ -63,8 +63,6 @@ Any other keyword argument is forwarded to :class:`~cubie.Solver`.
 ``Solver.__init__()``
 ~~~~~~~~~~~~~~~~~~~~~
 
-(``src/cubie/batchsolving/solver.py:278-291``)
-
 .. list-table::
    :header-rows: 1
    :widths: 20 15 65
@@ -94,8 +92,6 @@ loose keyword arguments (see "Kwarg routing" below).
 
 ``Solver.solve()``
 ~~~~~~~~~~~~~~~~~~
-
-(``src/cubie/batchsolving/solver.py:422-436``)
 
 .. list-table::
    :header-rows: 1
@@ -140,71 +136,76 @@ routing through the same six settings groups described next.
 Kwarg routing
 -------------
 
-Beyond the explicit parameters above, ``Solver`` accepts loose keyword
-arguments that are merged into six settings groups by
-``merge_kwargs_into_settings`` (``src/cubie/batchsolving/solver.py:325-399``):
+Beyond the explicit parameters above, ``Solver`` accepts loose
+keyword arguments and sorts them into settings groups. Any parameter
+below may be passed directly to :func:`~cubie.solve_ivp`,
+:class:`~cubie.Solver`, or :meth:`~cubie.Solver.update`:
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 20 55
+   :widths: 18 52 30
 
    * - Group
-     - Recognised-key set
+     - Parameters
      - Deep-dive page
    * - Step control
-     - ``ALL_STEP_CONTROLLER_PARAMETERS``
+     - ``step_controller``, ``dt``, ``dt_min``, ``dt_max``,
+       ``atol``, ``rtol``, ``safety``, ``min_gain``, ``max_gain``,
+       ``kp``, ``ki``, ``kd``, ``deadband_min``, ``deadband_max``,
+       ``gamma``
      - :doc:`optional_arguments`
    * - Algorithm
-     - ``ALL_ALGORITHM_STEP_PARAMETERS``
+     - ``newton_atol``, ``newton_rtol``, ``newton_max_iters``,
+       ``newton_damping``, ``newton_max_backtracks``,
+       ``krylov_atol``, ``krylov_rtol``, ``krylov_max_iters``,
+       ``linear_correction_type``, ``preconditioner_type``,
+       ``preconditioner_order``
      - :doc:`optional_arguments`, :doc:`choosing_algorithms`
    * - Output
-     - ``ALL_OUTPUT_FUNCTION_PARAMETERS``
+     - ``output_types``, ``saved_state_indices``,
+       ``saved_observable_indices``, ``summarised_state_indices``,
+       ``summarised_observable_indices``
      - :doc:`results`
+   * - Timing / loop
+     - ``save_every``, ``summarise_every``,
+       ``sample_summaries_every``, ``save_last``, plus the
+       per-buffer ``*_location`` placement overrides
+     - :doc:`timing`, :doc:`speed`
    * - Memory
-     - ``ALL_MEMORY_MANAGER_PARAMETERS``
+     - ``mem_proportion``, ``stream_group``
      - :doc:`memory`
-   * - Loop
-     - ``ALL_LOOP_SETTINGS``
-     - :doc:`timing`
    * - Cache
-     - ``ALL_CACHE_PARAMETERS``
+     - ``cache`` (``True``/``False``, a cache-mode string, or a
+       ``Path``)
      - :doc:`caching`
    * - Kernel
-     - ``ALL_KERNEL_PARAMETERS``
+     - ``max_registers``
      - :doc:`speed`
 
-A kwarg matching none of the six sets raises ``KeyError`` at
-``Solver.__init__`` (``solver.py:395-399``). Legacy timing spellings
-(``dt_save``, ``dt_summarise``, ``dt_update_summaries``) also raise
-``KeyError`` with a rename hint rather than being silently accepted.
+A keyword argument that matches no group raises ``KeyError`` at
+construction rather than being silently ignored, and the legacy
+timing spellings (``dt_save``, ``dt_summarise``,
+``dt_update_summaries``) raise ``KeyError`` with a rename hint.
 
-Previously undocumented kwargs
--------------------------------
-
-**blocksize**
-    CUDA threads per block for the kernel launch, passed to
-    :meth:`Solver.solve`. Default ``256``.
-
-**max_registers**
-    Per-thread register cap forwarded to ``cuda.jit`` via
-    ``BatchSolverConfig`` (``src/cubie/batchsolving/BatchSolverConfig.py``,
-    part of ``ALL_KERNEL_PARAMETERS``). Default ``None``, which leaves
-    register allocation to ``ptxas``; capping trades spill traffic for
-    more resident warps. See :doc:`speed`.
+Notes on selected parameters
+----------------------------
 
 **step_controller**
     Selects the step-size controller by name: ``"fixed"``, ``"i"``,
-    ``"pi"``, ``"pid"``, or ``"gustafsson"``
-    (``src/cubie/integrators/step_control/base_step_controller.py:94-97``).
-    When omitted, the chosen algorithm's own default controller is used
-    (fixed for errorless tableaus, otherwise an algorithm-tuned PID — see
-    :doc:`choosing_algorithms` and the per-algorithm "Defaults" sections
-    in the API reference).
+    ``"pi"``, ``"pid"``, or ``"gustafsson"``. When omitted, the
+    chosen algorithm's own default controller is used — fixed for
+    schemes without an embedded error estimate, otherwise an
+    algorithm-tuned PID. See :doc:`choosing_algorithms` and the
+    algorithm defaults table in the API reference.
+
+**max_registers**
+    Per-thread register cap forwarded to ``cuda.jit``. Default
+    ``None`` leaves register allocation to ``ptxas``; capping trades
+    spill traffic for more resident warps. See :doc:`speed`.
 
 **mem_proportion**
-    Proportion of VRAM (0.0-1.0) reserved for this solver's allocations
-    (``src/cubie/memory/mem_manager.py:383,395-397``, part of
-    ``ALL_MEMORY_MANAGER_PARAMETERS``). Default ``None``, which places
-    the solver in the automatic pool and sizes its allocation from an
-    equal share of the VRAM remaining after manually-proportioned
-    instances are accounted for. See :doc:`memory`.
+    Proportion of VRAM (0.0–1.0) reserved for this solver's
+    allocations. Default ``None`` places the solver in the automatic
+    pool, which shares the VRAM remaining after manually-proportioned
+    solvers are accounted for equally between its members. See
+    :doc:`memory`.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -11,6 +11,7 @@ value problems. The source code is available on `Github
 
    systems
    solving
+   configuration
    batching
    results
    drivers

--- a/docs/source/user_guide/optional_arguments.rst
+++ b/docs/source/user_guide/optional_arguments.rst
@@ -57,7 +57,7 @@ Newton step.
     - Default: ``1e-6``
     - Type: ``float`` or ``ndarray`` (must be positive)
 
-**max_newton_iters**
+**newton_max_iters**
     Maximum number of Newton iterations before the solver gives up. If the
     Newton loop hasn't converged after this many iterations, the step is
     marked as failed. Increase this if you have a very stiff system that
@@ -101,7 +101,7 @@ Newton step.
     - Default: ``1e-6``
     - Type: ``float`` or ``ndarray`` (must be positive)
 
-**max_linear_iters**
+**krylov_max_iters**
     Maximum number of linear solver iterations per Newton step. If the
     Krylov loop hasn't converged after this many iterations, it returns
     with its current best estimate. Increase for ill-conditioned systems.
@@ -153,7 +153,7 @@ Implicit Algorithm Applicability
      - ✓
      - ✓
      - ✗
-   * - max_newton_iters
+   * - newton_max_iters
      - ✓
      - ✓
      - ✓
@@ -183,7 +183,7 @@ Implicit Algorithm Applicability
      - ✓
      - ✓
      - ✓
-   * - max_linear_iters
+   * - krylov_max_iters
      - ✓
      - ✓
      - ✓
@@ -217,9 +217,9 @@ tableaus, and you can also define custom ones.
 
     - ERK defaults: ``dormand-prince-54`` (Dormand-Prince 5(4), adaptive)
     - DIRK defaults: ``lobatto_iiic_3`` (Lobatto IIIC, 3-stage, order 4,
-      adaptive)
+      fixed-step — no embedded error estimate)
     - FIRK defaults: ``firk_gauss_legendre_2`` (Gauss-Legendre, 2-stage,
-      order 4, adaptive)
+      order 4, fixed-step — no embedded error estimate)
     - Rosenbrock-W defaults: ``ros3p`` (ROS3P, 3-stage, order 3, stiff
       problems)
 
@@ -380,7 +380,7 @@ information about Newton iteration convergence.
     - Default: ``0.9``
     - Type: ``float`` (0 to 1)
 
-**max_newton_iters**
+**newton_max_iters**
     Expected maximum Newton iterations, used to scale the step size
     prediction. Should match or slightly exceed your actual Newton iteration
     limit.
@@ -491,7 +491,7 @@ Controller Applicability
      - ✗
      - ✗
      - ✓
-   * - max_newton_iters (ctrl)
+   * - newton_max_iters (ctrl)
      - ✗
      - ✗
      - ✗

--- a/docs/source/user_guide/optional_arguments.rst
+++ b/docs/source/user_guide/optional_arguments.rst
@@ -125,7 +125,7 @@ Newton step.
     better preconditioning (faster convergence) but cost more per iteration.
     For most problems, order 1-3 works well.
 
-    - Default: ``1``
+    - Default: ``2``
     - Type: ``int`` (1 to 32)
 
 Implicit Algorithm Applicability
@@ -215,10 +215,13 @@ tableaus, and you can also define custom ones.
     cost. Tableaus with embedded error estimates enable adaptive stepping;
     tableaus without them require fixed stepping.
 
-    - ERK defaults: ``DOPRI54`` (Dormand-Prince 5(4), adaptive)
-    - DIRK defaults: ``ESDIRK32`` (3rd order, adaptive)
-    - FIRK defaults: ``RadauIIA`` (5th order, stiff problems)
-    - Rosenbrock-W defaults: ``ROS34PW2`` (4th order, stiff problems)
+    - ERK defaults: ``dormand-prince-54`` (Dormand-Prince 5(4), adaptive)
+    - DIRK defaults: ``lobatto_iiic_3`` (Lobatto IIIC, 3-stage, order 4,
+      adaptive)
+    - FIRK defaults: ``firk_gauss_legendre_2`` (Gauss-Legendre, 2-stage,
+      order 4, adaptive)
+    - Rosenbrock-W defaults: ``ros3p`` (ROS3P, 3-stage, order 3, stiff
+      problems)
 
 Controller Options
 ------------------
@@ -319,7 +322,7 @@ error estimates to calculate step size adjustments.
     estimate affects the step size. Higher values react more aggressively to
     the current error.
 
-    - Default: ``1/18``
+    - Default: ``0.7``
     - Type: ``float``
 
 **ki**
@@ -327,8 +330,17 @@ error estimates to calculate step size adjustments.
     history affects the step size. Higher values provide more smoothing but
     slower response.
 
-    - Default: ``1/9``
+    - Default: ``-0.4``
     - Type: ``float``
+
+    Individual algorithms may pass their own tuned ``kp``/``ki`` as
+    controller defaults (e.g. Rosenbrock-W and FIRK default to
+    ``kp=0.6``); see the "Defaults" section of each algorithm's page in
+    the API reference. The 1/18, 1/9 pairing quoted in some external
+    references is a *recommended tuning* (the H312PID row in
+    :doc:`the step-control API page
+    </API_reference/integrators/step_control>`), not the library
+    default.
 
 PID Controller Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -339,13 +351,13 @@ response to rapidly changing errors.
 **kp**
     Proportional gain coefficient (same as PI controller).
 
-    - Default: ``1/18``
+    - Default: ``0.7``
     - Type: ``float``
 
 **ki**
     Integral gain coefficient (same as PI controller).
 
-    - Default: ``1/9``
+    - Default: ``-0.4``
     - Type: ``float``
 
 **kd**


### PR DESCRIPTION
Closes #146, closes #147.

## #146 — configuration reference

- New `docs/source/user_guide/configuration.rst`: tables of the `solve_ivp()`, `Solver()`, and `Solver.solve()` signature kwargs with defaults and effects (calling out that `grid_type` defaults to `"combinatorial"` in `solve_ivp` but `"verbatim"` in `Solver.solve`), the kwarg-routing rules (loose kwargs sort into settings groups; unknown kwargs raise `KeyError`; legacy timing spellings get a rename hint), and a per-group parameter index cross-linked to the existing deep-dive pages. Previously undocumented kwargs (`blocksize`, `max_registers`, `step_controller`, `mem_proportion`) are covered.
- Factual corrections in `optional_arguments.rst`: `kp`/`ki` config defaults are `0.7`/`-0.4` (the old `1/18`/`1/9` figures are the H312PID tuning recommendation, noted as such), `preconditioner_order` default is `2`, and the default tableau names are `dormand-prince-54`/`lobatto_iiic_3`/`firk_gauss_legendre_2`/`ros3p`.

## #147 — algorithm defaults

- The algorithms landing page gains a "Default settings" section stated once: a comparative table (algorithm → default scheme, order, default step control), the controller-selection rule (schemes without an embedded error estimate run fixed-step — including the default `dirk`/`firk` tableaus — with adaptive requests falling back to fixed with a `UserWarning`), and the shared Newton–Krylov defaults table.
- Each of the eight algorithm pages carries a short prose "Defaults" note covering only what is unique to it (e.g. Rosenbrock-W is linearly implicit, so only the Krylov settings apply), linking back to the shared section.

## Verification

- Every documented default was audited against source by an independent verifier (20+ spot checks, zero discrepancies).
- Sphinx HTML build succeeds with no warnings attributable to the new or edited pages (41 pre-existing warnings unchanged).

Note: the `allocator` kwarg is deliberately not documented — it is being removed by the in-flight #327 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)