### PR TITLE
fix: underived states convert to observables instead of crashing

### DIFF
--- a/src/cubie/odesystems/symbolic/indexedbasemaps.py
+++ b/src/cubie/odesystems/symbolic/indexedbasemaps.py
@@ -127,6 +127,9 @@ class IndexedBaseMap:
     def pop(self, sym: sp.Symbol) -> None:
         """Remove a symbol from the indexed base.
 
+        Surviving symbols are reindexed so every reference stays
+        within the shrunken base's bounds.
+
         Parameters
         ----------
         sym
@@ -144,6 +147,9 @@ class IndexedBaseMap:
             self.base_name, shape=(len(self.ref_map),), real=self.real
         )
         self.length = len(self.ref_map)
+        for index, existing in enumerate(self.ref_map):
+            self.index_map[existing] = index
+            self.ref_map[existing] = self.base[index]
 
     def push(self, sym: sp.Symbol, default_value: float = 0.0, unit: str = "dimensionless") -> None:
         """Append a new symbol to the indexed base.

--- a/src/cubie/odesystems/symbolic/parsing/parser.py
+++ b/src/cubie/odesystems/symbolic/parsing/parser.py
@@ -978,22 +978,26 @@ def _lhs_pass_sympy(
         )
 
     if underived_states:
+        # underived_states holds dxdt names ("dz"); the state itself
+        # is the name with the derivative prefix stripped ("z").
+        underived_names = {name[1:] for name in underived_states}
         warn(
-            f"States {underived_states} have no derivative equation. "
+            f"States {underived_names} have no derivative equation. "
             f"Converting to observables.",
             EquationWarning,
         )
-        for state in underived_states:
-            s_sym = sp.Symbol(state, real=True)
-            if state in observables:
+        for dx_name in underived_states:
+            state_name = dx_name[1:]
+            state_sym = sp.Symbol(state_name, real=True)
+            if state_name in observables.symbol_map:
                 raise ValueError(
-                    f"State {state} is both observable and state. "
+                    f"State {state_name} is both observable and state. "
                     f"Cannot convert."
                 )
-            observables.push(s_sym)
-            states.pop(s_sym)
-            dxdt.pop(s_sym)
-            observable_names.add(state)
+            observables.push(state_sym)
+            states.pop(state_sym)
+            dxdt.pop(sp.Symbol(dx_name, real=True))
+            observable_names.add(state_name)
 
     return anonymous_auxiliaries
 
