### PR TITLE
fix: half powers lower to math.sqrt instead of pow

### DIFF
--- a/src/cubie/odesystems/symbolic/codegen/numba_cuda_printer.py
+++ b/src/cubie/odesystems/symbolic/codegen/numba_cuda_printer.py
@@ -274,6 +274,13 @@ class CUDAPrinter(PythonCodePrinter):
         remaining integer exponents are wrapped with precision() so
         the pow stays in the working precision.
 
+        Half powers print as ``math.sqrt`` calls: ``x**(1/2)`` becomes
+        ``math.sqrt(x)`` and ``x**(-1/2)`` becomes
+        ``(precision(1)/math.sqrt(x))``. Numba lowers a float ``**``
+        with a 0.5 exponent to a generic pow expansion containing no
+        sqrt instruction, which is several times slower than the
+        dedicated sqrt in both precisions.
+
         A symbol exponent naming a factory-scope constant (listed in
         ``constant_names``) prints as its integer-exponent alias so
         integral constant values lower to multiplication chains
@@ -285,6 +292,13 @@ class CUDAPrinter(PythonCodePrinter):
         PREC = sp.printing.precedence.precedence
         base_str = self.parenthesize(expr.base, PREC(expr))
         exp_expr = expr.exp
+
+        if isinstance(exp_expr, (sp.Float, sp.Rational)):
+            half_check = float(exp_expr)
+            if half_check == 0.5:
+                return f"math.sqrt({base_str})"
+            if half_check == -0.5:
+                return f"(precision(1)/math.sqrt({base_str}))"
 
         if exp_expr.is_Integer:
             exponent_value = int(exp_expr)

--- a/tests/odesystems/symbolic/test_cuda_printer.py
+++ b/tests/odesystems/symbolic/test_cuda_printer.py
@@ -1,6 +1,10 @@
-import sympy as sp
+import math
 import re
 
+import numpy as np
+import sympy as sp
+
+from cubie import create_ODE_system, solve_ivp
 from cubie.odesystems.symbolic.codegen import (
     CUDAPrinter,
     print_cuda,
@@ -152,6 +156,44 @@ class TestCUDAPrinter:
         assert "**" not in result
         value = eval(result, {"_cse0": 2.0, "precision": float})
         assert value == 0.25
+
+    def test_sqrt_prints_as_math_sqrt(self):
+        """sp.sqrt lowers to a math.sqrt call, not a pow."""
+        x = sp.Symbol("x")
+        result = print_cuda(sp.sqrt(x))
+        assert result == "math.sqrt(x)"
+        value = eval(result, {"x": 9.0, "math": math})
+        assert value == 3.0
+
+    def test_float_half_power_prints_as_math_sqrt(self):
+        """A Float 0.5 exponent lowers to math.sqrt like Rational 1/2."""
+        x = sp.Symbol("x")
+        result = print_cuda(x ** sp.Float(0.5))
+        assert result == "math.sqrt(x)"
+
+    def test_compound_base_sqrt_parenthesised(self):
+        """sqrt of a compound base keeps the base parenthesised."""
+        a, b = sp.symbols("a b")
+        result = print_cuda(sp.sqrt(a + b))
+        assert result == "math.sqrt((a + b))"
+
+    def test_negative_half_power_prints_reciprocal_sqrt(self):
+        """x**-1/2 prints as a precision-cast reciprocal of math.sqrt."""
+        x = sp.Symbol("x")
+        for exponent in (sp.Rational(-1, 2), sp.Float(-0.5)):
+            result = print_cuda(x ** exponent)
+            assert result == "(precision(1)/math.sqrt(x))"
+            value = eval(
+                result,
+                {"x": 4.0, "precision": float, "math": math},
+            )
+            assert value == 0.5
+
+    def test_three_half_power_keeps_pow(self):
+        """Non-half fractional exponents keep the precision-wrapped pow."""
+        x = sp.Symbol("x")
+        result = print_cuda(x ** sp.Rational(3, 2))
+        assert result == "x**precision(3/2)"
 
     def test_higher_integer_power_wraps_exponent(self):
         """Test that x**4 wraps its exponent with precision()."""
@@ -578,3 +620,32 @@ class TestConstantExponentAlias:
             constant_names={"n"},
         )
         assert lines == ["out = x**_cubie_codegen_iexp_n"]
