### PR TITLE
fix: repeat chunked solves reuse the group's stored chunk parameters

### DIFF
--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -484,6 +484,9 @@ class MemoryManager:
     _queued_allocations: Dict[str, Dict] = field(
         default=attrsFactory(dict), validator=attrsval_instance_of(dict)
     )
+    _group_chunk_parameters: Dict[str, Tuple[int, int]] = field(
+        default=attrsFactory(dict), validator=attrsval_instance_of(dict)
+    )
 
     def __attrs_post_init__(self) -> None:
         """Initialise the manager with current GPU memory information."""
@@ -1249,11 +1252,33 @@ class MemoryManager:
         Processes all pending requests in the same stream group, applying
         coordinated chunking based on available memory. Calls
         allocation_ready_hook for each instance with their results.
+        Instances in the group with no queued requests receive an empty
+        response carrying the group's chunk parameters. When nothing is
+        queued (all allocations already in place from an earlier call),
+        every instance receives the group's stored chunk parameters, so
+        per-instance chunk state is restored on repeat runs.
 
         """
         stream_group = self.get_stream_group(triggering_instance)
         stream = self.get_stream(triggering_instance)
         queued_requests = self._queued_allocations.pop(stream_group, {})
+        peers = self.stream_groups.get_instances_in_group(stream_group)
+
+        if not queued_requests:
+            cached_parameters = self._group_chunk_parameters.get(stream_group)
+            if cached_parameters is None:
+                return None
+            chunk_length, num_chunks = cached_parameters
+            for peer in peers:
+                self.registry[peer].allocation_ready_hook(
+                    ArrayResponse(
+                        arr={},
+                        chunks=num_chunks,
+                        chunk_length=chunk_length,
+                        chunked_shapes={},
+                    )
+                )
+            return None
 
         # Get total_runs from first request
         num_runs = 1
@@ -1267,7 +1292,10 @@ class MemoryManager:
         chunk_length, num_chunks = self.get_chunk_parameters(
             queued_requests, num_runs, stream_group
         )
-        peers = self.stream_groups.get_instances_in_group(stream_group)
+        self._group_chunk_parameters[stream_group] = (
+            chunk_length,
+            num_chunks,
+        )
         notaries = set(peers) - set(queued_requests.keys())
         for instance_id, requests_dict in queued_requests.items():
             chunked_shapes = self.compute_chunked_shapes(
@@ -1290,15 +1318,16 @@ class MemoryManager:
             )
 
             self.registry[instance_id].allocation_ready_hook(response)
-            for peer in notaries:
-                self.registry[peer].allocation_ready_hook(
-                    ArrayResponse(
-                        arr={},
-                        chunks=num_chunks,
-                        chunk_length=chunk_length,
-                        chunked_shapes={},
-                    )
+
+        for peer in notaries:
+            self.registry[peer].allocation_ready_hook(
+                ArrayResponse(
+                    arr={},
+                    chunks=num_chunks,
+                    chunk_length=chunk_length,
+                    chunked_shapes={},
                 )
+            )
 
         return None
 

--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -1260,7 +1260,6 @@ class MemoryManager:
 
         """
         stream_group = self.get_stream_group(triggering_instance)
-        stream = self.get_stream(triggering_instance)
         queued_requests = self._queued_allocations.pop(stream_group, {})
         peers = self.stream_groups.get_instances_in_group(stream_group)
 
@@ -1279,6 +1278,8 @@ class MemoryManager:
                     )
                 )
             return None
+
+        stream = self.get_stream(triggering_instance)
 
         # Get total_runs from first request
         num_runs = 1

