### PR TITLE
fix: hot-swapping algorithm or controller keeps survivors' buffer registrations

### DIFF
--- a/src/cubie/AGENTS.md
+++ b/src/cubie/AGENTS.md
@@ -122,10 +122,12 @@ warp-coherent loops, …) live in `writing_cuda_functions.md`.
   `get_child_allocators(parent, child, name)` for device-side allocation; sizes via
   the `*_buffer_size` properties. Locations: `'local'` (thread registers / persistent
   local) vs `'shared'` (block shared memory). The shared/persistent carve-out and
-  buffer **aliasing** are registry-internal. `get_child_allocators` records the
-  parent→child ownership edge, and `clear_parent` cascades through recorded children —
-  this is how hot-swap paths drop a replaced component's whole chain, so registering
-  children through `get_child_allocators` is what keeps swap cleanup working.
+  buffer **aliasing** are registry-internal. `register_child(parent, child, name)`
+  registers a child's buffer footprint with its parent and records the ownership edge
+  (`get_child_allocators` calls it before returning allocators), and `clear_parent`
+  cascades through recorded children — this is how hot-swap paths drop a replaced
+  component's whole chain, so registering children through `register_child` /
+  `get_child_allocators` is what keeps swap cleanup working.
 - **Docs requirement:** a child `AGENTS.md` just **lists the buffers it registers**;
   it does not re-describe the registry mechanics or aliasing.
 

--- a/src/cubie/AGENTS.md
+++ b/src/cubie/AGENTS.md
@@ -122,7 +122,10 @@ warp-coherent loops, …) live in `writing_cuda_functions.md`.
   `get_child_allocators(parent, child, name)` for device-side allocation; sizes via
   the `*_buffer_size` properties. Locations: `'local'` (thread registers / persistent
   local) vs `'shared'` (block shared memory). The shared/persistent carve-out and
-  buffer **aliasing** are registry-internal.
+  buffer **aliasing** are registry-internal. `get_child_allocators` records the
+  parent→child ownership edge, and `clear_parent` cascades through recorded children —
+  this is how hot-swap paths drop a replaced component's whole chain, so registering
+  children through `get_child_allocators` is what keeps swap cleanup working.
 - **Docs requirement:** a child `AGENTS.md` just **lists the buffers it registers**;
   it does not re-describe the registry mechanics or aliasing.
 

--- a/src/cubie/buffer_registry.py
+++ b/src/cubie/buffer_registry.py
@@ -162,8 +162,8 @@ class BufferGroup:
     children : Dict[str, object]
         Child instances whose buffers this parent hosts, keyed by
         the registration base name, recorded by
-        :meth:`BufferRegistry.get_child_allocators`. Re-registering
-        a name replaces the recorded child.
+        :meth:`BufferRegistry.register_child`. Re-registering a
+        name replaces the recorded child.
     _shared_layout : Dict[str, slice] or None
         Cached unified shared memory layout (None when invalid).
     _persistent_layout : Dict[str, slice] or None
