### PR TITLE
fix: buffer registry releases collected parents

### DIFF
--- a/src/cubie/buffer_registry.py
+++ b/src/cubie/buffer_registry.py
@@ -10,6 +10,7 @@ computed on demand and invalidated when any buffer is modified.
 """
 
 from typing import Callable, Dict, Optional, Tuple, Any, Set
+from weakref import WeakKeyDictionary
 
 from attrs import asdict as attrs_asdict, define, field
 from attrs.validators import (
@@ -155,8 +156,6 @@ class BufferGroup:
 
     Attributes
     ----------
-    parent : object
-        Parent instance that owns this group.
     entries : Dict[str, CUDABuffer]
         Registered buffers by name.
     children : Dict[str, object]
@@ -175,7 +174,6 @@ class BufferGroup:
         computation.
     """
 
-    parent: object = field()
     entries: Dict[str, CUDABuffer] = field(factory=dict)
     children: Dict[str, object] = field(factory=dict, init=False)
     _shared_layout: Optional[Dict[str, slice]] = field(
@@ -561,12 +559,15 @@ class BufferRegistry:
 
     Attributes
     ----------
-    _groups : Dict[object, BufferGroup]
-        Maps parent instances to their buffer groups.
+    _groups : WeakKeyDictionary
+        Maps parent instances to their buffer groups. Parents are
+        held weakly: a group disappears with its parent, so dead
+        components do not accumulate in the registry across a
+        session.
     """
 
-    _groups: Dict[object, BufferGroup] = field(
-        factory=dict, init=False
+    _groups: WeakKeyDictionary = field(
+        factory=WeakKeyDictionary, init=False
     )
 
     def register(
@@ -616,7 +617,7 @@ class BufferRegistry:
         re-registering after children have built.
         """
         if parent not in self._groups:
-            self._groups[parent] = BufferGroup(parent=parent)
+            self._groups[parent] = BufferGroup()
         self._groups[parent].register(
             name, size, location, persistent, aliases, precision
         )

--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -175,6 +175,10 @@ class _WeakCallable:
             return None
         return target(*args, **kwargs)
 
+    # Unhashable by design: equality tracks the referent, which can
+    # be collected mid-lifetime, so no stable hash exists.
+    __hash__ = None
+
     def __eq__(self, other: object) -> bool:
         if isinstance(other, _WeakCallable):
             return self.target() == other.target()
@@ -611,10 +615,17 @@ class MemoryManager:
 
         self.stream_groups.add_instance(instance, stream_group)
 
+        try:
+            instance_ref = weakref_ref(instance)
+        except TypeError:
+            # Instances without weak-reference support keep the
+            # pre-existing lifetime contract: registered until the
+            # process ends, never purged.
+            instance_ref = None
         settings = InstanceMemorySettings(
             invalidate_hook=invalidate_cache_hook,
             allocation_ready_hook=allocation_ready_hook,
-            instance_ref=weakref_ref(instance),
+            instance_ref=instance_ref,
         )
 
         self.registry[instance_id] = settings

--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -52,6 +52,8 @@ from types import TracebackType
 from typing import Any, Optional, Callable, Dict, Tuple
 from warnings import warn
 from copy import deepcopy
+from inspect import ismethod
+from weakref import WeakMethod, ref as weakref_ref
 import ctypes
 
 from numba import cuda
@@ -131,6 +133,52 @@ def placeholder_dataready(response: ArrayResponse) -> None:
 
     """
     pass
+
+
+class _WeakCallable:
+    """Callable wrapper that holds bound methods weakly.
+
+    Registered instances supply bound methods as registry hooks; a
+    strong reference to those methods would keep the instance alive
+    for the lifetime of the registry. Bound methods are therefore
+    stored through :class:`weakref.WeakMethod`, while plain functions
+    are stored directly. Calling a wrapper whose referent has been
+    garbage collected is a no-op.
+
+    Parameters
+    ----------
+    func
+        Callable to wrap. An existing wrapper is copied rather than
+        double-wrapped.
+    """
+
+    def __init__(self, func: Callable) -> None:
+        if isinstance(func, _WeakCallable):
+            self._weak = func._weak
+            self._strong = func._strong
+        elif ismethod(func):
+            self._weak = WeakMethod(func)
+            self._strong = None
+        else:
+            self._weak = None
+            self._strong = func
+
+    def target(self) -> Optional[Callable]:
+        """Return the wrapped callable, or None once collected."""
+        if self._weak is not None:
+            return self._weak()
+        return self._strong
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        target = self.target()
+        if target is None:
+            return None
+        return target(*args, **kwargs)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, _WeakCallable):
+            return self.target() == other.target()
+        return self.target() == other
 
 
 def _ensure_cuda_context() -> None:
@@ -330,6 +378,9 @@ class InstanceMemorySettings:
         Function to call when allocations are ready.
     cap
         Maximum allocatable bytes for this instance.
+    instance_ref
+        Weak reference to the registered instance, used to detect
+        and purge entries whose instance has been collected.
 
     Attributes
     ----------
@@ -343,6 +394,8 @@ class InstanceMemorySettings:
         Function to call when allocations are ready.
     cap : int or None
         Maximum allocatable bytes for this instance.
+    instance_ref : weakref.ref or None
+        Weak reference to the registered instance.
 
     Properties
     ----------
@@ -355,6 +408,10 @@ class InstanceMemorySettings:
     to calculate total allocated memory. The invalidate_hook is called when the
     allocator/memory manager changes, requiring arrays and kernels to be
     re-allocated or redefined.
+
+    Bound-method hooks are stored weakly so the registry never keeps
+    a registered instance alive; once the instance is collected the
+    hooks become no-ops and the entry is purged by the manager.
     """
 
     proportion: float = field(
@@ -365,13 +422,19 @@ class InstanceMemorySettings:
     )
     invalidate_hook: Callable[[], None] = field(
         default=placeholder_invalidate,
+        converter=_WeakCallable,
         validator=attrsval_instance_of(Callable),
     )
     allocation_ready_hook: Callable[[ArrayResponse], None] = field(
-        default=placeholder_dataready
+        default=placeholder_dataready,
+        converter=_WeakCallable,
     )
     cap: Optional[int] = field(
         default=None, validator=attrsval_optional(attrsval_instance_of(int))
+    )
+    instance_ref: Optional[weakref_ref] = field(
+        default=None,
+        validator=attrsval_optional(attrsval_instance_of(weakref_ref)),
     )
 
     def add_allocation(self, key: str, arr: Any) -> None:
@@ -541,6 +604,7 @@ class MemoryManager:
             and 1.
 
         """
+        self._purge_dead_instances()
         instance_id = id(instance)
         if instance_id in self.registry:
             raise ValueError("Instance already registered")
@@ -550,6 +614,7 @@ class MemoryManager:
         settings = InstanceMemorySettings(
             invalidate_hook=invalidate_cache_hook,
             allocation_ready_hook=allocation_ready_hook,
+            instance_ref=weakref_ref(instance),
         )
 
         self.registry[instance_id] = settings
@@ -648,6 +713,7 @@ class MemoryManager:
             If proportion is not between 0 and 1.
 
         """
+        self._purge_dead_instances()
         instance_id = id(instance)
         if proportion < 0 or proportion > 1:
             raise ValueError("Proportion must be between 0 and 1")
@@ -674,6 +740,7 @@ class MemoryManager:
         -----
         If the instance is already in the manual pool, this is a no-op.
         """
+        self._purge_dead_instances()
         instance_id = id(instance)
         settings = self.registry[instance_id]
         if instance_id in self._manual_pool:
@@ -694,6 +761,7 @@ class MemoryManager:
         -----
         If the instance is already in the auto pool, this is a no-op.
         """
+        self._purge_dead_instances()
         instance_id = id(instance)
         settings = self.registry[instance_id]
         if instance_id in self._auto_pool:
@@ -739,6 +807,7 @@ class MemoryManager:
     @property
     def manual_pool_proportion(self):
         """Total proportion of VRAM currently assigned manually."""
+        self._purge_dead_instances()
         manual_settings = [
             self.registry[instance_id] for instance_id in self._manual_pool
         ]
@@ -750,6 +819,7 @@ class MemoryManager:
     @property
     def auto_pool_proportion(self):
         """Total proportion of VRAM currently distributed automatically."""
+        self._purge_dead_instances()
         auto_settings = [
             self.registry[instance_id] for instance_id in self._auto_pool
         ]
@@ -849,6 +919,37 @@ class MemoryManager:
         self._auto_pool.append(instance_id)
         self._rebalance_auto_pool()
         return self.registry[instance_id].proportion
+
+    def _purge_dead_instances(self) -> None:
+        """
+        Drop registry entries whose instance has been collected.
+
+        Registered instances are held weakly. Once an instance is
+        garbage collected, its manual or auto reservation is
+        released, its stream-group membership is removed, and any
+        allocations it still had queued are discarded.
+
+        """
+        dead_ids = [
+            instance_id
+            for instance_id, settings in self.registry.items()
+            if settings.instance_ref is not None
+            and settings.instance_ref() is None
+        ]
+        for instance_id in dead_ids:
+            self.registry.pop(instance_id)
+            if instance_id in self._manual_pool:
+                self._manual_pool.remove(instance_id)
+            if instance_id in self._auto_pool:
+                self._auto_pool.remove(instance_id)
+            self.stream_groups.remove_instance(instance_id)
+            for queued in self._queued_allocations.values():
+                queued.pop(instance_id, None)
+        if dead_ids:
+            # Freed reservations flow back to the surviving auto pool.
+            # The nested purge this triggers finds nothing dead, so
+            # the recursion terminates after one level.
+            self._rebalance_auto_pool()
 
     def _rebalance_auto_pool(self) -> None:
         """

--- a/src/cubie/memory/stream_groups.py
+++ b/src/cubie/memory/stream_groups.py
@@ -176,6 +176,28 @@ class StreamGroups:
 
         return self.groups[group]
 
+    def remove_instance(self, instance: Any) -> None:
+        """Remove an instance from its stream group, if it has one.
+
+        Parameters
+        ----------
+        instance
+            Host object or integer identifier to remove.
+
+        Notes
+        -----
+        Removing an instance that is in no group is a no-op; the
+        group and its stream are kept for the remaining members.
+        """
+        if isinstance(instance, int):
+            instance_id = instance
+        else:
+            instance_id = id(instance)
+        for members in self.groups.values():
+            if instance_id in members:
+                members.remove(instance_id)
+                return
+
     def change_group(self, instance: Any, new_group: str) -> None:
         """Move an instance to another stream group.
 

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -1,3 +1,6 @@
+import gc
+import weakref
+
 import pytest
 
 from numba import cuda
@@ -22,6 +25,13 @@ class DummyClass:
     def __init__(self, proportion=None, invalidate_all_hook=None):
         self.proportion = proportion
         self.invalidate_all_hook = invalidate_all_hook
+        self.last_response = None
+
+    def notice_invalidate(self):
+        self.proportion = None
+
+    def notice_allocation(self, response):
+        self.last_response = response
 
 
 @pytest.fixture(scope="function")
@@ -1420,3 +1430,77 @@ def test_cupy_stream_wrapper(stream1, stream2):
     # Check that the default current stream is untouched
     assert cp.cuda.get_current_stream().ptr != _numba_stream_ptr(stream1)
     assert cp.cuda.get_current_stream().ptr != _numba_stream_ptr(stream2)
+
+
+class TestDeadInstanceRelease:
+    """The registry releases instances once they are collected."""
+
+    def test_registry_does_not_pin_instances(self, mgr):
+        """Bound-method hooks leave the instance collectable."""
+        inst = DummyClass()
+        mgr.register(
+            inst,
+            proportion=0.4,
+            invalidate_cache_hook=inst.notice_invalidate,
+            allocation_ready_hook=inst.notice_allocation,
+        )
+        instance_id = id(inst)
+        ref = weakref.ref(inst)
+        del inst
+        gc.collect()
+        assert ref() is None
+        assert mgr.manual_pool_proportion == 0.0
+        assert instance_id not in mgr.registry
+        assert instance_id not in mgr._manual_pool
+
+    def test_dead_manual_instances_release_proportion(self, mgr):
+        """Collected manual instances free their reservations.
+
+        Three successive 0.5 reservations exceed the whole memory if
+        the dead instances' proportions are retained.
+        """
+        keeper = DummyClass()
+        mgr.register(keeper)
+        for _ in range(3):
+            inst = DummyClass()
+            mgr.register(inst, proportion=0.5)
+            del inst
+            gc.collect()
+        assert mgr.manual_pool_proportion == 0.0
+        survivor = DummyClass()
+        mgr.register(survivor, proportion=0.9)
+        assert abs(mgr.manual_pool_proportion - 0.9) < 1e-9
+        assert id(survivor) in mgr._manual_pool
+
+    def test_dead_auto_instance_leaves_pool(self, mgr):
+        """A collected auto instance stops diluting the auto pool."""
+        keeper = DummyClass()
+        mgr.register(keeper)
+        inst = DummyClass()
+        mgr.register(inst)
+        del inst
+        gc.collect()
+        assert abs(mgr.auto_pool_proportion - 1.0) < 1e-9
+        assert mgr.registry[id(keeper)].proportion == 1.0
+
+    def test_bound_method_hooks_compare_equal(self, mgr):
+        """Registered hooks compare equal to the source bound methods."""
+        inst = DummyClass(proportion=0.3)
+        mgr.register(
+            inst,
+            invalidate_cache_hook=inst.notice_invalidate,
+            allocation_ready_hook=inst.notice_allocation,
+        )
+        settings = mgr.registry[id(inst)]
+        assert settings.invalidate_hook == inst.notice_invalidate
+        assert settings.allocation_ready_hook == inst.notice_allocation
+        settings.invalidate_hook()
+        assert inst.proportion is None
+
+    def test_dead_hooks_are_noops(self, mgr):
+        """Hooks of a collected instance do nothing when invoked."""
+        inst = DummyClass()
+        mgr.register(inst, invalidate_cache_hook=inst.notice_invalidate)
+        del inst
+        gc.collect()
+        mgr.invalidate_all()

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -1504,3 +1504,19 @@ class TestDeadInstanceRelease:
         del inst
         gc.collect()
         mgr.invalidate_all()
+
+    def test_non_weakrefable_instance_registers(self, mgr):
+        """Objects without weakref support register and persist.
+
+        Such instances carry no instance_ref, so the purge treats
+        them as permanently alive.
+        """
+
+        class Slotted:
+            __slots__ = ()
+
+        inst = Slotted()
+        mgr.register(inst, proportion=0.2)
+        assert mgr.registry[id(inst)].instance_ref is None
+        assert abs(mgr.manual_pool_proportion - 0.2) < 1e-9
+        assert id(inst) in mgr.registry

--- a/tests/test_buffer_registry.py
+++ b/tests/test_buffer_registry.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import gc
+import weakref
+
 import numpy as np
 import pytest
 
@@ -213,30 +216,30 @@ def test_build_allocator_zero_flag():
 # ── BufferGroup.register validation ──────────────────────── #
 
 
-def test_register_empty_name_raises(single_integrator_run):
+def test_register_empty_name_raises():
     """BufferGroup.register raises ValueError for empty name."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     with pytest.raises(ValueError, match="cannot be empty"):
         group.register("", 10, "shared")
 
 
-def test_register_self_alias_raises(single_integrator_run):
+def test_register_self_alias_raises():
     """BufferGroup.register raises ValueError for self-aliasing."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     with pytest.raises(ValueError, match="cannot alias itself"):
         group.register("buf", 10, "shared", aliases="buf")
 
 
-def test_register_missing_alias_target_raises(single_integrator_run):
+def test_register_missing_alias_target_raises():
     """BufferGroup.register raises ValueError for missing alias target."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     with pytest.raises(ValueError, match="not registered"):
         group.register("child", 10, "shared", aliases="parent")
 
 
-def test_register_adds_entry_and_invalidates(single_integrator_run):
+def test_register_adds_entry_and_invalidates():
     """Registration adds entry to group and invalidates layouts."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("buf", 10, "shared")
     group.build_layouts()
     assert group._shared_layout is not None
@@ -251,32 +254,26 @@ def test_register_adds_entry_and_invalidates(single_integrator_run):
 # ── BufferGroup.update_buffer ─────────────────────────────── #
 
 
-def test_update_buffer_unregistered_returns_false_false(
-    single_integrator_run,
-):
+def test_update_buffer_unregistered_returns_false_false():
     """update_buffer returns (False, False) for unknown buffer."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     recognized, changed = group.update_buffer("missing", size=10)
     assert recognized is False
     assert changed is False
 
 
-def test_update_buffer_no_change_returns_true_false(
-    single_integrator_run,
-):
+def test_update_buffer_no_change_returns_true_false():
     """update_buffer returns (True, False) when values unchanged."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("buf", 10, "shared")
     recognized, changed = group.update_buffer("buf", size=10)
     assert recognized is True
     assert changed is False
 
 
-def test_update_buffer_changed_returns_true_true(
-    single_integrator_run,
-):
+def test_update_buffer_changed_returns_true_true():
     """update_buffer returns (True, True) and invalidates on change."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("buf", 10, "shared")
     group.build_layouts()
     assert group._shared_layout is not None
@@ -291,9 +288,9 @@ def test_update_buffer_changed_returns_true_true(
 # ── BufferGroup.invalidate_layouts ────────────────────────── #
 
 
-def test_invalidate_layouts_clears_all(single_integrator_run):
+def test_invalidate_layouts_clears_all():
     """invalidate_layouts sets all caches to None."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("s", 10, "shared")
     group.register("p", 5, "local", persistent=True)
     group.register("l", 3, "local")
@@ -309,11 +306,9 @@ def test_invalidate_layouts_clears_all(single_integrator_run):
 # ── BufferGroup.build_layouts ─────────────────────────────── #
 
 
-def test_build_layouts_shared_sequential_offsets(
-    single_integrator_run,
-):
+def test_build_layouts_shared_sequential_offsets():
     """build_layouts assigns sequential shared slices."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("a", 10, "shared")
     group.register("b", 20, "shared")
     group.build_layouts()
@@ -322,11 +317,9 @@ def test_build_layouts_shared_sequential_offsets(
     assert group.shared_layout["b"] == slice(10, 30)
 
 
-def test_build_layouts_persistent_sequential_offsets(
-    single_integrator_run,
-):
+def test_build_layouts_persistent_sequential_offsets():
     """build_layouts assigns sequential persistent slices."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("a", 15, "local", persistent=True)
     group.register("b", 25, "local", persistent=True)
     group.build_layouts()
@@ -335,9 +328,9 @@ def test_build_layouts_persistent_sequential_offsets(
     assert group.persistent_layout["b"] == slice(15, 40)
 
 
-def test_build_layouts_local_sizes_min_one(single_integrator_run):
+def test_build_layouts_local_sizes_min_one():
     """build_layouts uses max(size, 1) for local buffers."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("zero", 0, "local")
     group.register("nonzero", 7, "local")
     group.build_layouts()
@@ -346,11 +339,9 @@ def test_build_layouts_local_sizes_min_one(single_integrator_run):
     assert group.local_sizes["nonzero"] == 7
 
 
-def test_build_layouts_short_circuits_when_populated(
-    single_integrator_run,
-):
+def test_build_layouts_short_circuits_when_populated():
     """build_layouts returns early when all caches already built."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("s", 10, "shared")
     group.build_layouts()
     original = group._shared_layout
@@ -362,9 +353,9 @@ def test_build_layouts_short_circuits_when_populated(
 # ── BufferGroup.layout_aliases ────────────────────────────── #
 
 
-def test_alias_overlaps_shared_parent(single_integrator_run):
+def test_alias_overlaps_shared_parent():
     """Aliased buffer overlaps within shared parent when space."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("parent", 100, "shared")
     group.register("child", 30, "shared", aliases="parent")
     group.build_layouts()
@@ -373,9 +364,9 @@ def test_alias_overlaps_shared_parent(single_integrator_run):
     assert group.shared_layout["child"] == slice(0, 30)
 
 
-def test_alias_exceeds_parent_falls_back(single_integrator_run):
+def test_alias_exceeds_parent_falls_back():
     """Aliased buffer exceeding parent gets own shared allocation."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("parent", 50, "shared")
     group.register("child", 80, "shared", aliases="parent")
     group.build_layouts()
@@ -385,9 +376,9 @@ def test_alias_exceeds_parent_falls_back(single_integrator_run):
     assert group.shared_buffer_size() == 130
 
 
-def test_alias_fallback_persistent(single_integrator_run):
+def test_alias_fallback_persistent():
     """Persistent aliased buffer falls back to persistent layout."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("parent", 10, "local")
     group.register(
         "child", 5, "local", persistent=True, aliases="parent",
@@ -398,9 +389,9 @@ def test_alias_fallback_persistent(single_integrator_run):
     assert group.persistent_local_buffer_size() == 5
 
 
-def test_alias_fallback_local(single_integrator_run):
+def test_alias_fallback_local():
     """Local aliased buffer falls back to local pile."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("parent", 10, "local", persistent=True)
     group.register("child", 5, "local", aliases="parent")
     group.build_layouts()
@@ -408,11 +399,9 @@ def test_alias_fallback_local(single_integrator_run):
     assert group.local_sizes["child"] == 5
 
 
-def test_alias_local_child_of_shared_parent_overlaps(
-    single_integrator_run,
-):
+def test_alias_local_child_of_shared_parent_overlaps():
     """Local child aliasing shared parent overlaps in shared."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("parent", 100, "shared")
     group.register("child", 30, "local", aliases="parent")
     group.build_layouts()
@@ -421,11 +410,9 @@ def test_alias_local_child_of_shared_parent_overlaps(
     assert group.local_buffer_size() == 0
 
 
-def test_multiple_aliases_sequential_consumption(
-    single_integrator_run,
-):
+def test_multiple_aliases_sequential_consumption():
     """Multiple aliases consume parent space sequentially."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("parent", 100, "shared")
     group.register("c1", 40, "shared", aliases="parent")
     group.register("c2", 40, "shared", aliases="parent")
@@ -450,9 +437,9 @@ def test_multiple_aliases_sequential_consumption(
         pytest.param("local_sizes", id="local"),
     ],
 )
-def test_layout_property_triggers_build(prop, single_integrator_run):
+def test_layout_property_triggers_build(prop):
     """Accessing layout property triggers build when None."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("s", 5, "shared")
     group.register("p", 3, "local", persistent=True)
     group.register("l", 2, "local")
@@ -467,39 +454,37 @@ def test_layout_property_triggers_build(prop, single_integrator_run):
 # ── BufferGroup size methods ──────────────────────────────── #
 
 
-def test_shared_buffer_size_empty(single_integrator_run):
+def test_shared_buffer_size_empty():
     """shared_buffer_size returns 0 for empty layout."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     assert group.shared_buffer_size() == 0
 
 
-def test_shared_buffer_size_returns_max_stop(single_integrator_run):
+def test_shared_buffer_size_returns_max_stop():
     """shared_buffer_size returns max slice stop."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("a", 10, "shared")
     group.register("b", 20, "shared")
     assert group.shared_buffer_size() == 30
 
 
-def test_local_buffer_size_returns_sum(single_integrator_run):
+def test_local_buffer_size_returns_sum():
     """local_buffer_size returns sum of local sizes."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("a", 5, "local")
     group.register("b", 8, "local")
     assert group.local_buffer_size() == 13
 
 
-def test_persistent_buffer_size_empty(single_integrator_run):
+def test_persistent_buffer_size_empty():
     """persistent_local_buffer_size returns 0 for empty layout."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     assert group.persistent_local_buffer_size() == 0
 
 
-def test_persistent_buffer_size_returns_max_stop(
-    single_integrator_run,
-):
+def test_persistent_buffer_size_returns_max_stop():
     """persistent_local_buffer_size returns max slice stop."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("a", 30, "local", persistent=True)
     group.register("b", 40, "local", persistent=True)
     assert group.persistent_local_buffer_size() == 70
@@ -508,18 +493,16 @@ def test_persistent_buffer_size_returns_max_stop(
 # ── BufferGroup.get_allocator ─────────────────────────────── #
 
 
-def test_get_allocator_unregistered_raises(single_integrator_run):
+def test_get_allocator_unregistered_raises():
     """get_allocator raises KeyError for unregistered buffer."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     with pytest.raises(KeyError, match="not registered"):
         group.get_allocator("missing")
 
 
-def test_get_allocator_returns_allocator_for_registered(
-    single_integrator_run,
-):
+def test_get_allocator_returns_allocator_for_registered():
     """get_allocator returns allocator with correct name."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("buf", 10, "shared")
     alloc = group.get_allocator("buf")
     assert callable(alloc)
@@ -976,7 +959,7 @@ def test_layout_deterministic_regardless_of_access_order(
     single_integrator_run,
 ):
     """Layout is deterministic regardless of property access order."""
-    group = BufferGroup(parent=single_integrator_run)
+    group = BufferGroup()
     group.register("parent", 100, "shared")
     group.register("child", 30, "shared", aliases="parent")
     group.register("local", 20, "local")
@@ -1094,3 +1077,45 @@ def test_nested_shared_solver_buffers_sized_through_chain(
         loop_entries["algorithm_shared"].size
         == buffer_registry.shared_buffer_size(algo)
     )
+
+
+# ── Dead-parent release ───────────────────────────────────── #
+
+
+class _Owner:
+    """Weakref-able stand-in for a buffer-owning component."""
+
+    precision = np.float32
+
+
+def test_dead_parent_group_is_released(fresh_registry):
+    """A parent's buffer group disappears when the parent dies."""
+    owner = _Owner()
+    fresh_registry.register("buf", owner, 8, "shared")
+    assert owner in fresh_registry._groups
+    ref = weakref.ref(owner)
+    del owner
+    gc.collect()
+    assert ref() is None
+    assert "buf" not in [
+        name
+        for group in fresh_registry._groups.values()
+        for name in group.entries
+    ]
+
+
+def test_child_released_with_its_parent(fresh_registry):
+    """A recorded child is released once its parent dies."""
+    parent = _Owner()
+    child = _Owner()
+    fresh_registry.register("outer", parent, 8, "shared")
+    fresh_registry.register("inner", child, 4, "shared")
+    fresh_registry.register_child(parent, child, name="component")
+    child_ref = weakref.ref(child)
+    del child
+    gc.collect()
+    # The ownership edge keeps the child alive with its parent.
+    assert child_ref() is not None
+    del parent
+    gc.collect()
+    assert child_ref() is None


### PR DESCRIPTION
## Summary

`BufferRegistry` holds its parents weakly, so a component's buffer group disappears when the component is garbage collected. Previously `_groups` was a plain dict keyed by the parent objects themselves, released only by `clear_parent` (called on algorithm/controller hot-swap) or `reset()` (tests) — every `IVPLoop`, step, `NewtonKrylov`, and `MRLinearSolver` ever built stayed pinned for the session, and through their caches so did the compiled device functions and the owning `SymbolicODE`.

- `_groups` is a `weakref.WeakKeyDictionary`.
- The unused `BufferGroup.parent` field is removed — a strong value-to-key reference would make weak entries immortal, and nothing read it.
- The `clear_parent` cascade and hot-swap behaviour are unchanged; a parent's recorded children are still released with their parent (the ownership edge keeps a child alive exactly as long as its parent).

Stacked on #593 (this branch includes its commits): the memory-manager registry was the outer pin keeping kernels alive, and with both fixes a discarded solver's entire component graph — including the system — is collectable with no explicit cleanup:

```
# before: groups accumulate 4 per implicit solver; SymbolicODE
# stays alive until buffer_registry.reset()
# after (with #593): groups drain to 0, system collects on del
```

## Tests

- `test_dead_parent_group_is_released` / `test_child_released_with_its_parent` in `tests/test_buffer_registry.py` pin the weak-release behaviour and the parent-child lifetime coupling.
- `BufferGroup(parent=...)` unit-test constructions updated; group-level tests that only used the fixture for that argument drop it.
- Real GPU: buffer registry, integrator algorithms, integrator loops, solver, and solver-kernel suites — 366 passed.
- CUDASIM: `tests/test_buffer_registry.py` — 82 passed.

## Performance gate (benchmarks/lorenz_mean_runtime.py, defaults)

| Config | A (main 33bb429) | B (this branch) | Welch z | Verdict |
|---|---|---|---|---|
| fixed (classical-rk4) | 63.99 ± 1.10 ms | 63.17 ± 0.67 ms | -6.37 | no regression (improvement direction; session variance) |
| adaptive (tsit5) | 25.34 ± 0.42 ms | 25.16 ± 0.25 ms | -3.68 | no regression (improvement direction; session variance) |

Host-side change only; the compiled kernels are byte-identical to main's, so the negative drift reflects session-to-session variance, not the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