@@ -1297,24 +1301,28 @@ def _lhs_pass(
         raise ValueError(f"Observables {missing_obs} are never assigned to.")
 
     if underived_states:
+        # underived_states holds dxdt names ("dz"); the state itself
+        # is the name with the derivative prefix stripped ("z").
+        underived_names = {name[1:] for name in underived_states}
         warn(
-            f"States {underived_states} have no associated derivative "
+            f"States {underived_names} have no associated derivative "
             f"term. In the Cubie world, this makes it an 'observable'. "
-            f"{underived_states} have been moved from states to observables.",
+            f"{underived_names} have been moved from states to observables.",
             EquationWarning,
         )
-        for state in underived_states:
-            s_sym = sp.Symbol(state, real=True)
-            if state in observables:
+        for dx_name in underived_states:
+            state_name = dx_name[1:]
+            state_sym = sp.Symbol(state_name, real=True)
+            if state_name in observables.symbol_map:
                 raise ValueError(
-                    f"State {state} is already both observable and state. "
-                    f"It needs to be an observable if it has no derivative"
-                    f"term."
+                    f"State {state_name} is already both observable and "
+                    f"state. It needs to be an observable if it has no "
+                    f"derivative term."
                 )
-            observables.push(s_sym)
-            states.pop(s_sym)
-            dxdt.pop(s_sym)
-            observable_names.add(state)
+            observables.push(state_sym)
+            states.pop(state_sym)
+            dxdt.pop(sp.Symbol(dx_name, real=True))
+            observable_names.add(state_name)
 
     return anonymous_auxiliaries
 

--- a/tests/odesystems/symbolic/test_indexedbasemaps.py
+++ b/tests/odesystems/symbolic/test_indexedbasemaps.py
@@ -106,6 +106,9 @@ class TestIndexedBaseMap:
         assert "y" not in base_map.symbol_map
         assert base_map.length == initial_length - 1
         assert base_map.base.shape == (2,)
+        assert base_map.index_map == {x: 0, z: 1}
+        assert str(base_map.ref_map[x]) == "test[0]"
+        assert str(base_map.ref_map[z]) == "test[1]"
 
     def test_push_symbol(self):
         """Test adding a symbol to the map."""

--- a/tests/odesystems/symbolic/test_parser.py
+++ b/tests/odesystems/symbolic/test_parser.py
@@ -17,6 +17,7 @@ from cubie.odesystems.symbolic.parsing.parser import (
     TIME_SYMBOL,
     _detect_input_type,
     _lhs_pass,
+    _lhs_pass_sympy,
     _normalize_sympy_equations,
     _process_calls,
     _process_parameters,
@@ -1376,3 +1377,44 @@ class TestDerivativeNotation:
         anon_aux = _lhs_pass(lines, ib, strict=True)
 
         assert "d" in anon_aux
+
+
+class TestUnderivedStateConversion:
+    """A declared state without a derivative becomes an observable.
+
+    The conversion block strips the derivative prefix from the
+    outstanding dxdt name, moves the state symbol into observables,
+    and removes the state and dxdt entries.
+    """
+
+    def test_string_underived_state_becomes_observable(self):
+        """String pathway: an underived state is converted, not crashed."""
+        imap = IndexedBases.from_user_inputs(
+            ["x", "z"], ["k"], [], [], []
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _lhs_pass(["dx = x"], imap, strict=True)
+        assert any(
+            issubclass(w.category, EquationWarning) for w in caught
+        )
+        assert "z" in imap.observable_names
+        assert "z" not in imap.state_names
+        assert "dz" not in imap.dxdt_names
+
+    def test_sympy_underived_state_becomes_observable(self):
+        """SymPy pathway: an underived state is converted, not crashed."""
+        imap = IndexedBases.from_user_inputs(
+            ["x", "z"], ["k"], [], [], []
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _lhs_pass_sympy(
+                [(sp.Symbol("dx"), sp.Symbol("x"))], imap, strict=True
+            )
+        assert any(
+            issubclass(w.category, EquationWarning) for w in caught
+        )
+        assert "z" in imap.observable_names
+        assert "z" not in imap.state_names
+        assert "dz" not in imap.dxdt_names

--- a/tests/odesystems/symbolic/test_parser.py
+++ b/tests/odesystems/symbolic/test_parser.py
@@ -1402,6 +1402,25 @@ class TestUnderivedStateConversion:
         assert "z" not in imap.state_names
         assert "dz" not in imap.dxdt_names
 
+    def test_first_declared_underived_state_reindexes_survivors(self):
+        """Converting a non-final state leaves survivors in bounds."""
+        imap = IndexedBases.from_user_inputs(
+            ["z", "x"], ["k"], [], [], []
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _lhs_pass(["dx = x"], imap, strict=True)
+        assert any(
+            issubclass(w.category, EquationWarning) for w in caught
+        )
+        x_sym = sp.Symbol("x", real=True)
+        dx_sym = sp.Symbol("dx", real=True)
+        assert imap.states.index_map == {x_sym: 0}
+        assert str(imap.states.ref_map[x_sym]) == "state[0]"
+        assert imap.states.base.shape == (1,)
+        assert imap.dxdt.index_map == {dx_sym: 0}
+        assert str(imap.dxdt.ref_map[dx_sym]) == "out[0]"
+
     def test_sympy_underived_state_becomes_observable(self):
         """SymPy pathway: an underived state is converted, not crashed."""
         imap = IndexedBases.from_user_inputs(


### PR DESCRIPTION
## Summary
Declaring a state with no derivative equation converts it to an observable, as the parser warning has always promised. Both equation-parsing pathways now strip the derivative prefix from the outstanding dxdt name before operating on the maps: membership is tested against `observables.symbol_map`, the state symbol moves to observables, and the state and dxdt entries are removed under their own keys. Previously `create_ODE_system(dxdt=["dx = -k*x"], states={"x": 1.0, "z": 0.0})` crashed with `TypeError: argument of type 'IndexedBaseMap' is not a container or iterable`, and the block also operated on dxdt names ("dz") where state names ("z") were required. Regression tests for both pathways included; found during the coverage audit (companion to #582).

## Benchmark (lorenz_mean_runtime.py, A = main, B = this branch)
| config | A (main) | B (branch) | z | verdict |
|---|---|---|---|---|
| fixed (classical-rk4) | 63.10 ± 0.42 ms | 62.99 ± 0.38 ms | -1.93 | no significant difference |
| adaptive (tsit5) | 25.19 ± 0.29 ms | 25.12 ± 0.23 ms | -1.96 | no significant difference |

🤖 Generated with [Claude Code](https://claude.com/claude-code)