### PR TITLE
fix: as_pandas returns an empty summaries frame with no active metrics

### DIFF
--- a/src/cubie/batchsolving/solveresult.py
+++ b/src/cubie/batchsolving/solveresult.py
@@ -449,7 +449,7 @@ class SolveResult:
                     [[f"run_{run}"], df.columns]
                 )
             else:
-                summaries_dfs.append(pd.DataFrame)
+                summaries_dfs.append(pd.DataFrame())
 
         time_domain_df = pd.concat(time_dfs, axis=1)
         summaries_df = pd.concat(summaries_dfs, axis=1)

--- a/tests/batchsolving/test_solveresult.py
+++ b/tests/batchsolving/test_solveresult.py
@@ -711,7 +711,7 @@ def test_as_pandas_without_summaries_returns_a_dataframe(
 
     When no summary metrics are active, each run contributes an empty
     per-run DataFrame so the concatenated ``summaries`` entry is a
-    real (empty) DataFrame rather than raising.
+    real (empty) DataFrame.
     """
     result = SolveResult.from_solver(solver_no_summaries_arrays)
     assert result.active_outputs.state_summaries is False

--- a/tests/batchsolving/test_solveresult.py
+++ b/tests/batchsolving/test_solveresult.py
@@ -681,31 +681,13 @@ class TestSolveSpecFields:
             assert hasattr(spec, attr), f"SolveSpec missing attribute: {attr}"
 
 
-@pytest.fixture(scope="session")
-def solver_no_summaries_arrays(system, solver_settings):
-    """Solver run with only state output (no summary types active)."""
-    solver = Solver(
-        system,
-        output_types=["state"],
-        memory_manager=solver_settings["memory_manager"],
-        stream_group="solver_no_summaries_group",
-    )
-    solver.solve(
-        initial_values={
-            list(system.initial_values.names)[0]: [1.0, 2.0],
-        },
-        parameters={
-            list(system.parameters.names)[0]: [0.1, 0.2],
-        },
-        duration=0.02,
-        save_every=0.01,
-        dt=0.01,
-    )
-    return solver
-
-
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{"output_types": ["state"]}],
+    indirect=True,
+)
 def test_as_pandas_without_summaries_returns_a_dataframe(
-    solver_no_summaries_arrays,
+    solver_with_arrays,
 ):
     """as_pandas returns a usable summaries DataFrame with no metrics.
 
@@ -713,7 +695,7 @@ def test_as_pandas_without_summaries_returns_a_dataframe(
     per-run DataFrame so the concatenated ``summaries`` entry is a
     real (empty) DataFrame.
     """
-    result = SolveResult.from_solver(solver_no_summaries_arrays)
+    result = SolveResult.from_solver(solver_with_arrays)
     assert result.active_outputs.state_summaries is False
     assert result.active_outputs.observable_summaries is False
 

--- a/tests/batchsolving/test_solveresult.py
+++ b/tests/batchsolving/test_solveresult.py
@@ -679,3 +679,44 @@ class TestSolveSpecFields:
 
         for attr in expected_attrs:
             assert hasattr(spec, attr), f"SolveSpec missing attribute: {attr}"
+
+
+@pytest.fixture(scope="session")
+def solver_no_summaries_arrays(system, solver_settings):
+    """Solver run with only state output (no summary types active)."""
+    solver = Solver(
+        system,
+        output_types=["state"],
+        memory_manager=solver_settings["memory_manager"],
+        stream_group="solver_no_summaries_group",
+    )
+    solver.solve(
+        initial_values={
+            list(system.initial_values.names)[0]: [1.0, 2.0],
+        },
+        parameters={
+            list(system.parameters.names)[0]: [0.1, 0.2],
+        },
+        duration=0.02,
+        save_every=0.01,
+        dt=0.01,
+    )
+    return solver
+
+
+def test_as_pandas_without_summaries_returns_a_dataframe(
+    solver_no_summaries_arrays,
+):
+    """as_pandas returns a usable summaries DataFrame with no metrics.
+
+    When no summary metrics are active, each run contributes an empty
+    per-run DataFrame so the concatenated ``summaries`` entry is a
+    real (empty) DataFrame rather than raising.
+    """
+    result = SolveResult.from_solver(solver_no_summaries_arrays)
+    assert result.active_outputs.state_summaries is False
+    assert result.active_outputs.observable_summaries is False
+
+    pandas_dict = result.as_pandas
+    assert isinstance(pandas_dict["summaries"], pd.DataFrame)
+    assert pandas_dict["summaries"].empty


### PR DESCRIPTION
## Summary
`SolveResult.as_pandas` appends an empty per-run `pd.DataFrame()` instance when no summary metrics are active, so the concatenated `summaries` entry is a real (empty) DataFrame. Previously the `pd.DataFrame` class object itself was appended and `pd.concat` raised `TypeError: cannot concatenate object of type '<class 'type'>'` for any state-only solve. Regression test (state-only solver fixture) included; found during the coverage audit (companion to #582).

## Benchmark (lorenz_mean_runtime.py, A = main, B = this branch)
| config | A (main) | B (branch) | z | verdict |
|---|---|---|---|---|
| fixed (classical-rk4) | 63.10 ± 0.42 ms | 62.98 ± 0.38 ms | -2.07 | no significant difference |
| adaptive (tsit5) | 25.19 ± 0.29 ms | 25.12 ± 0.22 ms | -1.80 | no significant difference |

🤖 Generated with [Claude Code](https://claude.com/claude-code)