### PR TITLE
fix: output-schedule stops anchor to the final scheduled event; host and device share the count arithmetic

### DIFF
--- a/src/cubie/batchsolving/BatchSolverKernel.py
+++ b/src/cubie/batchsolving/BatchSolverKernel.py
@@ -591,6 +591,16 @@ class BatchSolverKernel(CUDAFactory):
             duration = precision(chunk_run_params.duration)
             warmup = precision(chunk_run_params.warmup)
             t0 = precision(chunk_run_params.t0)
+            save_stop = precision(
+                self.single_integrator.save_stop_time(
+                    duration, warmup, t0
+                )
+            )
+            summary_stop = precision(
+                self.single_integrator.summary_stop_time(
+                    duration, warmup, t0
+                )
+            )
 
             # Use the chunk-local run count
             runs = chunk_run_params.runs
@@ -627,6 +637,8 @@ class BatchSolverKernel(CUDAFactory):
                 duration,
                 warmup,
                 t0,
+                save_stop,
+                summary_stop,
                 runs,
             )
             kernel_event.record_end(stream)
@@ -770,6 +782,8 @@ class BatchSolverKernel(CUDAFactory):
             duration,
             warmup,
             t0,
+            save_stop,
+            summary_stop,
             n_runs,
         ):
             """Execute the compiled single-run loop for each batch chunk.
@@ -800,6 +814,13 @@ class BatchSolverKernel(CUDAFactory):
                 Warmup duration applied before the chunk starts.
             t0
                 Start time of the chunk integration window.
+            save_stop
+                Completion time of the regular save schedule, half
+                an interval past its final scheduled event.
+            summary_stop
+                Completion time of the summary-update schedule,
+                half a sample interval past its final scheduled
+                event.
             n_runs
                 Number of runs scheduled for the kernel launch.
 
@@ -852,6 +873,8 @@ class BatchSolverKernel(CUDAFactory):
                 duration,
                 warmup,
                 t0,
+                save_stop,
+                summary_stop,
             )
             if tx == 0:
                 status_codes_output[run_index] = status

--- a/src/cubie/integrators/SingleIntegratorRun.py
+++ b/src/cubie/integrators/SingleIntegratorRun.py
@@ -18,7 +18,12 @@ See Also
 
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
-from numpy import dtype as np_dtype, floor as np_floor
+from numpy import (
+    dtype as np_dtype,
+    finfo as np_finfo,
+    float64 as np_float64,
+    floor as np_floor,
+)
 
 from cubie.integrators.SingleIntegratorRunCore import (
     SingleIntegratorRunCore,
@@ -156,6 +161,41 @@ class SingleIntegratorRun(SingleIntegratorRunCore):
         """Return True if end-of-run-only state saving is configured."""
         return self._loop.compile_settings.save_last
 
+    def _regular_event_count(self, duration: float, interval: float) -> int:
+        """Count the scheduled output events of one kind in a duration.
+
+        The float64 quotient of the precision-cast operands carries
+        the representation rounding of ``duration`` and
+        ``interval``, so a bare floor loses the end-time event
+        whenever an integer schedule rounds just below the integer.
+        A tolerance of a few working-precision ulps of the quotient
+        (capped below one half) restores those events without
+        admitting genuinely fractional schedules. The device stop
+        times are derived from this same count
+        (:meth:`save_stop_time` / :meth:`summary_stop_time`), so
+        device events and host rows agree by construction.
+
+        Parameters
+        ----------
+        duration
+            Integration duration in time units.
+        interval
+            Scheduling interval in time units.
+
+        Returns
+        -------
+        int
+            Number of scheduled events, excluding the initial sample.
+        """
+        precision = self.precision
+        quotient = np_float64(precision(duration)) / np_float64(
+            precision(interval)
+        )
+        tolerance = min(
+            4.0 * float(np_finfo(precision).eps) * quotient, 0.49
+        )
+        return int(np_floor(quotient + tolerance))
+
     def output_length(self, duration: float) -> int:
         """Calculate number of time-domain output samples for a duration.
 
