### PR TITLE
fix: set_manual_proportion removes the instance from the auto pool

### DIFF
--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -677,7 +677,6 @@ class MemoryManager:
             return
         self._auto_pool.remove(instance_id)
         self._add_manual_proportion(instance, proportion)
-        settings.proportion = proportion
 
     def set_auto_limit_mode(self, instance: object) -> None:
         """

--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -649,11 +649,10 @@ class MemoryManager:
         if proportion < 0 or proportion > 1:
             raise ValueError("Proportion must be between 0 and 1")
         if instance_id in self._auto_pool:
-            self._add_manual_proportion(instance, proportion)
+            self._auto_pool.remove(instance_id)
         else:
             self._manual_pool.remove(instance_id)
-            self._add_manual_proportion(instance, proportion)
-            self.registry[instance_id].proportion = proportion
+        self._add_manual_proportion(instance, proportion)
 
     def set_manual_limit_mode(
         self, instance: object, proportion: float

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -617,6 +617,26 @@ class TestMemoryManager:
         assert mgr.registry[id(instance)].proportion == 0.4
         assert instance_id in mgr._manual_pool
 
+    @pytest.mark.parametrize(
+        "registered_instance_override", [{"proportion": None}], indirect=True
+    )
+    def test_set_manual_proportion_from_auto_pool(
+        self, registered_mgr, registered_instance
+    ):
+        """Test set_manual_proportion moves an auto instance to manual."""
+        mgr = registered_mgr
+        instance = registered_instance
+        instance_id = id(instance)
+        inst2 = DummyClass()
+        mgr.register(inst2)
+        assert instance_id in mgr._auto_pool
+        mgr.set_manual_proportion(instance, 0.01)
+        assert instance_id not in mgr._auto_pool
+        assert instance_id in mgr._manual_pool
+        assert mgr.registry[instance_id].proportion == 0.01
+        assert mgr.registry[instance_id].cap == int(0.01 * mgr.totalmem)
+        assert abs(mgr.registry[id(inst2)].proportion - 0.99) < 1e-6
+
     def test_rebalance_auto_pool(self, mgr):
         """Test _rebalance_auto_pool splits available proportion among auto pool."""
         inst1 = DummyClass()


### PR DESCRIPTION
## Summary

Fixes #567. `MemoryManager.set_manual_proportion` on an instance in the auto pool appended it to `_manual_pool` without removing it from `_auto_pool`, so the `_rebalance_auto_pool()` at the end of `_add_manual_proportion` immediately overwrote the manual cap with an equal auto share, and the instance was double-counted in both pools' arithmetic.

## Fix

`set_manual_proportion` removes the instance from whichever pool currently holds it before re-adding it manually, so the rebalance only redistributes among genuinely-auto instances. The redundant post-hoc `proportion` assignment is gone (`_add_manual_proportion` already sets proportion and cap).

## Tests

`tests/memory/test_memmgmt.py::TestMemoryManager::test_set_manual_proportion_from_auto_pool` reproduces the issue scenario (auto instance moved to a 0.01 manual proportion): asserts pool membership, `proportion`, `cap == 0.01 * totalmem`, and that the remaining auto instance absorbs the rest. Full `test_memmgmt.py` passes on simulator and real GPU (54 passed).

## Performance gate (benchmarks/lorenz_mean_runtime.py, defaults)

| Config | A (main 2a733d4) | B (this branch) | Welch z | Verdict |
|---|---|---|---|---|
| fixed (classical-rk4) | 66.49 ± 2.02 ms | 65.48 ± 1.19 ms | -4.30 | no regression |
| adaptive (tsit5) | 26.29 ± 0.91 ms | 25.74 ± 0.62 ms | -5.03 | no regression |

🤖 Generated with [Claude Code](https://claude.com/claude-code)