### PR TITLE
fix: algorithm steps receive the system's driver count

### DIFF
--- a/src/cubie/integrators/SingleIntegratorRunCore.py
+++ b/src/cubie/integrators/SingleIntegratorRunCore.py
@@ -595,8 +595,10 @@ class SingleIntegratorRunCore(CUDAFactory):
         recognized = set()
         system_recognized = self._system.update(updates_dict, silent=True)
 
-        # Capture n whether or not system updated, in case of an algo/step swap
+        # Capture n and n_drivers whether or not system updated, in case
+        # of an algo/step swap
         updates_dict.update({'n': self._system.sizes.states})
+        updates_dict.update({'n_drivers': self._system.sizes.drivers})
 
         # Capture outputsettings-generated compile settings and pass on
         out_rcgnzd = self._output_functions.update(updates_dict, silent=True)

--- a/src/cubie/integrators/SingleIntegratorRunCore.py
+++ b/src/cubie/integrators/SingleIntegratorRunCore.py
@@ -146,6 +146,7 @@ class SingleIntegratorRunCore(CUDAFactory):
 
         dt = step_control_settings.get("dt", None)
         algorithm_settings["n"] = n
+        algorithm_settings["n_drivers"] = system_sizes.drivers
         if dt is not None:
             algorithm_settings["dt"] = dt
         algorithm_settings["evaluate_driver_at_t"] = evaluate_driver_at_t

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -232,6 +232,36 @@ def test_solve_basic(
     assert hasattr(result, "summaries_array")
 
 
+@pytest.mark.parametrize(
+    "solver_settings_override", [{"algorithm": "firk"}], indirect=True
+)
+def test_solve_firk_with_driver_arrays(
+    solver_mutable,
+    simple_initial_values,
+    simple_parameters,
+    driver_settings,
+):
+    """A FIRK solve with driver arrays completes successfully.
+
+    The FIRK step evaluates drivers at the stage times through its own
+    stage driver stack, which is sized from the algorithm step's driver
+    count; a driven solve exercises that path end to end.
+    """
+    result = solver_mutable.solve(
+        initial_values=simple_initial_values,
+        parameters=simple_parameters,
+        drivers=driver_settings,
+        duration=0.05,
+        save_every=0.02,
+        settling_time=0.0,
+        blocksize=32,
+        grid_type="combinatorial",
+        results_type="full",
+    )
+    assert not np.any(result.status_codes)
+    assert np.all(np.isfinite(result.time_domain_array))
+
+
 def test_solve_with_different_grid_types(
     solver_mutable,
     simple_initial_values,

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -31,6 +31,16 @@ def test_construction_minimal(system):
     assert core._output_functions is not None
 
 
+def test_algorithm_step_receives_driver_count(system):
+    """The algorithm step's config carries the system's driver count."""
+    core = SingleIntegratorRunCore(
+        system=system,
+        algorithm_settings={"algorithm": "firk"},
+    )
+    assert system.sizes.drivers > 0
+    assert core._algo_step.n_drivers == system.sizes.drivers
+
+
 @pytest.mark.parametrize(
     "solver_settings_override",
     [{


### PR DESCRIPTION
## Summary

Fixes #570. `method="radau"` failed on the driven Van der Pol system at every tolerance/preconditioner combination while the undriven system solved cleanly.

## Root cause

`SingleIntegratorRunCore.__init__` set `algorithm_settings["n"]` but never `n_drivers`, so every algorithm step factory was built with the default `n_drivers=0` (the loop got the correct count; the steps did not). FIRK is the only algorithm that sizes its own registered buffer from that count: `stage_driver_stack` was registered with `stage_count * 0 = 0` elements while the generated n-stage residual indexes per-stage driver slots. On the GPU the per-stage slices read/write out of bounds, so Newton consumed garbage driver values for stages beyond the first and could never converge (`NEWTON_BACKTRACKING_NO_SUITABLE_STEP | MAX_NEWTON_ITERATIONS | MAX_LINEAR_ITERATIONS | STEP_TOO_SMALL` on every run); under `NUMBA_ENABLE_CUDASIM=1` the same path raises `IndexError` in `ArrayInterpolator.evaluate_all`. A driven system with a **zero-amplitude** signal failed identically (dynamics identical to the undriven system that succeeds), which isolated the defect to the driver plumbing rather than the forcing dynamics. DIRK/ERK/Rosenbrock read drivers through loop-owned buffers, which is why only FIRK collapsed.

## Fix

`algorithm_settings["n_drivers"] = system_sizes.drivers` at construction, so the step factory registers a correctly sized stage driver stack.

## Verification

- The issue's exact reproduction (16-run driven VdP, radau, default tolerances) completes with all-success statuses on the real GPU; undriven behaviour unchanged.
- Correctness: driven VdP in float64 at rtol=1e-9/atol=1e-12, radau vs tsit5 (independent explicit method): max |diff| = 3.8e-8 (undriven: 2.1e-11).
- `tests/integrators/test_SingleIntegratorRunCore.py::test_algorithm_step_receives_driver_count` pins the root cause — **fails on main, passes with the fix**.
- `tests/batchsolving/test_solver.py::test_solve_firk_with_driver_arrays` exercises the driven FIRK path end-to-end (crashes on main under the CUDA simulator).
- Full `test_solver.py` + `test_SingleIntegratorRun*.py`: 155 passed on real GPU.

Note: the default `firk` (Gauss-Legendre-2) tableau is errorless and therefore fixed-step; its coarse-dt truncation error against adaptive references predates this fix and is unrelated. While writing the regression test I also hit a separate hot-swap defect (`solver.update(algorithm=...)` after a solve loses controller buffer registrations); it is tracked as #580 and fixed in #581.

## Performance gate (benchmarks/lorenz_mean_runtime.py, defaults)

| Config | A (main 2a733d4) | B (this branch) | Welch z | Verdict |
|---|---|---|---|---|
| fixed (classical-rk4) | 66.49 ± 2.02 ms | 64.04 ± 1.03 ms | -10.82 | no regression |
| adaptive (tsit5) | 26.29 ± 0.91 ms | 25.45 ± 0.51 ms | -8.07 | no regression |

(First B invocation's fixed config had std >5% of mean and was discarded and rerun per the gate protocol.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
