### PR TITLE
fix: user device functions resolve inside generated modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@ optimisation conventions live in `src/cubie/writing_cuda_functions.md`.
 - **Python 3.10–3.14**, **CUDA 12 or 13** (via the `cuda12`/`cuda13` extras, or a system
   toolkit), **NVIDIA GPU (compute capability ≥6.0)**.
 - CPU-only dev/test without a GPU: set `NUMBA_ENABLE_CUDASIM=1` (Numba's CUDA simulator).
+  **CUDASIM is not production.** Behaviour under the simulator must never be considered when
+  evaluating code: designs, fixes, and diagnostics are judged solely on their real-GPU
+  behaviour. A path that works under CUDASIM but degrades or disappears on hardware is broken.
 - Dev shell is **PowerShell on Windows** — chain with `;`, not `&&`. Staying Windows-compatible is
   a project goal; CI runs on Ubuntu (Python 3.10/3.11/3.12).
 

--- a/docs/source/user_guide/userfunctions.rst
+++ b/docs/source/user_guide/userfunctions.rst
@@ -54,6 +54,9 @@ name.
   derivative is taken.
 - The derivative callable’s __name__ is used in generated code, so choose a
   descriptive name (e.g., myfunc_grad).
+- The derivative must itself be a CUDA device function
+  (``@cuda.jit(device=True)``) — it is called from generated device code
+  when an implicit method builds Jacobian terms.
 
 Example:
 
@@ -67,7 +70,7 @@ Example:
      def myfunc(a, b):
          return a * b
 
-     # This can be device or pure Python; codegen only needs the name
+     @cuda.jit(device=True)
      def myfunc_grad(a, b, index):
          if index == 0:
              return b
@@ -101,6 +104,50 @@ Example:
   (This is internal plumbing — when you solve through
   :func:`~cubie.solve_ivp` or :class:`~cubie.Solver`, the JVP code is
   generated for you.)
+
+End-to-end example
+------------------
+
+Device functions are supported end-to-end: systems whose equations call
+them can be built and solved directly. The device callables are made
+available to the generated module automatically, in both the string and
+Python-function input forms.
+
+.. code-block:: python
+
+   import numpy as np
+   from numba import cuda
+
+   from cubie import create_ODE_system, solve_ivp
+
+   @cuda.jit(device=True)
+   def cubed(x):
+       return x * x * x
+
+   @cuda.jit(device=True)
+   def d_cubed(x, index):
+       return 3.0 * x * x
+
+   system = create_ODE_system(
+       "dx = -cubed(x)",
+       states={"x": 2.0},
+       user_functions={"cubed": cubed},
+       user_function_derivatives={"cubed": d_cubed},
+   )
+
+   result = solve_ivp(
+       system,
+       y0={"x": 2.0},
+       method="backwards_euler",
+       duration=0.5,
+       dt=0.01,
+       save_every=0.05,
+   )
+   print(result.time_domain_array[:, 0, 0])
+
+The derivative mapping is only needed for implicit methods, which build
+Jacobian terms; explicit methods such as ``euler`` need only
+``user_functions``.
 
 Name collisions with SymPy
 --------------------------

--- a/src/cubie/odesystems/symbolic/codegen/neumann_convergence.py
+++ b/src/cubie/odesystems/symbolic/codegen/neumann_convergence.py
@@ -336,6 +336,7 @@ def check_neumann_convergence(
     beta: float = 1.0,
     gamma: float = 1.0,
     t0: float = 0.0,
+    user_functions: Optional[Dict[str, object]] = None,
 ) -> Dict[str, object]:
     """Evaluate whether the Neumann preconditioner is likely to converge.
 
@@ -364,6 +365,11 @@ def check_neumann_convergence(
         Transformation parameters from the FIRK formulation.
     t0
         Time at which to evaluate the Jacobian.
+    user_functions
+        Callables resolving user function names appearing in the
+        right-hand side, keyed by the printed name. Used only when
+        ``evaluator`` is omitted and forwarded to
+        :func:`build_rhs_evaluator`.
 
     Returns
     -------
@@ -374,7 +380,9 @@ def check_neumann_convergence(
         not be evaluated.
     """
     if evaluator is None:
-        evaluator = build_rhs_evaluator(equations, index_map)
+        evaluator = build_rhs_evaluator(
+            equations, index_map, user_functions=user_functions
+        )
 
     jacobian = evaluator.jacobian(index_map, t0=t0)
 

--- a/src/cubie/odesystems/symbolic/codegen/neumann_convergence.py
+++ b/src/cubie/odesystems/symbolic/codegen/neumann_convergence.py
@@ -13,17 +13,20 @@ dominant and the Neumann series diverges for all but the tiniest step
 sizes.
 
 The Jacobian is evaluated at the initial state by central finite
-differences of the guarded right-hand side rather than by substituting
-into the analytic Jacobian matrix. The analytic derivative of a CellML
-gating term such as ``(V - E) / (exp((V - E) / k) - 1)`` is ``0 / 0`` at
-the resting potential even though the term itself is finite there;
-finite-differencing the guarded RHS takes that removable-singularity
-limit numerically and yields a finite Jacobian.
+differences of the system's **compiled** ``dxdt`` device function,
+launched on the device at the system's compiled precision, so the
+diagnostic reflects the behaviour of the production device code rather
+than a host-side reconstruction. Finite-differencing the guarded
+right-hand side also takes removable singularities numerically: the
+analytic derivative of a CellML gating term such as
+``(V - E) / (exp((V - E) / k) - 1)`` is ``0 / 0`` at the resting
+potential even though the term itself is finite there, and the guarded
+device code evaluates it cleanly.
 
-Published Functions
--------------------
-:func:`build_rhs_evaluator`
-    Build a cached finite-difference Jacobian evaluator for a system.
+Published Objects
+-----------------
+:class:`NeumannRHSEvaluator`
+    Finite-difference Jacobian evaluator running the compiled ``dxdt``.
 :func:`neumann_spectral_radius`
     Pure-numeric Jacobi spectral-radius diagnostic as a function of the
     Jacobian and the ``beta``/``gamma``/tableau parameters.
@@ -34,64 +37,69 @@ Published Functions
 
 import logging
 import warnings
-from typing import Dict, Optional, Sequence, Union
+from typing import Callable, Dict, Optional, Sequence, Union
 
 import numpy as np
 import sympy as sp
+from numba import cuda
 
-from cubie.odesystems.symbolic.parsing.parser import TIME_SYMBOL
 from cubie.odesystems.symbolic.indexedbasemaps import IndexedBases
-from cubie.odesystems.symbolic.parsing.parser import ParsedEquations
-from cubie.odesystems.symbolic.sym_utils import topological_sort
 
 logger = logging.getLogger(__name__)
 
-# Central-difference step: cube-root of machine epsilon balances round-off
-# against truncation error for a double-precision second-order stencil.
-_FD_STEP = float(np.finfo(np.float64).eps) ** (1.0 / 3.0)
-
 
 class NeumannRHSEvaluator:
-    """Finite-difference Jacobian evaluator for a symbolic system.
+    """Finite-difference Jacobian evaluator for a compiled system.
 
-    Resolves the auxiliary chain into the state derivatives once and
-    compiles the guarded right-hand side to a NumPy callable. The
-    resulting object is cached on the owning :class:`SymbolicODE`; each
-    call reads current state/constant/parameter values from the index
-    map, so value changes are reflected without rebuilding.
+    Launches the system's compiled ``dxdt`` device function at
+    perturbed initial states and forms the Jacobian by central finite
+    differences, so the diagnostic sees exactly the device code the
+    solver runs, at the compiled precision. The object is cached on
+    the owning :class:`SymbolicODE`; each call fetches the current
+    compiled ``dxdt`` through ``dxdt_getter`` (rebuilding the wrapper
+    kernel only when the device function changes) and reads current
+    values from the index map, so value and constant changes are
+    reflected without rebuilding the evaluator.
     """
 
     def __init__(
         self,
-        rhs_callable,
-        argument_symbols: Sequence[sp.Symbol],
-        state_symbols: Sequence[sp.Symbol],
-        driver_symbols: Sequence[sp.Symbol],
+        dxdt_getter: Callable,
+        precision_getter: Callable,
     ) -> None:
-        self._rhs = rhs_callable
-        self._argument_symbols = list(argument_symbols)
-        self._state_symbols = list(state_symbols)
-        self._driver_symbols = set(driver_symbols)
-        self._state_count = len(state_symbols)
+        self._dxdt_getter = dxdt_getter
+        self._precision_getter = precision_getter
+        self._kernel = None
+        self._kernel_dxdt = None
 
-    def _value_map(
-        self,
-        index_map: IndexedBases,
-        t0: float,
-    ) -> Dict[sp.Symbol, float]:
-        """Collect current numeric values for every RHS symbol."""
-        values: Dict[sp.Symbol, float] = {}
-        for sym, val in index_map.states.default_values.items():
-            values[sym] = float(val)
-        for sym, val in index_map.constants.default_values.items():
-            values[sym] = float(val)
-        if hasattr(index_map, "parameters"):
-            for sym, val in index_map.parameters.default_values.items():
-                values[sym] = float(val)
-        for sym in self._driver_symbols:
-            values[sym] = 0.0
-        values[TIME_SYMBOL] = float(t0)
-        return values
+    def _evaluation_kernel(self):
+        """Return the evaluation kernel for the current ``dxdt``.
+
+        The kernel is compiled once per compiled ``dxdt`` object; a
+        settings change that rebuilds the device function triggers a
+        rebuild of the wrapper on the next call.
+        """
+        dxdt_function = self._dxdt_getter()
+        if dxdt_function is not self._kernel_dxdt:
+            # no cover: start
+            @cuda.jit
+            def evaluate_rhs(
+                states, parameters, drivers, observables, out, t
+            ):
+                i = cuda.grid(1)
+                if i < states.shape[0]:
+                    dxdt_function(
+                        states[i],
+                        parameters,
+                        drivers,
+                        observables[i],
+                        out[i],
+                        t,
+                    )
+            # no cover: end
+            self._kernel = evaluate_rhs
+            self._kernel_dxdt = dxdt_function
+        return self._kernel
 
     def jacobian(
         self,
@@ -103,151 +111,100 @@ class NeumannRHSEvaluator:
         Parameters
         ----------
         index_map
-            Index maps supplying current state/constant/parameter values.
+            Index maps supplying current state/parameter values.
         t0
             Time at which to evaluate the right-hand side.
 
         Returns
         -------
         numpy.ndarray
-            The ``state_count x state_count`` Jacobian. Entries that
-            cannot be evaluated are returned as ``nan``.
+            The ``state_count x state_count`` Jacobian in float64.
+            Entries that cannot be evaluated are returned as ``nan``.
         """
-        values = self._value_map(index_map, t0)
-        base_args = np.array(
-            [values.get(sym, 0.0) for sym in self._argument_symbols],
-            dtype=np.float64,
-        )
-        n = self._state_count
+        precision = np.dtype(self._precision_getter())
+        state_map = index_map.states.index_map
+        n = len(state_map)
+        base = np.zeros(n, dtype=np.float64)
+        state_defaults = index_map.states.default_values
+        for sym, idx in state_map.items():
+            base[idx] = float(state_defaults[sym])
 
-        def evaluate(args):
-            with np.errstate(all="ignore"):
-                try:
-                    return np.asarray(self._rhs(*args), dtype=np.float64)
-                except (
-                    ZeroDivisionError,
-                    FloatingPointError,
-                    OverflowError,
-                    ValueError,
-                ):
-                    return np.full(n, np.nan)
+        parameters = np.zeros(1, dtype=precision)
+        if hasattr(index_map, "parameters"):
+            parameter_map = index_map.parameters.index_map
+            if parameter_map:
+                parameters = np.zeros(
+                    len(parameter_map), dtype=precision
+                )
+                defaults = index_map.parameters.default_values
+                for sym, idx in parameter_map.items():
+                    parameters[idx] = float(defaults[sym])
 
-        jacobian = np.zeros((n, n), dtype=np.float64)
+        n_drivers = 1
+        if hasattr(index_map, "drivers"):
+            n_drivers = max(1, len(index_map.drivers.index_map))
+        drivers = np.zeros(n_drivers, dtype=precision)
+
+        n_observables = max(1, len(index_map.observables.index_map))
+        observables = np.zeros((2 * n, n_observables), dtype=precision)
+        out = np.zeros((2 * n, n), dtype=precision)
+
+        # Central-difference step: cube-root of the compiled
+        # precision's epsilon balances round-off against truncation
+        # error for a second-order stencil at that precision.
+        fd_step = float(np.finfo(precision).eps) ** (1.0 / 3.0)
+        states = np.empty((2 * n, n), dtype=precision)
         for col in range(n):
-            step = _FD_STEP * max(abs(base_args[col]), 1.0)
-            forward = base_args.copy()
-            backward = base_args.copy()
+            step = fd_step * max(abs(base[col]), 1.0)
+            forward = base.copy()
+            backward = base.copy()
             forward[col] += step
             backward[col] -= step
-            f_plus = evaluate(forward)
-            f_minus = evaluate(backward)
-            jacobian[:, col] = (f_plus - f_minus) / (2.0 * step)
-        return jacobian
+            states[2 * col] = forward
+            states[2 * col + 1] = backward
 
-
-def _host_guarded(func):
-    """Wrap a user callable so host evaluation degrades to ``nan``.
-
-    User device functions are host-callable under the CUDA simulator
-    but raise when called from host code on a real GPU; the guard
-    turns that into a ``nan`` result so the convergence diagnostic is
-    skipped gracefully instead of raising.
-    """
-
-    def wrapped(*args):
+        kernel = self._evaluation_kernel()
+        threads = 32
+        blocks = (2 * n + threads - 1) // threads
         try:
-            return float(func(*args))
-        except Exception:
-            return float("nan")
+            device_states = cuda.to_device(states)
+            device_parameters = cuda.to_device(parameters)
+            device_drivers = cuda.to_device(drivers)
+            device_observables = cuda.to_device(observables)
+            device_out = cuda.to_device(out)
+            kernel[blocks, threads](
+                device_states,
+                device_parameters,
+                device_drivers,
+                device_observables,
+                device_out,
+                precision.type(t0),
+            )
+            evaluated = device_out.copy_to_host()
+        except (
+            ZeroDivisionError,
+            FloatingPointError,
+            OverflowError,
+            ValueError,
+        ):
+            # The CUDA simulator surfaces domain errors as host
+            # exceptions where device code produces non-finite
+            # values; both funnel into the caller's
+            # could-not-evaluate path.
+            return np.full((n, n), np.nan)
 
-    return wrapped
-
-
-def build_rhs_evaluator(
-    equations: ParsedEquations,
-    index_map: IndexedBases,
-    user_functions: Optional[Dict[str, object]] = None,
-) -> NeumannRHSEvaluator:
-    """Compile a finite-difference Jacobian evaluator for a system.
-
-    Resolves the auxiliary assignments into each state derivative and
-    lambdifies the guarded right-hand side. This is the expensive step;
-    the returned evaluator is cheap to call and should be cached.
-
-    Parameters
-    ----------
-    equations
-        Parsed ODE equations (the same object passed to codegen).
-    index_map
-        Index maps (states, constants, drivers, ...) for the system.
-    user_functions
-        Callables resolving user function names appearing in the
-        right-hand side, keyed by the printed name. Each is wrapped so
-        a host-side call failure yields ``nan`` instead of raising.
-
-    Returns
-    -------
-    NeumannRHSEvaluator
-        Callable evaluator producing the state Jacobian by central
-        finite differences of the guarded right-hand side.
-    """
-    state_symbols = list(index_map.states.index_map.keys())
-    dxdt_symbols = list(index_map.dxdt.index_map.keys())
-    dxdt_set = set(dxdt_symbols)
-
-    # Resolve the auxiliary chain into the derivatives so the compiled
-    # right-hand side depends only on states/constants/drivers/time. The
-    # guarded Piecewise gating terms survive substitution and keep the
-    # RHS finite at removable singularities.
-    sorted_equations = topological_sort(equations.to_equation_list())
-    auxiliary_subs: Dict[sp.Symbol, sp.Expr] = {}
-    derivative_exprs: Dict[sp.Symbol, sp.Expr] = {}
-    for lhs, rhs in sorted_equations:
-        resolved = rhs.xreplace(auxiliary_subs)
-        if lhs in dxdt_set:
-            derivative_exprs[lhs] = resolved
-        else:
-            auxiliary_subs[lhs] = resolved
-
-    constant_symbols = list(index_map.constants.default_values.keys())
-    parameter_symbols = []
-    if hasattr(index_map, "parameters"):
-        parameter_symbols = list(
-            index_map.parameters.default_values.keys()
-        )
-    driver_symbols = []
-    if hasattr(index_map, "drivers"):
-        driver_symbols = list(index_map.drivers.index_map.keys())
-
-    argument_symbols = (
-        state_symbols
-        + constant_symbols
-        + parameter_symbols
-        + driver_symbols
-        + [TIME_SYMBOL]
-    )
-    rhs_vector = [
-        derivative_exprs.get(sym, sp.S.Zero) for sym in dxdt_symbols
-    ]
-    # Evaluate with the ``math`` module (scalar ternaries for Piecewise,
-    # builtin min/max) rather than NumPy: the finite-difference stencil
-    # feeds scalars, and NumPy's ``select`` requires array conditions.
-    guarded_functions = {
-        name: _host_guarded(func)
-        for name, func in (user_functions or {}).items()
-    }
-    rhs_callable = sp.lambdify(
-        argument_symbols,
-        rhs_vector,
-        modules=[guarded_functions, "math"],
-        cse=True,
-    )
-    return NeumannRHSEvaluator(
-        rhs_callable,
-        argument_symbols,
-        state_symbols,
-        driver_symbols,
-    )
+        evaluated = evaluated.astype(np.float64)
+        jacobian = np.empty((n, n), dtype=np.float64)
+        for col in range(n):
+            # Effective step from the precision-cast states so the
+            # divisor matches the perturbation the device code saw.
+            denominator = float(states[2 * col, col]) - float(
+                states[2 * col + 1, col]
+            )
+            jacobian[:, col] = (
+                evaluated[2 * col] - evaluated[2 * col + 1]
+            ) / denominator
+        return jacobian
 
 
 def neumann_spectral_radius(
@@ -326,9 +283,8 @@ def neumann_spectral_radius(
 
 
 def check_neumann_convergence(
-    equations: ParsedEquations,
     index_map: IndexedBases,
-    evaluator: Optional[NeumannRHSEvaluator] = None,
+    evaluator: NeumannRHSEvaluator,
     stage_coefficients: Optional[
         Sequence[Sequence[Union[float, sp.Expr]]]
     ] = None,
@@ -336,23 +292,20 @@ def check_neumann_convergence(
     beta: float = 1.0,
     gamma: float = 1.0,
     t0: float = 0.0,
-    user_functions: Optional[Dict[str, object]] = None,
 ) -> Dict[str, object]:
     """Evaluate whether the Neumann preconditioner is likely to converge.
 
     Evaluates the state Jacobian at the initial state by finite
-    differences and checks the spectral radius of the Jacobi iteration
-    matrix ``N = I - D^-1 M``.
+    differences of the compiled ``dxdt`` device function and checks the
+    spectral radius of the Jacobi iteration matrix ``N = I - D^-1 M``.
 
     Parameters
     ----------
-    equations
-        Parsed ODE equations (the same object passed to codegen).
     index_map
-        Index maps (states, constants, etc.) with default values.
+        Index maps (states, parameters, etc.) with default values.
     evaluator
-        Prebuilt finite-difference Jacobian evaluator. Built from
-        ``equations``/``index_map`` when omitted.
+        Finite-difference Jacobian evaluator wrapping the system's
+        compiled ``dxdt`` device function.
     stage_coefficients
         Butcher-tableau ``A`` matrix for the FIRK method. When provided,
         the full staged system ``beta I - gamma (A (x) J)`` is analysed
@@ -365,11 +318,6 @@ def check_neumann_convergence(
         Transformation parameters from the FIRK formulation.
     t0
         Time at which to evaluate the Jacobian.
-    user_functions
-        Callables resolving user function names appearing in the
-        right-hand side, keyed by the printed name. Used only when
-        ``evaluator`` is omitted and forwarded to
-        :func:`build_rhs_evaluator`.
 
     Returns
     -------
@@ -379,11 +327,6 @@ def check_neumann_convergence(
         ``J_numeric``. ``converges`` is ``None`` when the Jacobian could
         not be evaluated.
     """
-    if evaluator is None:
-        evaluator = build_rhs_evaluator(
-            equations, index_map, user_functions=user_functions
-        )
-
     jacobian = evaluator.jacobian(index_map, t0=t0)
 
     if not np.isfinite(jacobian).all():

--- a/src/cubie/odesystems/symbolic/codegen/neumann_convergence.py
+++ b/src/cubie/odesystems/symbolic/codegen/neumann_convergence.py
@@ -145,9 +145,28 @@ class NeumannRHSEvaluator:
         return jacobian
 
 
+def _host_guarded(func):
+    """Wrap a user callable so host evaluation degrades to ``nan``.
+
+    User device functions are host-callable under the CUDA simulator
+    but raise when called from host code on a real GPU; the guard
+    turns that into a ``nan`` result so the convergence diagnostic is
+    skipped gracefully instead of raising.
+    """
+
+    def wrapped(*args):
+        try:
+            return float(func(*args))
+        except Exception:
+            return float("nan")
+
+    return wrapped
+
+
 def build_rhs_evaluator(
     equations: ParsedEquations,
     index_map: IndexedBases,
+    user_functions: Optional[Dict[str, object]] = None,
 ) -> NeumannRHSEvaluator:
     """Compile a finite-difference Jacobian evaluator for a system.
 
@@ -161,6 +180,10 @@ def build_rhs_evaluator(
         Parsed ODE equations (the same object passed to codegen).
     index_map
         Index maps (states, constants, drivers, ...) for the system.
+    user_functions
+        Callables resolving user function names appearing in the
+        right-hand side, keyed by the printed name. Each is wrapped so
+        a host-side call failure yields ``nan`` instead of raising.
 
     Returns
     -------
@@ -209,8 +232,15 @@ def build_rhs_evaluator(
     # Evaluate with the ``math`` module (scalar ternaries for Piecewise,
     # builtin min/max) rather than NumPy: the finite-difference stencil
     # feeds scalars, and NumPy's ``select`` requires array conditions.
+    guarded_functions = {
+        name: _host_guarded(func)
+        for name, func in (user_functions or {}).items()
+    }
     rhs_callable = sp.lambdify(
-        argument_symbols, rhs_vector, modules=["math"], cse=True
+        argument_symbols,
+        rhs_vector,
+        modules=[guarded_functions, "math"],
+        cse=True,
     )
     return NeumannRHSEvaluator(
         rhs_callable,

--- a/src/cubie/odesystems/symbolic/codegen/neumann_convergence.py
+++ b/src/cubie/odesystems/symbolic/codegen/neumann_convergence.py
@@ -43,6 +43,7 @@ import numpy as np
 import sympy as sp
 from numba import cuda
 
+from cubie.cuda_simsafe import CUDA_SIMULATION
 from cubie.odesystems.symbolic.indexedbasemaps import IndexedBases
 
 logger = logging.getLogger(__name__)
@@ -166,7 +167,8 @@ class NeumannRHSEvaluator:
         kernel = self._evaluation_kernel()
         threads = 32
         blocks = (2 * n + threads - 1) // threads
-        try:
+
+        def launch():
             device_states = cuda.to_device(states)
             device_parameters = cuda.to_device(parameters)
             device_drivers = cuda.to_device(drivers)
@@ -180,18 +182,24 @@ class NeumannRHSEvaluator:
                 device_out,
                 precision.type(t0),
             )
-            evaluated = device_out.copy_to_host()
-        except (
-            ZeroDivisionError,
-            FloatingPointError,
-            OverflowError,
-            ValueError,
-        ):
-            # The CUDA simulator surfaces domain errors as host
-            # exceptions where device code produces non-finite
-            # values; both funnel into the caller's
-            # could-not-evaluate path.
-            return np.full((n, n), np.nan)
+            return device_out.copy_to_host()
+
+        if CUDA_SIMULATION:
+            # The simulator executes device code as host Python,
+            # where domain errors raise instead of producing the
+            # non-finite values device math returns; translate them
+            # into the caller's could-not-evaluate path.
+            try:
+                evaluated = launch()
+            except (
+                ZeroDivisionError,
+                FloatingPointError,
+                OverflowError,
+                ValueError,
+            ):
+                return np.full((n, n), np.nan)
+        else:
+            evaluated = launch()
 
         evaluated = evaluated.astype(np.float64)
         jacobian = np.empty((n, n), dtype=np.float64)

--- a/src/cubie/odesystems/symbolic/odefile.py
+++ b/src/cubie/odesystems/symbolic/odefile.py
@@ -161,13 +161,21 @@ class ODEFile:
                 has_function = False
         return has_function
 
-    def _import_function(self, func_name: str) -> Callable:
+    def _import_function(
+        self,
+        func_name: str,
+        injections: Optional[dict[str, Callable]] = None,
+    ) -> Callable:
         """Import ``func_name`` from the generated module.
 
         Parameters
         ----------
         func_name
             Name of the generated function to import.
+        injections
+            Callables set as module attributes after import so the
+            generated factory can resolve them by name, e.g. user
+            device functions called from the generated source.
 
         Returns
         -------
@@ -177,12 +185,15 @@ class ODEFile:
         spec = util.spec_from_file_location(func_name, self.file_path)
         module = util.module_from_spec(spec)
         spec.loader.exec_module(module)
+        for name, obj in (injections or {}).items():
+            setattr(module, name, obj)
         return getattr(module, func_name)
 
     def import_function(
         self,
         func_name: str,
         code_lines: Optional[str] = None,
+        injections: Optional[dict[str, Callable]] = None,
     ) -> Tuple[Callable, bool]:
         """Import a generated function, generating it when absent.
 
@@ -192,6 +203,10 @@ class ODEFile:
             Name of the factory function to import.
         code_lines
             Source code used to generate the function when it is not cached.
+        injections
+            Callables set as attributes on the generated module so the
+            factory can resolve them by name, e.g. user device
+            functions called from the generated source.
 
         Returns
         -------
@@ -224,8 +239,8 @@ class ODEFile:
                     f"{func_name} not found in cache and no code provided."
                 )
             self.add_function(code_lines)
-        
-        return self._import_function(func_name), was_cached
+
+        return self._import_function(func_name, injections), was_cached
 
     def add_function(self, printed_code: str) -> None:
         """Append generated code to the cache file.

--- a/src/cubie/odesystems/symbolic/symbolicODE.py
+++ b/src/cubie/odesystems/symbolic/symbolicODE.py
@@ -92,7 +92,7 @@ from cubie.odesystems.symbolic.codegen.time_derivative import (
 )
 from cubie.odesystems.symbolic.sym_utils import hash_system_definition
 from cubie.odesystems.baseODE import BaseODE, ODECache
-from cubie._utils import PrecisionDType
+from cubie._utils import PrecisionDType, is_devfunc
 from cubie.time_logger import default_timelogger
 
 # Neumann preconditioner helper types checked by the convergence
@@ -489,9 +489,44 @@ class SymbolicODE(BaseODE):
         """
         if self._neumann_rhs_evaluator is None:
             self._neumann_rhs_evaluator = build_rhs_evaluator(
-                self.equations, self.indices
+                self.equations,
+                self.indices,
+                user_functions=self._device_function_injections(),
             )
         return self._neumann_rhs_evaluator
+
+    def _device_function_injections(self) -> dict[str, Callable]:
+        """Collect device callables the generated module must resolve.
+
+        Generated factories call user device functions (and their
+        derivative helpers) by name, but the generated module is
+        imported standalone, so those callables are injected as module
+        attributes before the factory is compiled.
+
+        Returns
+        -------
+        dict[str, Callable]
+            Mapping from printed function name to device callable.
+        """
+        injections = {}
+        for name, func in (self.user_functions or {}).items():
+            if is_devfunc(func):
+                injections[name] = func
+        all_symbols = self.all_symbols or {}
+        for name, obj in all_symbols.items():
+            if name == "__function_aliases__":
+                continue
+            if is_devfunc(obj):
+                injections[name] = obj
+        # The string parser renames user functions (trailing
+        # underscore), and generated source prints the renamed symbol,
+        # so each device callable is injected under its alias too.
+        aliases = all_symbols.get("__function_aliases__", {}) or {}
+        for sym_name, orig_name in aliases.items():
+            func = (self.user_functions or {}).get(orig_name)
+            if func is not None and is_devfunc(func):
+                injections[sym_name] = func
+        return injections
 
     def build(self) -> ODECache:
         """Compile the ``dxdt`` factory and refresh the cache.
@@ -519,7 +554,9 @@ class SymbolicODE(BaseODE):
                 self.equations, self.indices, "dxdt_factory"
             )
         dxdt_factory, _ = self.gen_file.import_function(
-            "dxdt_factory", dxdt_code
+            "dxdt_factory",
+            dxdt_code,
+            injections=self._device_function_injections(),
         )
         dxdt_func = dxdt_factory(constants, numba_precision)
 
@@ -530,7 +567,9 @@ class SymbolicODE(BaseODE):
                 func_name="observables_factory",
             )
         observables_factory, _ = self.gen_file.import_function(
-            "observables_factory", obs_code
+            "observables_factory",
+            obs_code,
+            injections=self._device_function_injections(),
         )
         evaluate_observables = observables_factory(constants, numba_precision)
 
@@ -1077,7 +1116,11 @@ class SymbolicODE(BaseODE):
                     f"Solver helper '{func_type}' is not implemented."
                 )
 
-        factory, was_cached = self.gen_file.import_function(factory_name, code)
+        factory, was_cached = self.gen_file.import_function(
+            factory_name,
+            code,
+            injections=self._device_function_injections(),
+        )
 
         # For prepare_jac, retrieve aux_count from cached factory if needed
         if func_type == "prepare_jac" and self._jacobian_aux_count is None:

--- a/src/cubie/odesystems/symbolic/symbolicODE.py
+++ b/src/cubie/odesystems/symbolic/symbolicODE.py
@@ -77,7 +77,6 @@ from cubie.odesystems.symbolic.codegen import (
 from cubie.odesystems.symbolic.codegen.jacobian import generate_analytical_jvp
 from cubie.odesystems.symbolic.codegen.neumann_convergence import (
     NeumannRHSEvaluator,
-    build_rhs_evaluator,
     check_neumann_convergence,
 )
 from cubie.odesystems.symbolic.odefile import ODEFile
@@ -483,15 +482,16 @@ class SymbolicODE(BaseODE):
     def _get_neumann_evaluator(self) -> NeumannRHSEvaluator:
         """Return the cached finite-difference Jacobian evaluator.
 
-        The evaluator compiles the guarded right-hand side once; the
-        Neumann convergence diagnostic reuses it on every call and only
-        re-runs the cheap numeric spectral-radius check.
+        The evaluator launches the compiled ``dxdt`` device function
+        on the device, so the diagnostic reflects the production code
+        at the compiled precision. The getters fetch the current
+        compiled function and precision on every call, so settings
+        changes are picked up without rebuilding the evaluator.
         """
         if self._neumann_rhs_evaluator is None:
-            self._neumann_rhs_evaluator = build_rhs_evaluator(
-                self.equations,
-                self.indices,
-                user_functions=self._device_function_injections(),
+            self._neumann_rhs_evaluator = NeumannRHSEvaluator(
+                lambda: self.evaluate_f,
+                lambda: self.precision,
             )
         return self._neumann_rhs_evaluator
 
@@ -973,7 +973,6 @@ class SymbolicODE(BaseODE):
         # surfaces for reused code as well as freshly generated code.
         if func_type in _NEUMANN_PRECONDITIONER_TYPES:
             check_neumann_convergence(
-                self.equations,
                 self.indices,
                 evaluator=self._get_neumann_evaluator(),
                 stage_coefficients=stage_coefficients,

--- a/tests/odesystems/symbolic/test_neumann_convergence.py
+++ b/tests/odesystems/symbolic/test_neumann_convergence.py
@@ -84,8 +84,8 @@ def test_converges_for_diagonally_dominant_system(
 ):
     """A diagonally dominant Jacobian reports convergence."""
     result = check_neumann_convergence(
-        diagonally_dominant_system.equations,
         diagonally_dominant_system.indices,
+        diagonally_dominant_system._get_neumann_evaluator(),
     )
     assert result["converges"] is True
     assert result["rho_N"] < 1.0
@@ -98,8 +98,8 @@ def test_diverges_and_warns_for_off_diagonal_heavy_system(
     """A non-dominant Jacobian reports divergence and warns."""
     with pytest.warns(UserWarning):
         result = check_neumann_convergence(
-            off_diagonal_heavy_system.equations,
             off_diagonal_heavy_system.indices,
+            off_diagonal_heavy_system._get_neumann_evaluator(),
         )
     assert result["converges"] is False
     assert result["rho_N"] >= 1.0
@@ -113,8 +113,8 @@ def test_gating_singularity_converges_without_false_divergence(
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
         result = check_neumann_convergence(
-            gating_singularity_system.equations,
             gating_singularity_system.indices,
+            gating_singularity_system._get_neumann_evaluator(),
         )
     assert result["converges"] is True
     assert result["rho_N"] < 1.0
@@ -126,8 +126,8 @@ def test_non_finite_jacobian_reports_not_verified(
 ):
     """A non-finite Jacobian returns the full signature with no verdict."""
     result = check_neumann_convergence(
-        singular_initial_state_system.equations,
         singular_initial_state_system.indices,
+        singular_initial_state_system._get_neumann_evaluator(),
     )
     assert result["converges"] is None
     # The early-return path must expose the same keys as the normal path.
@@ -140,12 +140,12 @@ def test_finite_and_non_finite_paths_share_return_signature(
 ):
     """Both convergence paths return an identical set of keys."""
     finite = check_neumann_convergence(
-        diagonally_dominant_system.equations,
         diagonally_dominant_system.indices,
+        diagonally_dominant_system._get_neumann_evaluator(),
     )
     non_finite = check_neumann_convergence(
-        singular_initial_state_system.equations,
         singular_initial_state_system.indices,
+        singular_initial_state_system._get_neumann_evaluator(),
     )
     assert set(finite) == set(non_finite) == _RESULT_KEYS
 

--- a/tests/odesystems/symbolic/test_user_device_functions.py
+++ b/tests/odesystems/symbolic/test_user_device_functions.py
@@ -1,0 +1,112 @@
+"""End-to-end tests for user device functions in generated systems.
+
+The generated module is imported standalone, so user device callables
+must be injected into its namespace before the factory compiles. These
+tests build systems whose ``dxdt`` calls a real
+``@cuda.jit(device=True)`` function and solve them, comparing against
+an identical system written without user functions.
+"""
+
+import numpy as np
+import pytest
+from numba import cuda
+
+from cubie import create_ODE_system, solve_ivp
+
+
+@pytest.fixture(scope="module")
+def cubed():
+    @cuda.jit(device=True, inline="always")
+    def cubed(x):
+        return x * x * x
+
+    return cubed
+
+
+@pytest.fixture(scope="module")
+def d_cubed():
+    @cuda.jit(device=True, inline="always")
+    def d_cubed(x, index):
+        return 3.0 * x * x
+
+    return d_cubed
+
+
+def _solve(system, method):
+    result = solve_ivp(
+        system,
+        y0={"x": 2.0},
+        method=method,
+        duration=0.5,
+        dt=0.01,
+        save_every=0.05,
+    )
+    assert not np.any(result.status_codes)
+    return result.time_domain_array
+
+
+@pytest.fixture(scope="module")
+def reference_explicit(precision):
+    reference = create_ODE_system(
+        "dx = -x*x*x",
+        states={"x": 2.0},
+        precision=precision,
+        name="userfunc_reference_explicit",
+    )
+    return _solve(reference, "euler")
+
+
+def test_string_system_device_function_solves(cubed, precision,
+                                              reference_explicit):
+    """String-form dxdt calling a device function compiles and solves."""
+    system = create_ODE_system(
+        "dx = -cubed(x)",
+        states={"x": 2.0},
+        user_functions={"cubed": cubed},
+        precision=precision,
+        name="userfunc_string_explicit",
+    )
+    state = _solve(system, "euler")
+    np.testing.assert_allclose(state, reference_explicit, rtol=1e-6)
+
+
+def test_callable_system_device_function_solves(cubed, precision,
+                                                reference_explicit):
+    """Callable-form dxdt calling a device function compiles and solves."""
+
+    def rhs(t, y):
+        dx = -cubed(y.x)  # noqa: F821
+        return [dx]
+
+    system = create_ODE_system(
+        rhs,
+        states={"x": 2.0},
+        user_functions={"cubed": cubed},
+        precision=precision,
+        name="userfunc_callable_explicit",
+    )
+    state = _solve(system, "euler")
+    np.testing.assert_allclose(state, reference_explicit, rtol=1e-6)
+
+
+def test_device_function_with_derivative_implicit_solve(
+    cubed, d_cubed, precision
+):
+    """Jacobian-based helpers resolve the derivative device function."""
+    system = create_ODE_system(
+        "dx = -cubed(x)",
+        states={"x": 2.0},
+        user_functions={"cubed": cubed},
+        user_function_derivatives={"cubed": d_cubed},
+        precision=precision,
+        name="userfunc_string_implicit",
+    )
+    reference = create_ODE_system(
+        "dx = -x*x*x",
+        states={"x": 2.0},
+        precision=precision,
+        name="userfunc_reference_implicit",
+    )
+    state = _solve(system, "backwards_euler")
+    expected = _solve(reference, "backwards_euler")
+    np.testing.assert_allclose(state, expected, rtol=1e-5)

--- a/tests/odesystems/symbolic/test_user_device_functions.py
+++ b/tests/odesystems/symbolic/test_user_device_functions.py
@@ -115,15 +115,15 @@ def test_device_function_with_derivative_implicit_solve(
     np.testing.assert_allclose(state, expected, rtol=1e-5)
 
 
-def test_check_neumann_convergence_fallback_resolves_user_functions(
+def test_check_neumann_convergence_evaluates_device_function(
     cubed, d_cubed, precision
 ):
-    """The evaluator-less path forwards user functions to the builder.
+    """The diagnostic evaluates the compiled ``dxdt`` on the device.
 
-    ``check_neumann_convergence`` builds its own RHS evaluator when no
-    prebuilt evaluator is supplied; the user device callables must reach
-    that evaluator so the diagnostic degrades gracefully instead of
-    raising ``NameError``.
+    For ``dx = -cubed(x)`` at ``x = 2`` the Jacobian is ``-12``; a
+    single-state system is diagonally dominant, so the check returns
+    a genuine verdict even though the user function is a device-only
+    callable.
     """
     system = create_ODE_system(
         "dx = -cubed(x)",
@@ -131,11 +131,13 @@ def test_check_neumann_convergence_fallback_resolves_user_functions(
         user_functions={"cubed": cubed},
         user_function_derivatives={"cubed": d_cubed},
         precision=precision,
-        name="userfunc_neumann_fallback",
+        name="userfunc_neumann_device",
     )
     result = check_neumann_convergence(
-        system.equations,
         system.indices,
-        user_functions=system._device_function_injections(),
+        system._get_neumann_evaluator(),
     )
-    assert result["converges"] in (True, False, None)
+    assert result["converges"] is True
+    np.testing.assert_allclose(
+        result["J_numeric"], [[-12.0]], rtol=5e-2
+    )

--- a/tests/odesystems/symbolic/test_user_device_functions.py
+++ b/tests/odesystems/symbolic/test_user_device_functions.py
@@ -12,6 +12,9 @@ import pytest
 from numba import cuda
 
 from cubie import create_ODE_system, solve_ivp
+from cubie.odesystems.symbolic.codegen.neumann_convergence import (
+    check_neumann_convergence,
+)
 
 
 @pytest.fixture(scope="module")
@@ -110,3 +113,29 @@ def test_device_function_with_derivative_implicit_solve(
     state = _solve(system, "backwards_euler")
     expected = _solve(reference, "backwards_euler")
     np.testing.assert_allclose(state, expected, rtol=1e-5)
+
+
+def test_check_neumann_convergence_fallback_resolves_user_functions(
+    cubed, d_cubed, precision
+):
+    """The evaluator-less path forwards user functions to the builder.
+
+    ``check_neumann_convergence`` builds its own RHS evaluator when no
+    prebuilt evaluator is supplied; the user device callables must reach
+    that evaluator so the diagnostic degrades gracefully instead of
+    raising ``NameError``.
+    """
+    system = create_ODE_system(
+        "dx = -cubed(x)",
+        states={"x": 2.0},
+        user_functions={"cubed": cubed},
+        user_function_derivatives={"cubed": d_cubed},
+        precision=precision,
+        name="userfunc_neumann_fallback",
+    )
+    result = check_neumann_convergence(
+        system.equations,
+        system.indices,
+        user_functions=system._device_function_injections(),
+    )
+    assert result["converges"] in (True, False, None)


### PR DESCRIPTION
## Summary

Fixes #571. Systems whose equations call `@cuda.jit(device=True)` user functions compiled generated source that referenced the callables by name, but the generated module is imported standalone (header imports + `(constants, precision)` factory args only), so JIT compilation raised `NameError` in both the string and Python-function input forms.

## Fix

- `ODEFile._import_function`/`import_function` accept an `injections` mapping set as module attributes after import; `SymbolicODE` passes its device callables at every factory import (dxdt, observables, all solver helpers).
- `SymbolicODE._device_function_injections` collects device callables under every printed name: original names, derivative helpers (`d_<name>` / the derivative's `__name__` from `all_symbols`), **and the string parser's trailing-underscore aliases** — the dxdt/observables generators print the renamed symbol (e.g. `cubed_`), which the issue's codegen-level tests never exercised.
- The Neumann convergence diagnostic evaluates the **compiled `dxdt` device function on the device**: `NeumannRHSEvaluator` launches a small wrapper kernel over the finite-difference stencil states, so every system — with or without user device functions — is judged on the production device code at its compiled precision. The previous host-side lambdify reconstruction is gone, so user device functions get a genuine convergence verdict on real GPUs instead of a skipped check. The simulator's host-raised domain errors and the GPU's non-finite results both funnel into the existing could-not-evaluate path.

## Tests

- `tests/odesystems/symbolic/test_user_device_functions.py` — end-to-end solves of a device-user-function system in string and callable form (explicit euler vs a reference system written without user functions), an implicit `backwards_euler` solve with a device derivative helper exercising the Jacobian/JVP/preconditioner codegen, and a convergence-check test asserting the device-evaluated Jacobian of `dx = -cubed(x)` at `x = 2` is `-12` with a genuine `converges` verdict.
- `tests/odesystems/symbolic/test_neumann_convergence.py` — updated to the evaluator-based `check_neumann_convergence` signature; all convergence/divergence/singularity paths re-verified through the device evaluator.
- Full `tests/odesystems/symbolic`: 472 passed on the real GPU; affected files also pass under the CUDA simulator.

## Docs

`docs/source/user_guide/userfunctions.rst` states device functions are supported end-to-end, includes a runnable `create_ODE_system`/`solve_ivp` example (verified on GPU), and corrects the derivative-helper guidance: it must itself be a device function since it is called from generated device code. `AGENTS.md` states that CUDASIM behaviour is never considered when evaluating code.

## Performance gate (benchmarks/lorenz_mean_runtime.py, defaults)

| Config | A (main 2a733d4) | B (this branch) | Welch z | Verdict |
|---|---|---|---|---|
| fixed (classical-rk4) | 66.49 ± 2.02 ms | 64.49 ± 1.58 ms | -7.78 | no regression |
| adaptive (tsit5) | 26.29 ± 0.91 ms | 25.44 ± 0.46 ms | -8.35 | no regression |

The convergence-diagnostic rework after this table touches only host-side diagnostic code and a build-time wrapper kernel; the solver kernel is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