@@ -669,7 +669,7 @@ class BufferRegistry:
         """Remove a parent's buffer registrations and its children's.
 
         Cascades through the children recorded by
-        :meth:`get_child_allocators`, so clearing a component also
+        :meth:`register_child`, so clearing a component also
         clears every component whose buffers it hosts (e.g. an
         implicit step's nonlinear solver and that solver's inner
         linear solver). Unknown parents are ignored.
@@ -852,6 +852,71 @@ class BufferRegistry:
             )
         return self._groups[parent].get_allocator(name, zero)
 
+    def register_child(
+        self,
+        parent: object,
+        child: object,
+        name: Optional[str] = None,
+    ) -> Tuple[str, str]:
+        """Register a child's buffer footprint with its parent.
+
+        Registers '{name}_shared' and '{name}_persistent' entries in
+        the parent's group, sized from the child's current buffer
+        registrations, and records the parent-to-child ownership edge
+        that :meth:`clear_parent` cascades through. Idempotent:
+        repeated calls with the same name refresh the entry sizes and
+        replace the recorded child.
+
+        Parameters
+        ----------
+        parent
+            Parent instance that will allocate memory for the child.
+        child
+            Child instance whose buffer requirements should be
+            registered.
+        name
+            Optional base name for the buffer registrations. If not
+            provided, uses 'child_{id(child)}' as the base name.
+
+        Returns
+        -------
+        str
+            Name of the child's shared-memory entry.
+        str
+            Name of the child's persistent-local entry.
+        """
+        child_shared_size = self.shared_buffer_size(child)
+        child_persistent_size = self.persistent_local_buffer_size(child)
+
+        if name is None:
+            base_name = f'child_{id(child)}'
+        else:
+            base_name = name
+
+        shared_name = f'{base_name}_shared'
+        persistent_name = f'{base_name}_persistent'
+
+        precision = parent.precision
+
+        self.register(
+            shared_name,
+            parent,
+            child_shared_size,
+            'shared',
+            precision=precision
+        )
+        self.register(
+            persistent_name,
+            parent,
+            child_persistent_size,
+            'local',
+            persistent=True,
+            precision=precision
+        )
+        self._groups[parent].children[base_name] = child
+
+        return shared_name, persistent_name
+
     def get_child_allocators(
         self,
         parent: object,
@@ -860,9 +925,9 @@ class BufferRegistry:
     ) -> Tuple[Callable, Callable]:
         """Register child buffers and return shared and persistent allocators.
 
-        Registers buffers for a child device function within the parent's
-        buffer group, then returns allocators that provide slices into the
-        parent's shared and persistent memory regions.
+        Delegates registration and ownership recording to
+        :meth:`register_child`, then returns allocators that provide
+        slices into the parent's shared and persistent memory regions.
 
         Parameters
         ----------
@@ -880,58 +945,10 @@ class BufferRegistry:
             Allocator for child's shared memory (returns slice).
         Callable
             Allocator for child's persistent memory (returns slice).
-
-        Notes
-        -----
-        This method computes the shared and persistent buffer sizes for the
-        child, registers them with the parent's buffer group, and returns
-        allocators that slice the parent's memory regions appropriately.
-        The child's buffers are registered with names
-        '{name}_shared' and '{name}_persistent' if name is provided, otherwise
-        'child_{child_id}_shared' and 'child_{child_id}_persistent'.
-        The child instance is recorded under the base name in the
-        parent's group, so :meth:`clear_parent` cascades through it;
-        re-registering the same name replaces the recorded child.
         """
-        # Get child buffer sizes
-        child_shared_size = self.shared_buffer_size(child)
-        child_persistent_size = self.persistent_local_buffer_size(child)
-
-        # Generate buffer names
-        if name is None:
-            child_id = id(child)
-            base_name = f'child_{child_id}'
-        else:
-            base_name = name
-        
-        shared_name = f'{base_name}_shared'
-        persistent_name = f'{base_name}_persistent'
-
-        # Get precision from parent
-        precision = parent.precision
-
-        # Register child buffers with parent
-        self.register(
-            shared_name,
-            parent,
-            child_shared_size,
-            'shared',
-            precision=precision
+        shared_name, persistent_name = self.register_child(
+            parent, child, name
         )
-        self.register(
-            persistent_name,
-            parent,
-            child_persistent_size,
-            'local',
-            persistent=True,
-            precision=precision
-        )
-
-        # Record the ownership edge so clear_parent can cascade;
-        # re-registering a name replaces the recorded child.
-        self._groups[parent].children[base_name] = child
-
-        # Get and return allocators
         alloc_shared = self.get_allocator(shared_name, parent)
         alloc_persistent = self.get_allocator(persistent_name, parent)
 

--- a/src/cubie/buffer_registry.py
+++ b/src/cubie/buffer_registry.py
@@ -671,8 +671,7 @@ class BufferRegistry:
             del self._groups[parent]
 
     def reset(self) -> None:
-        """Clear all buffer registrations, for example when switching
-        algorithms."""
+        """Clear every parent's buffer registrations from the registry."""
         allparents = list(self._groups.keys())
         for parent in allparents:
             self.clear_parent(parent)