@@ -170,18 +210,88 @@ class SingleIntegratorRun(SingleIntegratorRunCore):
             Number of output samples including initial and optionally final.
         """
         save_every = self.save_every
-        precision = self.precision
-        duration = precision(duration)
 
         regular_samples = 0
         final_samples = 1 if self.save_last else 0
         initial_sample = 1
         if save_every is not None:
-            regular_samples = int(np_floor(duration / save_every))
+            regular_samples = self._regular_event_count(
+                duration, save_every
+            )
         return regular_samples + initial_sample + final_samples
+
+    def save_stop_time(
+        self, duration: float, settling_time: float, t0: float
+    ) -> float:
+        """Return the completion time of the regular save schedule.
+
+        The stop sits half an interval past the final scheduled
+        save event, so accumulation drift in either direction can
+        neither strand the final host-allocated row nor admit an
+        event past the requested duration. Without a regular save
+        schedule the stop is the end time.
+
+        Parameters
+        ----------
+        duration
+            Integration duration in time units.
+        settling_time
+            Lead-in time before samples are collected.
+        t0
+            Initial integration time.
+
+        Returns
+        -------
+        float
+            Save-schedule stop time.
+        """
+        start = np_float64(settling_time) + np_float64(t0)
+        save_every = self.save_every
+        if save_every is None:
+            return float(start + np_float64(self.precision(duration)))
+        events = self._regular_event_count(duration, save_every)
+        return float(start + (events + 0.5) * np_float64(save_every))
+
+    def summary_stop_time(
+        self, duration: float, settling_time: float, t0: float
+    ) -> float:
+        """Return the completion time of the summary-update schedule.
+
+        The stop sits half a sample interval past the final
+        scheduled summary-update event. Without a summary schedule
+        the stop is the end time.
+
+        Parameters
+        ----------
+        duration
+            Integration duration in time units.
+        settling_time
+            Lead-in time before samples are collected.
+        t0
+            Initial integration time.
+
+        Returns
+        -------
+        float
+            Summary-schedule stop time.
+        """
+        start = np_float64(settling_time) + np_float64(t0)
+        sample_every = self.sample_summaries_every
+        if sample_every is None:
+            sample_every = self.summarise_every
+        if sample_every is None:
+            return float(start + np_float64(self.precision(duration)))
+        events = self._regular_event_count(duration, sample_every)
+        return float(start + (events + 0.5) * np_float64(sample_every))
 
     def summaries_length(self, duration: float) -> int:
         """Calculate number of summary output samples for a duration.
+
+        The device flushes one summary row per
+        ``samples_per_summary`` update events. Update events follow
+        the same representation-tolerant floor count as saves, and
+        the row count is the number of completed windows in that
+        update total.
 
         Parameters
         ----------
@@ -194,13 +304,22 @@ class SingleIntegratorRun(SingleIntegratorRunCore):
             Number of summary intervals.
         """
         summarise_every = self.summarise_every
+        sample_every = self.sample_summaries_every
         precision = self.precision
 
         regular_summaries = 0
         if summarise_every is not None:
-            regular_summaries = int(
-                precision(duration) / precision(summarise_every)
+            if sample_every is None:
+                sample_every = summarise_every
+            updates = self._regular_event_count(duration, sample_every)
+            samples_per_summary = int(
+                np_floor(
+                    np_float64(precision(summarise_every))
+                    / np_float64(precision(sample_every))
+                    + 0.5
+                )
             )
+            regular_summaries = updates // max(samples_per_summary, 1)
         return regular_summaries
 
     @property

--- a/src/cubie/integrators/loops/ode_loop.py
+++ b/src/cubie/integrators/loops/ode_loop.py
@@ -474,20 +474,6 @@ class IVPLoop(CUDAFactory):
         save_regularly = config.save_regularly
         summarise_regularly = config.summarise_regularly
 
-        # Half-interval margins for the schedule-completion tests.
-        # Repeated float addition of an inexact interval drifts the
-        # accumulated schedule by ulps per event; comparing against
-        # t_end plus half an interval keeps the final host-allocated
-        # slot reachable without altering the schedule itself.
-        if save_regularly:
-            half_save_every = precision(0.5 * save_every)
-        else:
-            half_save_every = precision(0.0)
-        if summarise_regularly:
-            half_sample_every = precision(0.5 * sample_summaries_every)
-        else:
-            half_sample_every = precision(0.0)
-
         # Loop sizes from config (sizes also used for iteration bounds)
         n_states = int32(config.n_states)
         n_parameters = int32(config.n_parameters)
@@ -517,12 +503,14 @@ class IVPLoop(CUDAFactory):
             duration,
             settling_time,
             t0,
+            save_stop,
+            summary_stop,
         ):  # pragma: no cover - CUDA fns not marked in coverage
             """Advance an integration using a compiled CUDA device loop.
 