--- a/tests/batchsolving/arrays/test_chunking.py
+++ b/tests/batchsolving/arrays/test_chunking.py
@@ -75,6 +75,36 @@ def test_chunked_solve_produces_valid_output(
 
 
 
+def test_repeat_chunked_solve_matches_first(
+    system, precision, chunked_solved_solver, driver_settings
+):
+    """A repeat chunked solve on the same solver reproduces the first."""
+    solver, first_result = chunked_solved_solver
+    assert solver.chunks > 1
+    first_state = first_result.time_domain_array.copy()
+
+    n_runs = 5
+    n_states = system.sizes.states
+    n_params = system.sizes.parameters
+    inits = np.ones((n_states, n_runs), dtype=precision)
+    params = np.ones((n_params, n_runs), dtype=precision)
+
+    second_result = solver.solve(
+        inits,
+        params,
+        drivers=driver_settings,
+        duration=0.05,
+        summarise_every=None,
+        save_every=0.01,
+        dt=0.01,
+    )
+
+    assert solver.chunks > 1
+    np.testing.assert_array_equal(
+        second_result.time_domain_array, first_state
+    )
+
+
 def test_input_buffers_released_after_kernel(chunked_solved_solver):
     chunked_solver, result_chunked = chunked_solved_solver
 

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -792,6 +792,41 @@ class TestMemoryManager:
 
         mgr.allocate_queue(instance)
 
+    @pytest.mark.parametrize(
+        "fixed_mem_override", [{"free": 1024}], indirect=True
+    )
+    def test_allocate_queue_empty_rebroadcasts_chunk_parameters(self, mgr):
+        """Test allocate_queue with nothing queued resends chunk params."""
+        instance = DummyClass()
+        responses = []
+        mgr.register(
+            instance, allocation_ready_hook=lambda r: responses.append(r)
+        )
+
+        requests = {
+            "arr1": ArrayRequest(
+                shape=(4, 100),
+                dtype=np.float32,
+                memory="device",
+                chunk_axis_index=1,
+                total_runs=100,
+            ),
+        }
+        mgr.queue_request(instance, requests)
+        mgr.allocate_queue(instance)
+
+        assert len(responses) == 1
+        first = responses[0]
+        assert first.chunks > 1
+
+        # Repeat call with nothing queued: chunk parameters rebroadcast
+        mgr.allocate_queue(instance)
+        assert len(responses) == 2
+        second = responses[1]
+        assert second.arr == {}
+        assert second.chunks == first.chunks
+        assert second.chunk_length == first.chunk_length
+
     def test_is_grouped(self, mgr):
         """Test is_grouped returns correct grouping status for instances."""
         # Test instance in default group (should return False)


### PR DESCRIPTION
## Summary

Fixes #568. A second `solver.solve()` with identical inputs on the same `Solver` returned corrupted results for a deterministic subset of runs on the chunked path.

## Root cause

On a repeat solve with identical inputs, every host array passes the `_arrays_equal` fast paths, so `InputArrays`/`OutputArrays` queue no allocation requests. `BatchSolverKernel.run` rebuilds `run_params` fresh each call (`num_chunks=1`) and relies on the allocation callback to restore chunk metadata — but `allocate_queue` pops an empty queue and its hook loop never executes, so no hooks fire (not even notary hooks). The kernel then launches a single "chunk" with the **full** run count against **chunk-sized** device buffers: out-of-bounds device writes corrupt a deterministic subset, and only chunk 0's slice is written back to host (the rest keeps solve-#1 values, which match — hence "a subset mismatched, identical indices every repetition").

## Fix

`allocate_queue` records each stream group's chunk parameters when it allocates. When called with nothing queued, it rebroadcasts those parameters to every instance in the group via empty notary responses, restoring `run_params.num_chunks`/`chunk_length` and the array managers' `_chunks` on repeat solves. Notary instances are also now notified once per `allocate_queue` call instead of once per requesting instance.

## Tests

- `tests/batchsolving/arrays/test_chunking.py::test_repeat_chunked_solve_matches_first` — re-solves on the `chunked_solved_solver` fixture and asserts the second result is chunked and exactly equals the first. **Fails on main, passes with the fix** (verified both ways on the real GPU).
- `tests/memory/test_memmgmt.py::test_allocate_queue_empty_rebroadcasts_chunk_parameters` — unit test that an empty-queue `allocate_queue` after a chunked allocation resends the same `chunks`/`chunk_length` with an empty `arr`.
- Full `test_chunking.py` + `test_memmgmt.py`: 84 passed on real GPU.

## Performance gate (benchmarks/lorenz_mean_runtime.py, defaults)

| Config | A (main 2a733d4) | B (this branch) | Welch z | Verdict |
|---|---|---|---|---|
| fixed (classical-rk4) | 66.49 ± 2.02 ms | 64.89 ± 1.33 ms | -6.63 | no regression |
| adaptive (tsit5) | 26.29 ± 0.91 ms | 25.63 ± 0.55 ms | -6.22 | no regression |

🤖 Generated with [Claude Code](https://claude.com/claude-code)