### PR TITLE
test: solver_with_arrays fixture waits for device writeback

### DIFF
--- a/tests/batchsolving/test_solveresult.py
+++ b/tests/batchsolving/test_solveresult.py
@@ -28,6 +28,10 @@ def solver_with_arrays(
         stream=solver_settings["stream"],
         warmup=solver_settings["warmup"],
     )
+    # kernel.run launches and copies back asynchronously; wait for the
+    # host arrays like Solver.solve does before results are read.
+    solver.memory_manager.sync_stream(solver.kernel)
+    solver.kernel.wait_for_writeback()
 
     return solver
 


### PR DESCRIPTION
## Summary

Root-causes and fixes the ordering-dependent flake in `tests/batchsolving/test_solveresult.py::TestSolveResultInstantiation::test_instantiation_type_equivalence` disclosed in #582 (failed once in three full-suite runs, never reproducible in isolation).

## Root cause

`Solver.solve` performs `self.memory_manager.sync_stream(self.kernel)` and `self.kernel.wait_for_writeback()` after `kernel.run` and before constructing a `SolveResult` (`src/cubie/batchsolving/solver.py:619-620`) because `kernel.run` launches and copies back asynchronously — `OutputArrays.finalise` issues stream-ordered D2H into pinned host memory. The session fixture `solver_with_arrays` called `solver.kernel.run(...)` directly with neither wait, so `SolveResult.from_solver` raced the in-flight copies. On a lightly loaded GPU the copies win the race, which is why the test passes in isolation; under a full-suite parallel run the window widens and the read occasionally observes incomplete host arrays. This is the only test-suite `kernel.run` call that reads result arrays afterwards (`test_SolverKernel.py`'s uses only compare compile settings).

## Fix

The fixture performs the same two waits as `Solver.solve` after `kernel.run`.

## Verification

`test_solveresult.py`: 34 passed on the CUDA simulator and on the real GPU.

## Performance gate (benchmarks/lorenz_mean_runtime.py, defaults)

Test-only diff — the package source is byte-identical to `main`, so the B side doubles as a main-vs-main control:

| Config | A (main 2a733d4) | B (this branch) | Welch z | Verdict |
|---|---|---|---|---|
| fixed (classical-rk4) | 62.44 ± 0.51 ms | 62.31 ± 0.33 ms | -2.12 | no significant difference |
| adaptive (tsit5) | 25.04 ± 0.49 ms | 24.86 ± 0.23 ms | -3.34 | identical source; documents ~3z session drift between A and B sessions |

🤖 Generated with [Claude Code](https://claude.com/claude-code)