--- a/src/cubie/buffer_registry.py
+++ b/src/cubie/buffer_registry.py
@@ -159,6 +159,11 @@ class BufferGroup:
         Parent instance that owns this group.
     entries : Dict[str, CUDABuffer]
         Registered buffers by name.
+    children : Dict[str, object]
+        Child instances whose buffers this parent hosts, keyed by
+        the registration base name, recorded by
+        :meth:`BufferRegistry.get_child_allocators`. Re-registering
+        a name replaces the recorded child.
     _shared_layout : Dict[str, slice] or None
         Cached unified shared memory layout (None when invalid).
     _persistent_layout : Dict[str, slice] or None
@@ -172,6 +177,7 @@ class BufferGroup:
 
     parent: object = field()
     entries: Dict[str, CUDABuffer] = field(factory=dict)
+    children: Dict[str, object] = field(factory=dict, init=False)
     _shared_layout: Optional[Dict[str, slice]] = field(
         default=None, init=False
     )
@@ -660,15 +666,26 @@ class BufferRegistry:
             self._groups[parent].invalidate_layouts()
 
     def clear_parent(self, parent: object) -> None:
-        """Remove all buffer registrations for a parent.
+        """Remove a parent's buffer registrations and its children's.
+
+        Cascades through the children recorded by
+        :meth:`get_child_allocators`, so clearing a component also
+        clears every component whose buffers it hosts (e.g. an
+        implicit step's nonlinear solver and that solver's inner
+        linear solver). Unknown parents are ignored.
 
         Parameters
         ----------
         parent
             Parent instance to remove.
         """
-        if parent in self._groups:
-            del self._groups[parent]
+        group = self._groups.pop(parent, None)
+        if group is None:
+            return
+        # Popping before recursing makes a registration cycle
+        # terminate: a revisited parent has no group and returns.
+        for child in group.children.values():
+            self.clear_parent(child)
 
     def reset(self) -> None:
         """Clear every parent's buffer registrations from the registry."""
@@ -872,6 +889,9 @@ class BufferRegistry:
         The child's buffers are registered with names
         '{name}_shared' and '{name}_persistent' if name is provided, otherwise
         'child_{child_id}_shared' and 'child_{child_id}_persistent'.
+        The child instance is recorded under the base name in the
+        parent's group, so :meth:`clear_parent` cascades through it;
+        re-registering the same name replaces the recorded child.
         """
         # Get child buffer sizes
         child_shared_size = self.shared_buffer_size(child)
@@ -906,6 +926,10 @@ class BufferRegistry:
             persistent=True,
             precision=precision
         )
+
+        # Record the ownership edge so clear_parent can cascade;
+        # re-registering a name replaces the recorded child.
+        self._groups[parent].children[base_name] = child
 
         # Get and return allocators
         alloc_shared = self.get_allocator(shared_name, parent)

--- a/src/cubie/integrators/SingleIntegratorRunCore.py
+++ b/src/cubie/integrators/SingleIntegratorRunCore.py
@@ -666,6 +666,27 @@ class SingleIntegratorRunCore(CUDAFactory):
         # Include unpacked dict keys in recognized set
         return recognized | unpacked_keys
 
+    @staticmethod
+    def _clear_component_buffers(component):
+        """Drop buffer registrations for a replaced component.
+
+        Clears the component's own buffer group and, for algorithm
+        steps that own a nonlinear solver, the groups of the solver
+        chain (e.g. NewtonKrylov and its inner LinearSolver). Buffer
+        groups belonging to surviving components (the loop, and the
+        component not being swapped) are left registered.
+
+        Parameters
+        ----------
+        component
+            Algorithm step or step controller about to be replaced.
+        """
+        buffer_registry.clear_parent(component)
+        child = getattr(component, "solver", None)
+        while child is not None:
+            buffer_registry.clear_parent(child)
+            child = getattr(child, "linear_solver", None)
+
     def _switch_algos(self, updates_dict):
         """Replace the algorithm step when ``updates_dict`` contains a
         new ``"algorithm"`` key and propagate defaults.