+
+
+def test_sqrt_rhs_matches_analytic_solution(precision):
+    """A sqrt right-hand side integrates to its analytic solution.
+
+    ``dx = -sqrt(x)`` with ``x(0) = 4`` has the exact solution
+    ``x(t) = (2 - t/2)**2``, so the generated ``math.sqrt`` lowering is
+    checked end to end against a closed-form reference.
+    """
+    system = create_ODE_system(
+        "dx = -sqrt(x)",
+        states={"x": 4.0},
+        precision=precision,
+        name="sqrt_lowering_analytic",
+    )
+    result = solve_ivp(
+        system,
+        y0={"x": 4.0},
+        method="tsit5",
+        duration=1.0,
+        dt=0.01,
+        save_every=0.1,
+        output_types=["state", "time"],
+    )
+    assert not np.any(result.status_codes)
+    time = np.asarray(result.time).reshape(-1)
+    state = np.squeeze(result.time_domain_array)
+    expected = (2.0 - time / 2.0) ** 2
+    np.testing.assert_allclose(state, expected, rtol=1e-4, atol=1e-5)

--- a/tests/odesystems/symbolic/test_cuda_printer.py
+++ b/tests/odesystems/symbolic/test_cuda_printer.py
@@ -2,6 +2,7 @@ import math
 import re
 
 import numpy as np
+import pytest
 import sympy as sp
 
 from cubie import create_ODE_system, solve_ivp
@@ -622,18 +623,24 @@ class TestConstantExponentAlias:
         assert lines == ["out = x**_cubie_codegen_iexp_n"]
 
 
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{"precision": np.float32}, {"precision": np.float64}],
+    indirect=True,
+)
 def test_sqrt_rhs_matches_analytic_solution(precision):
     """A sqrt right-hand side integrates to its analytic solution.
 
     ``dx = -sqrt(x)`` with ``x(0) = 4`` has the exact solution
     ``x(t) = (2 - t/2)**2``, so the generated ``math.sqrt`` lowering is
-    checked end to end against a closed-form reference.
+    checked end to end against a closed-form reference in both
+    precisions.
     """
     system = create_ODE_system(
         "dx = -sqrt(x)",
         states={"x": 4.0},
         precision=precision,
-        name="sqrt_lowering_analytic",
+        name=f"sqrt_lowering_analytic_{np.dtype(precision).name}",
     )
     result = solve_ivp(
         system,


### PR DESCRIPTION
## Summary

Answers the sqrt residual flagged in #582: printing `sp.sqrt` as `x**precision(1/2)` **is a perf regression**, and this PR fixes it. `sp.sqrt` is structurally `Pow`, so it bypassed the `CUDA_FUNCTIONS['sqrt'] = 'math.sqrt'` mapping and reached `_print_Pow`'s fallback. Numba lowers a float `**` with a 0.5 exponent to a generic pow expansion whose PTX contains **no sqrt instruction at all**.

## Evidence (T4, per-operation microbenchmark, 2^20 threads x 256 sqrt ops)

| precision | `x**0.5` | `math.sqrt(x)` | ratio |
|---|---|---|---|
| float32 | 1.356 ± 0.056 ms | 0.330 ± 0.060 ms | **4.1x** |
| float64 | 90.694 ± 2.282 ms | 10.116 ± 0.313 ms | **9.0x** |

PTX inspection: the `math.sqrt` kernels contain 54 (f32) / 38 (f64) sqrt mentions; the pow kernels contain zero.

## Fix

`_print_Pow` special-cases half powers ahead of the integer-exponent handling: `x**(1/2)` prints as `math.sqrt(x)` and `x**(-1/2)` as `(precision(1)/math.sqrt(x))`, for both `Rational` and `Float` exponents (`Float(0.5)` does not compare equal to `Rational(1,2)` structurally, so the match is numeric). Negative halves cover the `1/(2*sqrt(x))` terms SymPy produces when differentiating sqrt for Jacobians/JVPs. Other fractional exponents (e.g. `3/2`) keep the precision-wrapped pow; the existing square/cube multiplication rewrites and integer-exponent handling are untouched.

## Tests

- Printer units: `sqrt(x)`, `Float(0.5)` exponent, compound base, `x**(-1/2)` (both exponent types, value-checked), and `x**(3/2)` staying pow.
- End-to-end: `dx = -sqrt(x)`, `x(0)=4` solved with tsit5 against the analytic solution `x(t) = (2 - t/2)**2`.
- Full `tests/odesystems/symbolic`: 474 passed on real GPU; printer file passes under CUDASIM.

Note for local checkouts: generated-source caches (`generated/`) predating this change still contain the pow form — the codegen cache is keyed by system definition, not printer version.

## Performance gate (benchmarks/lorenz_mean_runtime.py, defaults)

| Config | A (main 2a733d4) | B (this branch) | Welch z | Verdict |
|---|---|---|---|---|
| fixed (classical-rk4) | 62.44 ± 0.51 ms | 62.46 ± 0.40 ms | +0.34 | no significant difference |
| adaptive (tsit5) | 25.04 ± 0.49 ms | 24.85 ± 0.23 ms | -3.55 | no regression (improvement direction; Lorenz has no sqrt, session variance) |

A first B invocation ran concurrently with an unrelated CPU test sweep and was discarded as contaminated per the gate protocol; the table shows the idle-machine rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)