### PR TITLE
fix[CI]: release-please job checks out repo before tagging

### DIFF
--- a/.github/workflows/ci_semver_manage.yml
+++ b/.github/workflows/ci_semver_manage.yml
@@ -19,12 +19,13 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: python
+      - uses: actions/checkout@v7
+        if: ${{ steps.release.outputs.release_created }}
       - name: tag major and minor versions
         if: ${{ steps.release.outputs.release_created }}
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN }}@github.com/googleapis/release-please-action.git"
           git tag -d v${{ steps.release.outputs.major }} || true
           git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
           git push origin :v${{ steps.release.outputs.major }} || true


### PR DESCRIPTION
## Problem
The `release-please` job's `tag major and minor versions` step failed with:

```
fatal: not in a git directory
Error: Process completed with exit code 128.
```

The step runs `git config`/`git tag`/`git push` in the workspace, but the job never ran `actions/checkout`, so there was no repository for git to operate on. It stayed hidden until #574 added `id: release`, which let the step fire for the first time (before that, `steps.release.outputs.release_created` was always empty and the step was skipped). The release-please action itself works fine — the log showed it producing `v0`/`v0.1`, so this is unrelated to the Node 24 / v6 bump.

## Fix
- Add `actions/checkout@v7` (gated on `release_created`) before the tag step so the git commands have a checked-out repo.
- Remove the unused `gh-token` remote — it pointed at the upstream `googleapis/release-please-action.git` and was never used; tag pushes go to `origin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)