### PR TITLE
fix: manual proportion of a formerly-auto instance survives rebalance

### DIFF
--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -649,6 +649,7 @@ class MemoryManager:
         if proportion < 0 or proportion > 1:
             raise ValueError("Proportion must be between 0 and 1")
         if instance_id in self._auto_pool:
+            self._auto_pool.remove(instance_id)
             self._add_manual_proportion(instance, proportion)
         else:
             self._manual_pool.remove(instance_id)

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -1365,3 +1365,19 @@ def test_cupy_stream_wrapper(stream1, stream2):
     # Check that the default current stream is untouched
     assert cp.cuda.get_current_stream().ptr != _numba_stream_ptr(stream1)
     assert cp.cuda.get_current_stream().ptr != _numba_stream_ptr(stream2)
+
+
+def test_set_manual_proportion_from_auto_pool(mgr):
+    """set_manual_proportion moves an auto instance to the manual pool.
+
+    The instance must leave the auto pool so the subsequent auto-pool
+    rebalance cannot overwrite the requested manual proportion.
+    """
+    inst = DummyClass()
+    mgr.register(inst)
+    instance_id = id(inst)
+    assert instance_id in mgr._auto_pool
+    mgr.set_manual_proportion(inst, 0.4)
+    assert instance_id in mgr._manual_pool
+    assert instance_id not in mgr._auto_pool
+    assert abs(mgr.proportion(inst) - 0.4) < 1e-6


### PR DESCRIPTION
## Summary
`MemoryManager.set_manual_proportion` removes the instance from the auto pool before adding the manual proportion. Previously the instance stayed in both pools, and `_rebalance_auto_pool` immediately overwrote the requested manual proportion with an auto-computed share (requesting 0.4 yielded 0.6). Regression test included; found during the coverage audit (companion to #582).

## Benchmark (lorenz_mean_runtime.py, A = main, B = this branch)
| config | A (main) | B (branch) | z | verdict |
|---|---|---|---|---|
| fixed (classical-rk4) | 63.10 ± 0.42 ms | 63.05 ± 0.51 ms | -0.79 | no significant difference |
| adaptive (tsit5) | 25.19 ± 0.29 ms | 25.09 ± 0.20 ms | -2.84 | no significant difference |

🤖 Generated with [Claude Code](https://claude.com/claude-code)