### PR TITLE
chore[CI]: workflow actions run on the Node 24 runtime

### DIFF
--- a/.github/workflows/ci_nocuda_tests.yml
+++ b/.github/workflows/ci_nocuda_tests.yml
@@ -32,9 +32,9 @@ jobs:
     # github.base_ref is only true if the current event is a pull request
       
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci_semver_manage.yml
+++ b/.github/workflows/ci_semver_manage.yml
@@ -14,7 +14,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-please-oss/release-please-action@v5
+      - uses: release-please-oss/release-please-action@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: python

--- a/.github/workflows/ci_semver_manage.yml
+++ b/.github/workflows/ci_semver_manage.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-please-oss/release-please-action@v6
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: python

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,9 +20,9 @@ jobs:
     - name: Verify gh-aw installation
       run: gh aw version
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         cache: pip
         python-version: "3.12"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,8 +17,8 @@ jobs:
           NUMBA_CUDA_USE_NVIDIA_BINDING: "0"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
 
       - name: Set up virtual environment
         run: python -m venv .venv
@@ -40,7 +40,7 @@ jobs:
           find ./docs/build -name "*.html" -exec sed -i "s|</head>|$META_TAG\n</head>|g" {} +
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -34,7 +34,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dists
           path: dist/
@@ -55,7 +55,7 @@ jobs:
       
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-dists
           path: dist/

--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - name: Set nightly dev version
@@ -41,7 +41,7 @@ jobs:
           python -m build
       
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dists
           path: dist/
@@ -63,7 +63,7 @@ jobs:
       
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-dists
           path: dist/


### PR DESCRIPTION
## Summary

Sweeps the GitHub Actions workflows for actions running on the **deprecated Node 20** runtime (and EOL Node 16) and bumps them to their latest major versions, all on **Node 24**. Each action's runtime and the compatibility of the inputs we use were source-verified against the pinned and target `action.yml` before bumping.

| Action | Old | New | Was on |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | node20 |
| `actions/setup-python` | v3 / v4 / v5 | **v6** | node16 / node20 |
| `actions/upload-artifact` | v4 | **v7** | node20 |
| `actions/download-artifact` | v4 | **v8** | node20 |
| `peaceiris/actions-gh-pages` | v3 | **v4** | node16 |
| `release-please-oss/release-please-action` | v5 | **v6** | node20 |

Files touched: `ci_nocuda_tests.yml`, `ci_semver_manage.yml`, `copilot-setup-steps.yml`, `documentation.yml`, `pypi.yml`, `test_pypi.yml`.

## Verification

- All target majors confirmed `runs.using: node24` from their `action.yml`.
- Inputs in use (`python-version`, `cache`, `name`, `path`, `publish_branch`/`github_token`/`publish_dir`/`force_orphan`, `token`/`release-type`) are unchanged across the bumps; `download-artifact` v8 reads v7-uploaded artifacts.
- GitHub-hosted `ubuntu-latest` already provides the node24 runtime.

## Out of scope (deliberately)

- **`ci_cuda_tests.yml`** — under active parallel development; its node20 bumps + the Codecov `test-results-action` migration are being handled separately.
- **`build-windows-gpu-ami.yml`** — belongs to the runs-on/AWS migration branch (not on `main`); its `checkout`/`configure-aws-credentials` node bumps ride with that effort.
- **Not Node-based, unaffected:** `codecov/codecov-action` (composite), `pypa/gh-action-pypi-publish` (composite), `ribtoks/tdg-github-action` (composite), `hashicorp/setup-packer` (already node24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)