### PR TITLE
fix: Solver.update recognises profileCUDA instead of raising KeyError

### DIFF
--- a/src/cubie/batchsolving/solver.py
+++ b/src/cubie/batchsolving/solver.py
@@ -727,7 +727,6 @@ class Solver:
                 self.driver_interpolator.driver_del_t
             )
 
-        recognised = set()
         all_unrecognized = set(updates_dict.keys())
         all_unrecognized -= driver_recognised
         all_unrecognized -= self.update_memory_settings(
@@ -738,12 +737,12 @@ class Solver:
         )
         all_unrecognized -= self.kernel.update(updates_dict, silent=True)
 
-        if "profileCUDA" in updates_dict:  # pragma: no cover
+        if "profileCUDA" in updates_dict:
             if updates_dict["profileCUDA"]:
                 self.enable_profiling()
             else:
                 self.disable_profiling()
-            recognised.add("profileCUDA")
+            all_unrecognized.discard("profileCUDA")
 
         recognised = set(updates_dict.keys()) - all_unrecognized
 

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -363,6 +363,19 @@ def test_update_silent_mode(precision, solver_mutable):
     assert solver.kernel.dt == new_dt
 
 
+def test_update_profileCUDA(solver_mutable):
+    """Test that update toggles profiling without raising KeyError."""
+    solver = solver_mutable
+
+    updated_keys = solver.update({"profileCUDA": True})
+    assert updated_keys == {"profileCUDA"}
+    assert solver.kernel._profileCUDA is True
+
+    updated_keys = solver.update({"profileCUDA": False})
+    assert updated_keys == {"profileCUDA"}
+    assert solver.kernel._profileCUDA is False
+
+
 def test_update_saved_variables(solver_mutable, system):
     """Test updating saved variables with labels."""
     solver = solver_mutable


### PR DESCRIPTION
## Summary

Closes #590.

`Solver.update()` raised `KeyError: Unrecognized parameters: {'profileCUDA'}` on every call that included `profileCUDA`, even though the toggle itself was applied. Two defects combined in `src/cubie/batchsolving/solver.py`:

1. The `profileCUDA` branch never removed the key from `all_unrecognized`, unlike the driver/memory/system/kernel subgroups.
2. The `recognised` set built inside that branch was overwritten immediately afterwards by a recomputation from `all_unrecognized`.

## Changes

- The `profileCUDA` branch discards the key from `all_unrecognized` after calling `enable_profiling()`/`disable_profiling()`; `recognised` is computed once from the remaining unrecognised keys.
- The dead `recognised = set()` pre-initialisation is removed and the branch no longer carries `# pragma: no cover` — it is now exercised by `test_update_profileCUDA`, which asserts `update(profileCUDA=True/False)` toggles the kernel flag and returns exactly `{"profileCUDA"}`.
- `test_update_unrecognized_keys` continues to cover that a genuinely unknown key still raises `KeyError`.

## Testing

- CUDASIM: `pytest tests/batchsolving/test_solver.py -k update` — 7 passed.
- Real GPU: same selection — 7 passed.
- `ruff check` and the flake8 blocking gate pass on the changed files.

## Performance gate (`benchmarks/lorenz_mean_runtime.py`)

| Config | A (main 2a733d4) mean ± std | B (PR branch) mean ± std | Welch z | Verdict |
|---|---|---|---|---|
| fixed (classical-rk4) | 63.19 ± 0.91 ms | 63.27 ± 0.80 ms | +0.66 | no significant difference |
| adaptive (tsit5) | 25.13 ± 0.54 ms | 25.29 ± 0.60 ms | +2.02 | no significant difference |

🤖 Generated with [Claude Code](https://claude.com/claude-code)