-            The loop terminates when the time of the next saved sample
-            exceeds the end time (t0 + settling_time + duration), or when
-            the maximum number of iterations is reached.
+            The loop terminates when every output schedule passes its
+            stop time, or when the maximum number of iterations is
+            reached.
 
             Parameters
             ----------
@@ -552,6 +540,18 @@ class IVPLoop(CUDAFactory):
                 Lead-in time before samples are collected.
             t0
                 Initial integration time.
+            save_stop
+                Time half a save interval past the final scheduled
+                save event; the save schedule is complete once
+                ``next_save`` exceeds it. Computed host-side with
+                the same arithmetic as the output allocation
+                (:meth:`SingleIntegratorRun.save_stop_time`).
+            summary_stop
+                Time half a sample interval past the final
+                scheduled summary-update event; the summary
+                schedule is complete once ``next_update_summary``
+                exceeds it
+                (:meth:`SingleIntegratorRun.summary_stop_time`).
 
             Returns
             -------
@@ -561,8 +561,6 @@ class IVPLoop(CUDAFactory):
             t = float64(t0)
             t_prec = precision(t)
             t_end = precision(settling_time + t0 + duration)
-            save_stop = precision(t_end + half_save_every)
-            summary_stop = precision(t_end + half_sample_every)
 
             # Clear inherited arrays on entry
             persistent_local[:] = precision(0.0)
@@ -714,10 +712,11 @@ class IVPLoop(CUDAFactory):
                 end_of_step = t_prec + dt_raw
                 if save_regularly or summarise_regularly:
                     # Loop continues until all scheduled outputs are