@@ -687,7 +708,7 @@ class SingleIntegratorRunCore(CUDAFactory):
 
         new_algo = updates_dict.get("algorithm").lower()
         if new_algo != self.compile_settings.algorithm:
-            buffer_registry.reset()
+            self._clear_component_buffers(self._algo_step)
             old_settings = self._algo_step.settings_dict
             old_settings["algorithm"] = new_algo
             self._algo_step = get_algorithm_step(
@@ -727,7 +748,7 @@ class SingleIntegratorRunCore(CUDAFactory):
         new_controller = updates_dict.get("step_controller").lower()
 
         if new_controller != self.compile_settings.step_controller:
-            buffer_registry.reset()
+            self._clear_component_buffers(self._step_controller)
             old_settings = self._step_controller.settings_dict
             old_settings["step_controller"] = new_controller
             old_settings["algorithm_order"] = updates_dict.get(

--- a/src/cubie/integrators/SingleIntegratorRunCore.py
+++ b/src/cubie/integrators/SingleIntegratorRunCore.py
@@ -666,27 +666,6 @@ class SingleIntegratorRunCore(CUDAFactory):
         # Include unpacked dict keys in recognized set
         return recognized | unpacked_keys
 
-    @staticmethod
-    def _clear_component_buffers(component):
-        """Drop buffer registrations for a replaced component.
-
-        Clears the component's own buffer group and, for algorithm
-        steps that own a nonlinear solver, the groups of the solver
-        chain (e.g. NewtonKrylov and its inner LinearSolver). Buffer
-        groups belonging to surviving components (the loop, and the
-        component not being swapped) are left registered.
-
-        Parameters
-        ----------
-        component
-            Algorithm step or step controller about to be replaced.
-        """
-        buffer_registry.clear_parent(component)
-        child = getattr(component, "solver", None)
-        while child is not None:
-            buffer_registry.clear_parent(child)
-            child = getattr(child, "linear_solver", None)
-
     def _switch_algos(self, updates_dict):
         """Replace the algorithm step when ``updates_dict`` contains a
         new ``"algorithm"`` key and propagate defaults.
@@ -708,7 +687,7 @@ class SingleIntegratorRunCore(CUDAFactory):
 
         new_algo = updates_dict.get("algorithm").lower()
         if new_algo != self.compile_settings.algorithm:
-            self._clear_component_buffers(self._algo_step)
+            buffer_registry.clear_parent(self._algo_step)
             old_settings = self._algo_step.settings_dict
             old_settings["algorithm"] = new_algo
             self._algo_step = get_algorithm_step(
@@ -748,7 +727,7 @@ class SingleIntegratorRunCore(CUDAFactory):
         new_controller = updates_dict.get("step_controller").lower()
 
         if new_controller != self.compile_settings.step_controller:
-            self._clear_component_buffers(self._step_controller)
+            buffer_registry.clear_parent(self._step_controller)
             old_settings = self._step_controller.settings_dict
             old_settings["step_controller"] = new_controller
             old_settings["algorithm_order"] = updates_dict.get(

--- a/src/cubie/integrators/SingleIntegratorRunCore.py
+++ b/src/cubie/integrators/SingleIntegratorRunCore.py
@@ -213,10 +213,10 @@ class SingleIntegratorRunCore(CUDAFactory):
 
 
         # Register algorithm step and controller buffers with loop as parent
-        buffer_registry.get_child_allocators(
+        buffer_registry.register_child(
             self._loop, self._algo_step, name="algorithm"
         )
-        buffer_registry.get_child_allocators(
+        buffer_registry.register_child(
                 self._loop, self._step_controller, name='controller'
         )
 
@@ -641,10 +641,10 @@ class SingleIntegratorRunCore(CUDAFactory):
             step_recognized |= self._apply_inner_tolerance_defaults()
 
         # Re-register algo and controller buffers to refresh sizing in loop
-        buffer_registry.get_child_allocators(
+        buffer_registry.register_child(
                 self._loop, self._algo_step, name='algorithm'
         )
-        buffer_registry.get_child_allocators(
+        buffer_registry.register_child(
                 self._loop, self._step_controller, name='controller'
         )
 
@@ -777,10 +777,10 @@ class SingleIntegratorRunCore(CUDAFactory):
             'evaluate_observables': evaluate_observables}
 
         # Re-register algo and controller buffers to refresh sizing in loop
-        buffer_registry.get_child_allocators(
+        buffer_registry.register_child(
                 self._loop, self._algo_step, name='algorithm'
         )
-        buffer_registry.get_child_allocators(
+        buffer_registry.register_child(
                 self._loop, self._step_controller, name='controller'
         )
 

--- a/src/cubie/integrators/algorithms/backwards_euler.py
+++ b/src/cubie/integrators/algorithms/backwards_euler.py
@@ -125,7 +125,7 @@ class BackwardsEulerStep(ODEImplicitStep):
         config = self.compile_settings
 
         # Register solver child buffers
-        _ = buffer_registry.get_child_allocators(
+        buffer_registry.register_child(
             self, self.solver, name='solver_scratch'
         )
 

--- a/src/cubie/integrators/algorithms/crank_nicolson.py
+++ b/src/cubie/integrators/algorithms/crank_nicolson.py
@@ -126,7 +126,7 @@ class CrankNicolsonStep(ODEImplicitStep):
         config = self.compile_settings
         # Register solver child buffers
 
-        _ = buffer_registry.get_child_allocators(
+        buffer_registry.register_child(
             self, self.solver, name='solver'
         )
 

--- a/src/cubie/integrators/algorithms/generic_dirk.py
+++ b/src/cubie/integrators/algorithms/generic_dirk.py
@@ -230,7 +230,7 @@ class DIRKStep(ODEImplicitStep):
 
         # Register solver scratch and solver persistent buffers so they can
         # be aliased
-        _ = buffer_registry.get_child_allocators(
+        buffer_registry.register_child(
                 self,
                 self.solver,
                 name='solver'

--- a/src/cubie/integrators/algorithms/generic_firk.py
+++ b/src/cubie/integrators/algorithms/generic_firk.py
@@ -237,7 +237,7 @@ class FIRKStep(ODEImplicitStep):
         all_stages_n = tableau.stage_count * n
         stage_driver_stack_elements = tableau.stage_count * config.n_drivers
 
-        _, _ = buffer_registry.get_child_allocators(
+        buffer_registry.register_child(
             self, self.solver, name="solver"
         )
         buffer_registry.register(

--- a/src/cubie/integrators/matrix_free_solvers/newton_krylov.py
+++ b/src/cubie/integrators/matrix_free_solvers/newton_krylov.py
@@ -294,7 +294,7 @@ class NewtonKrylov(MatrixFreeSolver):
         # Record the linear solver as a child at registration time so
         # clear_parent cascades reach it before this solver has built;
         # build refreshes the same named registration with real sizes.
-        _ = buffer_registry.get_child_allocators(
+        buffer_registry.register_child(
             self, self.linear_solver, name="linear_solver"
         )
 

--- a/src/cubie/integrators/matrix_free_solvers/newton_krylov.py
+++ b/src/cubie/integrators/matrix_free_solvers/newton_krylov.py
@@ -291,6 +291,12 @@ class NewtonKrylov(MatrixFreeSolver):
             config.krylov_iters_local_location,
             precision=np_int32,
         )
+        # Record the linear solver as a child at registration time so
+        # clear_parent cascades reach it before this solver has built;
+        # build refreshes the same named registration with real sizes.
+        _ = buffer_registry.get_child_allocators(
+            self, self.linear_solver, name="linear_solver"
+        )
 
     def build(self) -> NewtonKrylovCache:
         """Compile Newton-Krylov solver device function.

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -232,6 +232,38 @@ def test_solve_basic(
     assert hasattr(result, "summaries_array")
 
 
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{"algorithm": "tsit5", "step_controller": "pid"}],
+    indirect=True,
+)
+def test_algorithm_hot_swap_after_solve(
+    solver_mutable,
+    simple_initial_values,
+    simple_parameters,
+    driver_settings,
+):
+    """Swapping the algorithm after a solve leaves the solver usable."""
+    solve_kwargs = dict(
+        initial_values=simple_initial_values,
+        parameters=simple_parameters,
+        drivers=driver_settings,
+        duration=0.05,
+        save_every=0.02,
+        settling_time=0.0,
+        blocksize=32,
+        grid_type="combinatorial",
+        results_type="full",
+    )
+    first = solver_mutable.solve(**solve_kwargs)
+    assert not np.any(first.status_codes)
+
+    solver_mutable.update(algorithm="bogacki-shampine-32")
+    second = solver_mutable.solve(**solve_kwargs)
+    assert not np.any(second.status_codes)
+    assert np.all(np.isfinite(second.time_domain_array))
+
+
 def test_solve_with_different_grid_types(
     solver_mutable,
     simple_initial_values,

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -558,6 +558,57 @@ def test_update_empty_dict_noop(single_integrator_run_mutable):
     assert result == set()
 
 
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{"algorithm": "tsit5", "step_controller": "pid"}],
+    indirect=True,
+)
+def test_algorithm_hot_swap_preserves_controller_buffers(
+    single_integrator_run_mutable,
+):
+    """An algorithm swap keeps the controller's buffer registrations."""
+    run = single_integrator_run_mutable
+    run.update({"algorithm": "bogacki-shampine-32"})
+    assert run.device_function is not None
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{"algorithm": "tsit5", "step_controller": "pid"}],
+    indirect=True,
+)
+def test_controller_hot_swap_preserves_algorithm_buffers(
+    single_integrator_run_mutable,
+):
+    """A controller swap keeps the algorithm's buffer registrations."""
+    run = single_integrator_run_mutable
+    run.update({"step_controller": "gustafsson"})
+    assert run.device_function is not None
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{"algorithm": "backwards_euler"}],
+    indirect=True,
+)
+def test_implicit_algorithm_hot_swap_clears_solver_chain(
+    single_integrator_run_mutable,
+):
+    """Swapping away from an implicit step drops its solver chain groups."""
+    from cubie.buffer_registry import buffer_registry
+
+    run = single_integrator_run_mutable
+    old_step = run._algo_step
+    old_solver = old_step.solver
+    old_linear_solver = old_solver.linear_solver
+
+    run.update({"algorithm": "crank_nicolson"})
+    assert run.device_function is not None
+    assert old_step not in buffer_registry._groups
+    assert old_solver not in buffer_registry._groups
+    assert old_linear_solver not in buffer_registry._groups
+
+
 def test_update_unrecognised_raises(single_integrator_run_mutable):
     """Unrecognised keys raise KeyError when silent=False."""
     with pytest.raises(KeyError, match="Unrecognized"):