-                    # complete. The half-interval margin on the stop
-                    # times tolerates upward accumulation drift, which
-                    # otherwise pushes the final scheduled event past
-                    # t_end and strands its host-allocated slot.
+                    # complete: each stop time sits half an interval
+                    # past that schedule's final event, so drift in
+                    # either direction can neither strand the final
+                    # host-allocated slot nor admit an event past
+                    # the requested duration.
                     finished = True
                     if save_regularly:
                         save_finished = bool_(next_save > save_stop)

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -877,6 +877,12 @@ def run_device_loop(
     persistent_required = max(1, singleintegratorrun.persistent_local_elements)
 
     numba_precision = from_dtype(precision)
+    save_stop = precision(
+        singleintegratorrun.save_stop_time(duration, warmup, t0)
+    )
+    summary_stop = precision(
+        singleintegratorrun.summary_stop_time(duration, warmup, t0)
+    )
 
     @cuda.jit(
         # (
@@ -924,6 +930,8 @@ def run_device_loop(
             duration,
             warmup,
             t0,
+            save_stop,
+            summary_stop,
         )
 
     kernel[1, 1, 0, shared_bytes](

--- a/tests/integrated_numerical_tests/test_dt_min_hang.py
+++ b/tests/integrated_numerical_tests/test_dt_min_hang.py
@@ -14,7 +14,11 @@ guard both historical failure modes of accumulation drift:
 - upward drift pushed the final scheduled save past ``t_end``,
   leaving the last host-allocated slot unwritten so the run
   returned uninitialized memory as its final sample with a success
-  status (issue #554).
+  status (issue #554);
+- a truncating precision-width quotient in the host allocation
+  counted one sample fewer than the device schedule fires, so the
+  final save wrote one row past the allocated output array
+  (issue #554).
 """
 
 import numpy as np
@@ -140,4 +144,48 @@ def test_final_save_slot_written_on_inexact_grid(oscillator_system):
         f"saved times are not strictly increasing: {times}"
     )
     assert times[-1] == pytest.approx(1.0, abs=1e-6)
+    assert np.isfinite(result.time_domain_array).all()
+
+
+def test_truncated_quotient_allocates_endpoint_slot(oscillator_system):
+    """The end-time sample lost by a truncating quotient is allocated.
+
+    With duration=0.01 and save_every=0.001 in float32 the quotient
+    is 9.9999993: a precision-width truncating division counts ten
+    samples while the device schedule fires eleven saves (the
+    initial sample plus ten crossings, the last within the
+    half-interval margin), writing one row past the output array
+    (issue #554). The host now rounds the float64 quotient to
+    nearest, so all eleven rows are allocated and written.
+    """
+    n = 1
+    result = solve_ivp(
+        system=oscillator_system,
+        y0={
+            "x1": np.ones(n, dtype=np.float32),
+            "v1": np.zeros(n, dtype=np.float32),
+            "x2": np.full(n, -0.5, dtype=np.float32),
+            "v2": np.zeros(n, dtype=np.float32),
+        },
+        parameters={
+            "k": np.full(n, 3.0, dtype=np.float32),
+            "c_couple": np.full(n, 0.3, dtype=np.float32),
+            "omega": np.full(n, 2.5, dtype=np.float32),
+        },
+        method="dormand-prince-54",
+        duration=0.01,
+        dt_min=1e-8,
+        dt_max=1.0,
+        save_every=0.001,
+        output_types=["state", "time"],
+        grid_type="verbatim",
+    )
+
+    assert int(result.status_codes[0]) == 0, result.status_messages
+    times = result.time[:, 0]
+    assert times.shape[0] == 11
+    assert np.all(np.diff(times) > 0.0), (
+        f"saved times are not strictly increasing: {times}"
+    )
+    assert times[-1] == pytest.approx(0.01, rel=1e-4)
     assert np.isfinite(result.time_domain_array).all()


### PR DESCRIPTION
Stacked on #566; completes the #554 fix by making host allocation and device event counts agree by construction, and restores the `save_every` contract #566's `t_end`-anchored margin broke.

## Problems in #566 as merged (compute-sanitizer evidence)

1. **The off-by-one OOB persists.** With `duration=4.0, save_every=1e-3, float32`, the host allocates `floor(f32-quotient 3999.9998)+1 = 4000` rows while the device schedule fires 4001 saves; sanitizer shows the identical 514 invalid `__global__` writes on `fix-327+#566` as on unpatched fix-327 (offsets `run*4` past the state allocation). numba's allocator slack usually hides it on main; CuPy's pool (#561) turns it into `cudaErrorIllegalAddress`.
2. **The half-interval margin past `t_end` fires saves beyond the requested duration.** `duration=0.2, save_every=0.07`: the device integrates past `t_end` and saves at t=0.21 — a sample the schedule contract excludes — and that write is itself out-of-bounds (host allocated 3 rows). `test_regular_saves_fill_allocation_at_fp_endpoints` passes on #566 only because the overflow is invisible without the sanitizer.

## Fix

One shared rule, no new loop state, no new branches: the number of scheduled events is `floor(float64(precision(duration)) / float64(precision(interval)) + tol)` with `tol = min(4·eps·quotient, 0.49)` — a representation tolerance that keeps integer schedules distorted by ulp-level rounding (`1.0/0.1`, `4.0/0.001`) while admitting nothing genuinely fractional (`0.2/0.07` stays at 2 events, no t=0.21 save).

- `SingleIntegratorRun._regular_event_count` feeds `output_length`, `summaries_length`, and new `save_stop_time` / `summary_stop_time` methods (final scheduled event + half an interval — the margin now only absorbs accumulator drift around the final event).
- `BatchSolverKernel` passes the two stop times to the loop as scalar kernel arguments; the device performs no schedule arithmetic (an earlier in-device variant cost ~0.36 ms of per-thread f64 division on tsit5 at 2²⁴ threads).
- The loop's termination compare and all event paths are unchanged from #566 — only the values of the two existing stop constants differ.

## Verification (RTX, real GPU)

- compute-sanitizer on the 512-run deterministic repro merged with fix-327: **0 errors** (was 514), output shape (4001, 3, 512) allocated and fully written.
- 973 tests across `tests/batchsolving` + `tests/integrators`, 441 across the schedule/output suites, CUDASIM smoke — all passing, including #566's regression tests (11/11 slots on `1.0/0.1`, zero-gap completion) with their original expectations, plus a new truncated-quotient regression test (`0.01/0.001` → 11 rows).
- Performance (`benchmarks/lorenz_mean_runtime.py`, interleaved session-level sampling, 4 base runs vs 3 branch runs): fixed `classical-rk4` 62.66→62.68 ms (identical); adaptive `tsit5` 24.59→24.71 ms (+0.49%, Welch t≈2.2, not significant at session level and smaller than the base's own within-session drift of 0.14 ms on unchanged code). Methodology note: single-pair Welch z against a stale reference flips verdicts on identical binaries (measured z from −2.4 to +2.6 A-vs-A); session-level interleaving is the resolvable comparison at this effect size.

Merge order: #566 → this → unblocks #561 (whose CuPy pool surfaces the OOB as a crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)