--- a/tests/test_buffer_registry.py
+++ b/tests/test_buffer_registry.py
@@ -621,6 +621,76 @@ def test_registry_clear_parent_unknown_noop(
     fresh_registry.clear_parent(output_functions)  # should not raise
 
 
+def test_registry_clear_parent_cascades_through_children(
+    fresh_registry, single_integrator_run, step_controller,
+    output_functions,
+):
+    """clear_parent removes recorded children recursively.
+
+    Chain: single_integrator_run hosts step_controller, which hosts
+    output_functions; clearing the root clears all three groups.
+    """
+    fresh_registry.register("inner", output_functions, 4, "shared")
+    fresh_registry.register("mid", step_controller, 6, "shared")
+    fresh_registry.get_child_allocators(
+        step_controller, output_functions, name="inner_child",
+    )
+    fresh_registry.register(
+        "outer", single_integrator_run, 8, "shared",
+    )
+    fresh_registry.get_child_allocators(
+        single_integrator_run, step_controller, name="mid_child",
+    )
+
+    fresh_registry.clear_parent(single_integrator_run)
+    assert single_integrator_run not in fresh_registry._groups
+    assert step_controller not in fresh_registry._groups
+    assert output_functions not in fresh_registry._groups
+
+
+def test_registry_child_reregistration_replaces_recorded_child(
+    fresh_registry, single_integrator_run, step_controller,
+    output_functions,
+):
+    """Re-registering a child name replaces the recorded child.
+
+    After the same base name is registered with a new child, a
+    cascade from the parent clears the new child only; the replaced
+    child's group survives.
+    """
+    fresh_registry.register("a", step_controller, 6, "shared")
+    fresh_registry.get_child_allocators(
+        single_integrator_run, step_controller, name="component",
+    )
+    fresh_registry.register("b", output_functions, 4, "shared")
+    fresh_registry.get_child_allocators(
+        single_integrator_run, output_functions, name="component",
+    )
+
+    fresh_registry.clear_parent(single_integrator_run)
+    assert output_functions not in fresh_registry._groups
+    assert step_controller in fresh_registry._groups
+    fresh_registry.clear_parent(step_controller)
+
+
+def test_registry_clear_parent_terminates_on_cycle(
+    fresh_registry, single_integrator_run, step_controller,
+):
+    """A registration cycle clears both groups without recursing."""
+    fresh_registry.register("a", single_integrator_run, 4, "shared")
+    fresh_registry.register("b", step_controller, 4, "shared")
+    fresh_registry.get_child_allocators(
+        single_integrator_run, step_controller, name="down",
+    )
+    fresh_registry.get_child_allocators(
+        step_controller, single_integrator_run, name="up",
+    )
+
+    fresh_registry.clear_parent(single_integrator_run)
+    assert single_integrator_run not in fresh_registry._groups
+    assert step_controller not in fresh_registry._groups
+
+
 def test_registry_reset_clears_all(
     fresh_registry, step_controller, output_functions,
 ):

--- a/tests/test_buffer_registry.py
+++ b/tests/test_buffer_registry.py
@@ -632,13 +632,13 @@ def test_registry_clear_parent_cascades_through_children(
     """
     fresh_registry.register("inner", output_functions, 4, "shared")
     fresh_registry.register("mid", step_controller, 6, "shared")
-    fresh_registry.get_child_allocators(
+    fresh_registry.register_child(
         step_controller, output_functions, name="inner_child",
     )
     fresh_registry.register(
         "outer", single_integrator_run, 8, "shared",
     )
-    fresh_registry.get_child_allocators(
+    fresh_registry.register_child(
         single_integrator_run, step_controller, name="mid_child",
     )
 
@@ -679,10 +679,10 @@ def test_registry_clear_parent_terminates_on_cycle(
     """A registration cycle clears both groups without recursing."""
     fresh_registry.register("a", single_integrator_run, 4, "shared")
     fresh_registry.register("b", step_controller, 4, "shared")
-    fresh_registry.get_child_allocators(
+    fresh_registry.register_child(
         single_integrator_run, step_controller, name="down",
     )
-    fresh_registry.get_child_allocators(
+    fresh_registry.register_child(
         step_controller, single_integrator_run, name="up",
     )
 


### PR DESCRIPTION
## Summary

Fixes #580. `solver.update(algorithm=...)` (or `step_controller=...`) on a live integrator run crashed on the next build: `_switch_algos`/`_switch_controllers` called `buffer_registry.reset()`, wiping **every** buffer group — including those of the surviving components. After an algorithm swap, an adaptive controller's `timestep_buffer` group was gone and `AdaptivePIDController.build_controller` failed inside `buffer_registry.get_allocator`; a controller swap symmetrically dropped the algorithm step's buffers. Fixed-step and I controllers register no buffers, which is why default-controller swaps in CI never tripped it.

## Fix

The registry itself now owns the cleanup, using ownership information it already sees:

- `register_child(parent, child, name)` registers the child's shared/persistent footprint entries under the parent and records the parent→child edge in the parent's `BufferGroup` (`children`, keyed by the registration base name, so re-registering a name replaces the recorded child — the same silent-replace semantics as buffer entries). `get_child_allocators` delegates to it and returns the allocators; call sites that registered children purely for the side effect (implicit steps, DIRK, FIRK, NewtonKrylov, the loop-sizing refreshes) call `register_child` directly.
- `clear_parent` cascades through recorded children, popping each group before recursing so a registration cycle terminates instead of recursing forever.
- The swap paths call `buffer_registry.clear_parent(old_component)` directly. `SingleIntegratorRunCore` carries no knowledge of component internals: any ownership shape — implicit step → NewtonKrylov → LinearSolver today, differently-shaped inner solvers or buffer-owning controller children tomorrow — is cleaned up as long as children register through `register_child` / `get_child_allocators`, which is the existing house rule.
- `NewtonKrylov.register_buffers` records its linear solver child at registration time via `register_child` (matching the implicit steps' pattern) so the cascade reaches the full chain even before a first build; `build` refreshes the same named registration with real sizes.

Surviving groups (loop, controller on algo swap, algo on controller swap) stay registered; the loop's `algorithm`/`controller` child-size entries are refreshed by the existing sizing-refresh calls (now `register_child`) in `update()` and `build()`.

## Tests

Regression tests (all fail on main, pass with the fix):
- `test_SingleIntegratorRunCore.py::test_algorithm_hot_swap_preserves_controller_buffers` — tsit5+pid → bogacki-shampine-32, then build.
- `test_SingleIntegratorRunCore.py::test_controller_hot_swap_preserves_algorithm_buffers` — pid → gustafsson, then build.
- `test_SingleIntegratorRunCore.py::test_implicit_algorithm_hot_swap_clears_solver_chain` — backwards_euler → crank_nicolson; asserts the old step/NewtonKrylov/LinearSolver groups are gone from the registry (the step is swapped before ever building, which is exactly the case the registration-time edge recording covers).
- `test_solver.py::test_algorithm_hot_swap_after_solve` — the issue's scenario: solve, swap algorithm, solve again with success statuses.

Registry-level unit tests (`test_buffer_registry.py`): cascade through a three-level chain, same-name re-registration replacing the recorded child (replaced child's group survives a later cascade), and cycle termination.

`test_buffer_registry.py` + `test_SingleIntegratorRunCore.py` + `test_solver.py` + `matrix_free_solvers`: 322 passed on real GPU; 321 on the simulator lane.

## Performance gate (benchmarks/lorenz_mean_runtime.py, defaults)

The benchmark never swaps algorithms, so the executed code path is identical to main. Initial B runs flagged ±3–5 z in both directions on repeats; a main-vs-main control confirmed session noise. Full record against A = 63.53 ± 0.57 / 25.42 ± 0.38 ms (main 2a733d4):

| Run | fixed (classical-rk4) | z | adaptive (tsit5) | z |
|---|---|---|---|---|
| main (control) | 63.45 ± 0.53 ms | -1.00 | 25.35 ± 0.34 ms | -1.30 |
| branch #1 | 63.86 ± 0.77 ms | +3.42 | 25.38 ± 0.33 ms | -0.87 |
| branch #2 | 63.25 ± 0.50 ms | -3.67 | 25.25 ± 0.35 ms | -3.20 |
| branch #3 | 63.17 ± 0.44 ms | -4.95 | 25.35 ± 0.35 ms | -1.30 |

Branch means straddle main's own repeat range (63.23–63.53 ms): no regression. The registry rework after these runs touches host-side registration/cleanup bookkeeping only; no device code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

