### PR TITLE
fix: step-controller defaults are per-algorithm literature values

### DIFF
--- a/docs/source/API_reference/integrators/algorithms.rst
+++ b/docs/source/API_reference/integrators/algorithms.rst
@@ -73,11 +73,11 @@ same family.
      - Crank–Nicolson with an embedded backward-Euler error
        estimate
      - 2
-     - PID: ``kp=0.7``, ``ki=-0.4``, gain clamp 0.5–2.0
+     - Gustafsson predictive: gain clamp 0.2–8.0
    * - ``erk``
      - ``dormand-prince-54`` (explicit, seven stages)
      - 5(4)
-     - PID: ``kp=0.7``, ``ki=-0.4``, gain clamp 0.1–5.0
+     - PI: ``kp=0.7``, ``ki=-0.4``, gain clamp 0.2–10.0
    * - ``dirk``
      - ``lobatto_iiic_3`` (diagonally implicit, three stages)
      - 4
@@ -90,15 +90,17 @@ same family.
    * - ``rosenbrock``
      - ``ros3p`` (linearly implicit, three stages)
      - 3
-     - PID: ``kp=0.6``, ``ki=-0.4``, gain clamp 0.5–2.0
+     - Gustafsson predictive: gain clamp 0.2–8.0
 
 How the step controller is chosen
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Adaptive step control needs an embedded error estimate. When an
 algorithm or tableau is named without setting ``step_controller``,
-CuBIE selects the family's tuned PID controller if the scheme
-provides an estimate, and a fixed-step controller if it does not.
+CuBIE selects the family's tuned controller if the scheme provides
+an estimate — a PI controller for explicit Runge–Kutta, the
+Gustafsson predictive controller for the implicit families — and a
+fixed-step controller if it does not.
 This is why ``dirk`` and ``firk`` run fixed-step out of the box:
 their default tableaus carry no embedded estimate. Aliases that do
 (``radau``, for example) enable the family's adaptive defaults
@@ -106,11 +108,13 @@ automatically. Explicitly pairing an adaptive controller with an
 estimate-free scheme falls back to fixed stepping with a
 ``UserWarning``.
 
-The adaptive family defaults all use a 1.0–1.2 deadband (step-size
-increases smaller than 20% are skipped; decreases always apply). Every value can be overridden
-per solve — see :doc:`/user_guide/configuration` for how kwargs
-reach the controller and :doc:`/user_guide/optional_arguments` for
-the full parameter list.
+The implicit family defaults use a 1.0–1.2 deadband (step-size
+increases smaller than 20% are skipped; decreases always apply),
+matching RADAU5's step-freeze band; the explicit ``erk`` defaults
+apply no deadband. Every value can be overridden per solve — see
+:doc:`/user_guide/configuration` for how kwargs reach the controller
+and :doc:`/user_guide/optional_arguments` for the full parameter
+list.
 
 Implicit solver defaults
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/API_reference/integrators/algorithms/crank_nicolson_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/crank_nicolson_step.rst
@@ -9,8 +9,8 @@ Defaults
 ``algorithm="crank_nicolson"`` performs a single-stage, order-2
 update and runs a backward-Euler companion solve each step; the
 difference between the two supplies an embedded error estimate, so
-the method defaults to adaptive PID control (``kp=0.7``,
-``ki=-0.4``, step-size growth clamped to 0.5–2.0×). Both implicit
+the method defaults to Gustafsson predictive control (step-size
+growth clamped to 0.2–8.0×). Both implicit
 solves use the shared Newton–Krylov defaults listed in
 :ref:`algorithm-defaults`.
 

--- a/docs/source/API_reference/integrators/algorithms/generic_dirk_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_dirk_step.rst
@@ -17,8 +17,8 @@ Defaults
 (L-stable Lobatto IIIC, three stages, order 4). That tableau has no
 embedded error estimate, so the default is fixed-step control;
 choosing a DIRK tableau that provides an estimate enables the
-family's adaptive PID defaults (``kp=0.7``, ``ki=-0.4``, step-size
-growth clamped to 0.1–5.0×). Each stage runs one Newton–Krylov
+family's Gustafsson predictive defaults (step-size growth clamped
+to 0.2–8.0×). Each stage runs one Newton–Krylov
 solve with the shared defaults listed in
 :ref:`algorithm-defaults`. The implicit-midpoint, SDIRK, and
 Hairer–Wanner L-stable schemes on the

--- a/docs/source/API_reference/integrators/algorithms/generic_erk_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_erk_step.rst
@@ -14,9 +14,9 @@ Defaults
 
 ``algorithm="erk"`` integrates with the ``dormand-prince-54``
 tableau — explicit Dormand–Prince 5(4), seven stages, with an
-embedded fourth-order error estimate — under adaptive PID control
+embedded fourth-order error estimate — under adaptive PI control
 (``kp=0.7``, ``ki=-0.4``, ``safety=0.9``, step-size growth clamped
-to 0.1–5.0×). ``dopri54``, ``rk45``, and ``ode45`` are aliases for
+to 0.2–10.0×). ``dopri54``, ``rk45``, and ``ode45`` are aliases for
 the same scheme; the other named schemes in the
 :doc:`ERK tableau registry <generic_erk_tableaus>` resolve to this
 class too, falling back to fixed-step control when a tableau has no

--- a/docs/source/API_reference/integrators/algorithms/generic_firk_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_firk_step.rst
@@ -19,8 +19,8 @@ together as one coupled Newton–Krylov system with the shared
 defaults listed in :ref:`algorithm-defaults`. The default tableau
 has no embedded error estimate, so it runs under fixed-step
 control; tableaus that provide one — ``radau`` (Radau IIA-5), for
-example — enable the family's adaptive PID defaults (``kp=0.6``,
-``ki=-0.4``, step-size growth clamped to 0.5–2.0×). Named schemes
+example — enable the family's Gustafsson predictive defaults
+(step-size growth clamped to 0.2–8.0×). Named schemes
 are listed on the
 :doc:`FIRK tableau registry <generic_firk_tableaus>` page.
 

--- a/docs/source/API_reference/integrators/algorithms/generic_rosenbrock_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_rosenbrock_step.rst
@@ -15,8 +15,8 @@ Defaults
 
 ``algorithm="rosenbrock"`` integrates with the ``ros3p`` tableau
 (three stages, order 3, with an embedded error estimate) under
-adaptive PID control (``kp=0.6``, ``ki=-0.4``, step-size growth
-clamped to 0.5–2.0×). Rosenbrock-W methods are linearly implicit —
+Gustafsson predictive control (step-size growth clamped to
+0.2–8.0×). Rosenbrock-W methods are linearly implicit —
 each stage performs one linear solve rather than a Newton
 iteration — so of the solver settings in
 :ref:`algorithm-defaults` only the Krylov and preconditioner

--- a/docs/source/user_guide/choosing_algorithms.rst
+++ b/docs/source/user_guide/choosing_algorithms.rst
@@ -231,9 +231,10 @@ Select one by name with ``step_controller`` inside
    ratio.  Widely used with implicit methods; useful when step
    rejections are frequent.
 
-Each algorithm picks a sensible default controller (an adaptive
-controller when it has an error estimate, ``fixed`` otherwise), so for
-most problems you don't need to choose at all.  To override:
+Each algorithm picks a sensible default controller (``pi`` for
+explicit Runge--Kutta, ``gustafsson`` for the implicit families,
+``fixed`` when there is no error estimate), so for most problems you
+don't need to choose at all.  To override:
 
 .. code-block:: python
 

--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -198,9 +198,10 @@ Notes on selected parameters
     Selects the step-size controller by name: ``"fixed"``, ``"i"``,
     ``"pi"``, ``"pid"``, or ``"gustafsson"``. When omitted, the
     chosen algorithm's own default controller is used — fixed for
-    schemes without an embedded error estimate, otherwise an
-    algorithm-tuned PID. See :doc:`choosing_algorithms` and the
-    algorithm defaults table in the API reference.
+    schemes without an embedded error estimate, otherwise PI for
+    explicit Runge–Kutta and Gustafsson for the implicit families.
+    See :doc:`choosing_algorithms` and the algorithm defaults table
+    in the API reference.
 
 **max_registers**
     Per-thread register cap forwarded to ``cuda.jit``. Default

--- a/src/cubie/integrators/algorithms/AGENTS.md
+++ b/src/cubie/integrators/algorithms/AGENTS.md
@@ -69,10 +69,14 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
   `"erk"`, `"dirk"`, `"firk"`, `"rosenbrock"` use the class-default tableau; the
   **non-tableau methods** `"euler"`, `"backwards_euler"`, `"backwards_euler_pc"`,
   `"crank_nicolson"` are fixed schemes with no tableau.
-- `StepControlDefaults` are chosen from `tableau.has_error_estimate` (PID when an
-  embedded estimate exists, fixed otherwise). **Errorless tableaus must use a fixed
-  controller** — constructors enforce this; never pair an adaptive controller with an
-  errorless tableau.
+- `StepControlDefaults` are chosen from `tableau.has_error_estimate` (fixed when no
+  embedded estimate exists; otherwise PI for explicit RK, Gustafsson for the implicit
+  families — DIRK/FIRK/Rosenbrock-W/Crank-Nicolson — with RADAU5's gain limits and
+  deadband). **Errorless tableaus must use a fixed controller** — constructors enforce
+  this; never pair an adaptive controller with an errorless tableau. Controller-defaults
+  dicts must never contain keys that are also algorithm parameters (e.g. `gamma`,
+  `newton_max_iters`): on hot-swap the defaults merge into the shared `updates_dict`
+  and would overwrite the algorithm's own setting.
 - **`update` additions:** new keywords must be added to `ALL_ALGORITHM_STEP_PARAMETERS`
   (`base_algorithm_step.py`) or `update` rejects them; `ODEImplicitStep` routes solver
   params to its owned solver via `_LINEAR_SOLVER_PARAMS` / `_NEWTON_KRYLOV_PARAMS`.

--- a/src/cubie/integrators/algorithms/crank_nicolson.py
+++ b/src/cubie/integrators/algorithms/crank_nicolson.py
@@ -13,7 +13,7 @@ Published Classes
 Constants
 ---------
 :data:`CN_DEFAULTS`
-    Default PID adaptive controller settings.
+    Default Gustafsson adaptive controller settings.
 
 See Also
 --------
@@ -43,15 +43,22 @@ ALGO_CONSTANTS = {'beta': 1.0,
 
 CN_DEFAULTS = StepControlDefaults(
     step_controller={
-        "step_controller": "pid",
-        "kp": 0.7,
-        "ki": -0.4,
+        "step_controller": "gustafsson",
         "deadband_min": 1.0,
-        "deadband_max": 1.1,
-        "min_gain": 0.5,
-        "max_gain": 2.0,
+        "deadband_max": 1.2,
+        "min_gain": 0.2,
+        "max_gain": 8.0,
+        "safety": 0.9,
     }
 )
+"""Default step controller settings for Crank--Nicolson.
+
+The Gustafsson predictive controller is the standard choice for
+Newton-based implicit methods (Gustafsson 1994). Step-ratio limits,
+deadband, and safety factor follow Hairer & Wanner's RADAU5
+(``facl = 0.2``, ``facr = 8``, ``quot1 = 1.0``, ``quot2 = 1.2``,
+``safe = 0.9``).
+"""
 
 
 @define

--- a/src/cubie/integrators/algorithms/generic_dirk.py
+++ b/src/cubie/integrators/algorithms/generic_dirk.py
@@ -12,7 +12,7 @@ Published Classes
 Constants
 ---------
 :data:`DIRK_ADAPTIVE_DEFAULTS`
-    Default PID controller settings for adaptive tableaus.
+    Default Gustafsson controller settings for adaptive tableaus.
 
 :data:`DIRK_FIXED_DEFAULTS`
     Default fixed-step settings for errorless tableaus.
@@ -21,7 +21,7 @@ Notes
 -----
 The step controller defaults are selected dynamically based on whether
 the tableau has an embedded error estimate. Tableaus with error
-estimates default to adaptive stepping (PID controller), while
+estimates default to adaptive stepping (Gustafsson controller), while
 errorless tableaus default to fixed stepping.
 
 See Also
@@ -63,13 +63,12 @@ from cubie.buffer_registry import buffer_registry
 
 DIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
     step_controller={
-        "step_controller": "pid",
-        "kp": 0.7,
-        "ki": -0.4,
+        "step_controller": "gustafsson",
         "deadband_min": 1.0,
-        "deadband_max": 1.1,
-        "min_gain": 0.1,
-        "max_gain": 5.0,
+        "deadband_max": 1.2,
+        "min_gain": 0.2,
+        "max_gain": 8.0,
+        "safety": 0.9,
     }
 )
 """Default step controller settings for adaptive DIRK tableaus.
@@ -77,9 +76,13 @@ DIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
 This configuration is used when the DIRK tableau has an embedded error
 estimate (``tableau.has_error_estimate == True``).
 
-The PI controller provides robust adaptive stepping with proportional and
-derivative terms to smooth step size adjustments. The deadband prevents
-unnecessary step size changes for small variations in the error estimate.
+The Gustafsson predictive controller is the standard choice for
+implicit Runge--Kutta methods (Gustafsson 1994; the default for SDIRK
+families in OrdinaryDiffEq.jl). Step-ratio limits, deadband, and
+safety factor follow Hairer & Wanner's RADAU5 (``facl = 0.2``,
+``facr = 8``, ``quot1 = 1.0``, ``quot2 = 1.2``, ``safe = 0.9``); the
+deadband keeps the step unchanged for small gains so warp-coherent
+threads avoid needless step-size churn.
 
 Notes
 -----
@@ -146,8 +149,8 @@ class DIRKStep(ODEImplicitStep):
         This constructor creates a DIRK step object and automatically selects
         appropriate default step controller settings based on whether the
         tableau has an embedded error estimate. Tableaus with error estimates
-        default to adaptive stepping (PI controller), while errorless tableaus
-        default to fixed stepping.
+        default to adaptive stepping (Gustafsson controller), while
+        errorless tableaus default to fixed stepping.
 
         Parameters
         ----------
@@ -178,7 +181,7 @@ class DIRKStep(ODEImplicitStep):
         The step controller defaults are selected dynamically:
 
         - If ``tableau.has_error_estimate`` is ``True``:
-          Uses :data:`DIRK_ADAPTIVE_DEFAULTS` (PI controller)
+          Uses :data:`DIRK_ADAPTIVE_DEFAULTS` (Gustafsson controller)
         - If ``tableau.has_error_estimate`` is ``False``:
           Uses :data:`DIRK_FIXED_DEFAULTS` (fixed-step controller)
 

--- a/src/cubie/integrators/algorithms/generic_erk.py
+++ b/src/cubie/integrators/algorithms/generic_erk.py
@@ -35,7 +35,7 @@ Published Classes
 Module-Level Constants
 ----------------------
 :data:`ERK_ADAPTIVE_DEFAULTS`
-    Default PID controller settings applied when the tableau has an
+    Default PI controller settings applied when the tableau has an
     embedded error estimate.
 
 :data:`ERK_FIXED_DEFAULTS`
@@ -76,14 +76,14 @@ from cubie.integrators.algorithms.generic_erk_tableaus import (
 
 ERK_ADAPTIVE_DEFAULTS = StepControlDefaults(
     step_controller={
-        "step_controller": "pid",
+        "step_controller": "pi",
         "kp": 0.7,
         "ki": -0.4,
         "deadband_min": 1.0,
-        "deadband_max": 1.1,
-        "min_gain": 0.1,
-        "max_gain": 5.0,
-        "safety": 0.9
+        "deadband_max": 1.0,
+        "min_gain": 0.2,
+        "max_gain": 10.0,
+        "safety": 0.9,
     }
 )
 """Default step controller settings for adaptive ERK tableaus.
@@ -91,6 +91,13 @@ ERK_ADAPTIVE_DEFAULTS = StepControlDefaults(
 Applied when ``tableau.has_error_estimate`` is ``True``. Users can
 override individual settings by passing step controller parameters
 explicitly.
+
+The PI gains are the standard explicit Runge--Kutta pair
+``0.7/(order + 1)`` proportional and ``0.4/(order + 1)`` integral
+(Gustafsson 1991), and the step-ratio limits and safety factor match
+Hairer & Wanner's DOPRI5 (``facl = 0.2``, ``facr = 10``,
+``safe = 0.9``). Explicit steps are cheap to recompute, so no
+step-freeze deadband is applied.
 """
 
 ERK_FIXED_DEFAULTS = StepControlDefaults(
@@ -211,7 +218,7 @@ class ERKStep(ODEExplicitStep):
         >>> import numpy as np
         >>> step = ERKStep(precision=np.float32,n=3)
         >>> step.controller_defaults.step_controller["step_controller"]
-        'pid'
+        'pi'
 
         Create an ERK step with Classical RK4 (errorless):
 

--- a/src/cubie/integrators/algorithms/generic_firk.py
+++ b/src/cubie/integrators/algorithms/generic_firk.py
@@ -12,7 +12,7 @@ Published Classes
 Constants
 ---------
 :data:`FIRK_ADAPTIVE_DEFAULTS`
-    Default PID controller settings for adaptive tableaus.
+    Default Gustafsson controller settings for adaptive tableaus.
 
 :data:`FIRK_FIXED_DEFAULTS`
     Default fixed-step settings for errorless tableaus.
@@ -62,13 +62,12 @@ from cubie.buffer_registry import buffer_registry
 
 FIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
     step_controller={
-        "step_controller": "pid",
-        "kp": 0.6,
-        "ki": -0.4,
+        "step_controller": "gustafsson",
         "deadband_min": 1.0,
-        "deadband_max": 1.1,
-        "min_gain": 0.5,
-        "max_gain": 2.0,
+        "deadband_max": 1.2,
+        "min_gain": 0.2,
+        "max_gain": 8.0,
+        "safety": 0.9,
     }
 )
 """Default step controller settings for adaptive FIRK tableaus.
@@ -76,9 +75,12 @@ FIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
 This configuration is used when the FIRK tableau has an embedded error
 estimate (``tableau.has_error_estimate == True``).
 
-The PI controller provides robust adaptive stepping with proportional and
-derivative terms to smooth step size adjustments. The deadband prevents
-unnecessary step size changes for small variations in the error estimate.
+The Gustafsson predictive controller with these limits reproduces the
+step control of Hairer & Wanner's RADAU5, the reference implementation
+for fully implicit Runge--Kutta methods (``facl = 0.2``, ``facr = 8``,
+``quot1 = 1.0``, ``quot2 = 1.2``, ``safe = 0.9``). The deadband keeps
+the step unchanged for small gains so warp-coherent threads avoid
+needless step-size churn.
 
 Notes
 -----
@@ -153,8 +155,8 @@ class FIRKStep(ODEImplicitStep):
         This constructor creates a FIRK step object and automatically selects
         appropriate default step controller settings based on whether the
         tableau has an embedded error estimate. Tableaus with error estimates
-        default to adaptive stepping (PI controller), while errorless tableaus
-        default to fixed stepping.
+        default to adaptive stepping (Gustafsson controller), while
+        errorless tableaus default to fixed stepping.
 
         Parameters
         ----------
@@ -185,7 +187,7 @@ class FIRKStep(ODEImplicitStep):
         The step controller defaults are selected dynamically:
 
         - If ``tableau.has_error_estimate`` is ``True``:
-          Uses :data:`FIRK_ADAPTIVE_DEFAULTS` (PI controller)
+          Uses :data:`FIRK_ADAPTIVE_DEFAULTS` (Gustafsson controller)
         - If ``tableau.has_error_estimate`` is ``False``:
           Uses :data:`FIRK_FIXED_DEFAULTS` (fixed-step controller)
 

--- a/src/cubie/integrators/algorithms/generic_rosenbrock_w.py
+++ b/src/cubie/integrators/algorithms/generic_rosenbrock_w.py
@@ -12,7 +12,7 @@ Published Classes
 Constants
 ---------
 :data:`ROSENBROCK_ADAPTIVE_DEFAULTS`
-    Default PID controller settings for adaptive tableaus.
+    Default Gustafsson controller settings for adaptive tableaus.
 
 :data:`ROSENBROCK_FIXED_DEFAULTS`
     Default fixed-step settings for errorless tableaus.
@@ -67,13 +67,12 @@ from cubie.buffer_registry import buffer_registry
 
 ROSENBROCK_ADAPTIVE_DEFAULTS = StepControlDefaults(
     step_controller={
-        "step_controller": "pid",
-        "kp": 0.6,
-        "ki": -0.4,
+        "step_controller": "gustafsson",
         "deadband_min": 1.0,
-        "deadband_max": 1.1,
-        "min_gain": 0.5,
-        "max_gain": 2.0,
+        "deadband_max": 1.2,
+        "min_gain": 0.2,
+        "max_gain": 8.0,
+        "safety": 0.9,
     }
 )
 """Default step controller settings for adaptive Rosenbrock tableaus.
@@ -81,9 +80,14 @@ ROSENBROCK_ADAPTIVE_DEFAULTS = StepControlDefaults(
 This configuration is used when the Rosenbrock tableau has an embedded error
 estimate (``tableau.has_error_estimate == True``).
 
-The PI controller provides robust adaptive stepping with proportional and
-derivative terms to smooth step size adjustments. The deadband prevents
-unnecessary step size changes for small variations in the error estimate.
+The Gustafsson predictive controller is the standard choice for
+Rosenbrock methods (the default for the Rosenbrock family in
+OrdinaryDiffEq.jl). Rosenbrock steps report no Newton iterations, so
+the controller's iteration-dependent safety factor stays at its
+ceiling and only the predictive gain acts. Step-ratio limits,
+deadband, and safety factor follow Hairer & Wanner's RADAU5
+(``facl = 0.2``, ``facr = 8``, ``quot1 = 1.0``, ``quot2 = 1.2``,
+``safe = 0.9``).
 
 Notes
 -----
@@ -165,8 +169,8 @@ class GenericRosenbrockWStep(ODEImplicitStep):
         This constructor creates a Rosenbrock-W step object and automatically
         selects appropriate default step controller settings based on whether
         the tableau has an embedded error estimate. Tableaus with error
-        estimates default to adaptive stepping (PI controller), while
-        errorless tableaus default to fixed stepping.
+        estimates default to adaptive stepping (Gustafsson controller),
+        while errorless tableaus default to fixed stepping.
 
         Parameters
         ----------
@@ -198,7 +202,8 @@ class GenericRosenbrockWStep(ODEImplicitStep):
         The step controller defaults are selected dynamically:
 
         - If ``tableau.has_error_estimate`` is ``True``:
-          Uses :data:`ROSENBROCK_ADAPTIVE_DEFAULTS` (PI controller)
+          Uses :data:`ROSENBROCK_ADAPTIVE_DEFAULTS` (Gustafsson
+          controller)
         - If ``tableau.has_error_estimate`` is ``False``:
           Uses :data:`ROSENBROCK_FIXED_DEFAULTS` (fixed-step controller)
 

--- a/tests/integrated_numerical_tests/test_status_staining.py
+++ b/tests/integrated_numerical_tests/test_status_staining.py
@@ -61,6 +61,12 @@ def test_recovered_transient_failure_reports_success():
     proceeds to completion with a finite trajectory.  The delivered status
     must be ``0`` and the trajectory must be returned unmasked under the
     default ``nan_error_trajectories=True``.
+
+    The controller is pinned to a gently clamped PID (0.5--2.0 gain
+    limits) rather than the algorithm default: the recovery window
+    must stay open long enough for the reduced steps to converge, and
+    a springier controller can walk ``dt`` through ``dt_min`` before
+    the inner solve first succeeds.
     """
     system = _build_system()
     duration = 1.0
@@ -78,6 +84,13 @@ def test_recovered_transient_failure_reports_success():
         rtol=1e-3,
         save_every=duration / 10.0,
         krylov_max_iters=2,
+        step_controller="pid",
+        kp=0.6,
+        ki=-0.4,
+        deadband_min=1.0,
+        deadband_max=1.1,
+        min_gain=0.5,
+        max_gain=2.0,
         output_types=["state", "time"],
         grid_type="verbatim",
     )

--- a/tests/integrators/algorithms/instrumented/generic_dirk.py
+++ b/tests/integrators/algorithms/instrumented/generic_dirk.py
@@ -59,8 +59,8 @@ class InstrumentedDIRKStep(InstrumentedODEImplicitStep):
         This constructor creates a DIRK step object and automatically selects
         appropriate default step controller settings based on whether the
         tableau has an embedded error estimate. Tableaus with error estimates
-        default to adaptive stepping (PI controller), while errorless tableaus
-        default to fixed stepping.
+        default to adaptive stepping (Gustafsson controller), while
+        errorless tableaus default to fixed stepping.
 
         Parameters
         ----------
@@ -129,7 +129,7 @@ class InstrumentedDIRKStep(InstrumentedODEImplicitStep):
         The step controller defaults are selected dynamically:
 
         - If ``tableau.has_error_estimate`` is ``True``:
-          Uses :data:`DIRK_ADAPTIVE_DEFAULTS` (PI controller)
+          Uses :data:`DIRK_ADAPTIVE_DEFAULTS` (Gustafsson controller)
         - If ``tableau.has_error_estimate`` is ``False``:
           Uses :data:`DIRK_FIXED_DEFAULTS` (fixed-step controller)
 

--- a/tests/integrators/algorithms/instrumented/generic_firk.py
+++ b/tests/integrators/algorithms/instrumented/generic_firk.py
@@ -17,7 +17,7 @@ Notes
 The module defines two sets of default step controller settings:
 
 - :data:`FIRK_ADAPTIVE_DEFAULTS`: Used when the tableau has an embedded
-  error estimate. Defaults to PI controller with adaptive stepping.
+  error estimate. Defaults to Gustafsson controller with adaptive stepping.
 - :data:`FIRK_FIXED_DEFAULTS`: Used when the tableau lacks an error
   estimate. Defaults to fixed-step controller.
 
@@ -84,8 +84,8 @@ class InstrumentedFIRKStep(InstrumentedODEImplicitStep):
         This constructor creates a FIRK step object and automatically selects
         appropriate default step controller settings based on whether the
         tableau has an embedded error estimate. Tableaus with error estimates
-        default to adaptive stepping (PI controller), while errorless tableaus
-        default to fixed stepping.
+        default to adaptive stepping (Gustafsson controller), while
+        errorless tableaus default to fixed stepping.
 
         Parameters
         ----------
@@ -152,7 +152,7 @@ class InstrumentedFIRKStep(InstrumentedODEImplicitStep):
         The step controller defaults are selected dynamically:
 
         - If ``tableau.has_error_estimate`` is ``True``:
-          Uses :data:`FIRK_ADAPTIVE_DEFAULTS` (PI controller)
+          Uses :data:`FIRK_ADAPTIVE_DEFAULTS` (Gustafsson controller)
         - If ``tableau.has_error_estimate`` is ``False``:
           Uses :data:`FIRK_FIXED_DEFAULTS` (fixed-step controller)
 

--- a/tests/integrators/algorithms/instrumented/generic_rosenbrock_w.py
+++ b/tests/integrators/algorithms/instrumented/generic_rosenbrock_w.py
@@ -52,8 +52,9 @@ class InstrumentedRosenbrockWStep(InstrumentedODEImplicitStep):
         This constructor creates a Rosenbrock-W step object and automatically
         selects appropriate default step controller settings based on whether
         the tableau has an embedded error estimate. Tableaus with error
-        estimates default to adaptive stepping (PI controller), while
-        errorless tableaus default to fixed stepping.
+        estimates default to adaptive stepping (Gustafsson
+        controller), while errorless tableaus default to fixed
+        stepping.
 
         Parameters
         ----------
@@ -106,7 +107,7 @@ class InstrumentedRosenbrockWStep(InstrumentedODEImplicitStep):
         The step controller defaults are selected dynamically:
 
         - If ``tableau.has_error_estimate`` is ``True``:
-          Uses :data:`ROSENBROCK_ADAPTIVE_DEFAULTS` (PI controller)
+          Uses :data:`ROSENBROCK_ADAPTIVE_DEFAULTS` (Gustafsson controller)
         - If ``tableau.has_error_estimate`` is ``False``:
           Uses :data:`ROSENBROCK_FIXED_DEFAULTS` (fixed-step controller)
 

--- a/tests/integrators/algorithms/test_step_algorithms.py
+++ b/tests/integrators/algorithms/test_step_algorithms.py
@@ -730,18 +730,21 @@ def test_firk_step_is_multistage_matches_tableau():
         (ERKStep, ERK_TABLEAU_REGISTRY["classical-rk4"], {"step_controller": "fixed"}),
         (ERKStep, ERK_TABLEAU_REGISTRY["heun-21"], {"step_controller": "fixed"}),
         # ERK adaptive tableaus default to PI
-        (ERKStep, ERK_TABLEAU_REGISTRY["dormand-prince-54"], {"step_controller": "pid"}),
-        (ERKStep, DEFAULT_ERK_TABLEAU, {"step_controller": "pid"}),
-        # DIRK with error estimate defaults to PI
-        (DIRKStep, DIRK_TABLEAU_REGISTRY["sdirk_2_2"], {"step_controller":
-                                                            "fixed"}),
-        # DIRK with an embedded error estimate defaults to adaptive
+        (ERKStep, ERK_TABLEAU_REGISTRY["dormand-prince-54"],
+         {"step_controller": "pi"}),
+        (ERKStep, DEFAULT_ERK_TABLEAU, {"step_controller": "pi"}),
+        # DIRK without an error estimate defaults to fixed
+        (DIRKStep, DIRK_TABLEAU_REGISTRY["sdirk_2_2"],
+         {"step_controller": "fixed"}),
+        # DIRK with an embedded error estimate defaults to Gustafsson
         (DIRKStep, DIRK_TABLEAU_REGISTRY["l_stable_sdirk_4"],
-         {"step_controller": "pid"}),
-        # FIRK with error estimate defaults to PI
-        (FIRKStep, FIRK_TABLEAU_REGISTRY["radau"], {"step_controller": "pid"}),
-        # Rosenbrock with error estimate defaults to PI
-        (GenericRosenbrockWStep, DEFAULT_ROSENBROCK_TABLEAU, {"step_controller": "pid"}),
+         {"step_controller": "gustafsson"}),
+        # FIRK with error estimate defaults to Gustafsson
+        (FIRKStep, FIRK_TABLEAU_REGISTRY["radau"],
+         {"step_controller": "gustafsson"}),
+        # Rosenbrock with error estimate defaults to Gustafsson
+        (GenericRosenbrockWStep, DEFAULT_ROSENBROCK_TABLEAU,
+         {"step_controller": "gustafsson"}),
     ],
 )
 def test_tableau_controller_defaults(step_class, tableau, expected_dict):

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -205,7 +205,7 @@ def test_user_step_control_overrides_algorithm_defaults(
         algorithm_settings=algorithm_settings,
     )
 
-    assert run.step_controller == "pid"
+    assert run.step_controller == "gustafsson"
     assert run.dt_min == pytest.approx(override_settings["dt_min"])
     assert run.dt_max == pytest.approx(override_settings["dt_max"])
     controller_settings = run._step_controller.settings_dict


### PR DESCRIPTION
Closes #328.

## What

Per-algorithm step-controller defaults replace the blanket `pid` /
`kp=0.7` / `ki=-0.4` configuration, following the published tunings
for each method family:

| Family | Controller | Gains / limits | Source |
|---|---|---|---|
| ERK (`generic_erk.py`) | `pi` | `kp=0.7`, `ki=-0.4`, gain clamp 0.2–10, `safety=0.9`, no deadband | Gustafsson (1991) PI gains (`0.7/k`, `0.4/k`, the OrdinaryDiffEq.jl explicit-RK default); clamp/safety from Hairer & Wanner DOPRI5 (`facl=0.2`, `facr=10`, `safe=0.9`) and SciPy's RK MIN/MAX_FACTOR |
| DIRK (`generic_dirk.py`) | `gustafsson` | gain clamp 0.2–8, deadband 1.0–1.2, `safety=0.9` | Gustafsson (1994) predictive controller — the OrdinaryDiffEq.jl default for (E)SDIRK; limits from RADAU5 (`facl=0.2`, `facr=8`, `quot1=1`, `quot2=1.2`, `safe=0.9`) |
| FIRK (`generic_firk.py`) | `gustafsson` | same as DIRK | RADAU5's own controller — cubie's Gustafsson implements the identical `safe·(1+2·NIT)/(NEWT+2·NIT)` Newton-aware safety factor |
| Rosenbrock-W (`generic_rosenbrock_w.py`) | `gustafsson` | same as DIRK | OrdinaryDiffEq.jl default for the Rosenbrock family; the step reports no Newton iterations so the iteration term stays at its ceiling and only the predictive gain acts |
| Crank–Nicolson (`crank_nicolson.py`) | `gustafsson` | same as DIRK | Newton-based implicit method → stiff-family controller |

Errorless tableaus keep their fixed-step defaults. The controller
*class* defaults (`PIStepControlConfig` kp/ki, `gamma=0.9`, base
`min_gain`/`max_gain`) are unchanged; only the per-algorithm
`StepControlDefaults` dicts changed.

Notes:

- ERK moves from `pid` (with `kd` left at 0) to `pi`: identical
  arithmetic, one fewer persistent-local history slot per thread.
- The Gustafsson defaults deliberately do **not** set `gamma` or
  `newton_max_iters`: those names collide with algorithm/solver
  parameters, and the hot-swap path merges controller defaults into
  the shared `updates_dict` (`SingleIntegratorRunCore.py`). The
  controller's own defaults (`gamma=0.9` = RADAU5 `SAFE`,
  `newton_max_iters=20`) already match the literature values. A
  warning about this collision is recorded in
  `src/cubie/integrators/algorithms/AGENTS.md`.
- The wider gain clamps (max 8–10× vs the previous 2–5×) let the
  controllers grow `dt` out of transients far faster, which is the
  runtime motivation in #328.

Docs (algorithm defaults table, per-algorithm API pages, user guide)
updated to match.

## Sources

- K. Gustafsson, "Control theoretic techniques for stepsize selection
  in explicit Runge-Kutta methods", ACM TOMS 17(4), 1991.
- K. Gustafsson, "Control-theoretic techniques for stepsize selection
  in implicit Runge-Kutta methods", ACM TOMS 20(4), 1994.
- E. Hairer & G. Wanner, Solving ODEs II, and the RADAU5/DOPRI5
  Fortran sources (`radau5.f`: `SAFE=0.9`, `FACL=5` → 0.2 lower
  ratio, `FACR=1/8` → 8.0 upper ratio, `QUOT1=1.0`, `QUOT2=1.2`).
- OrdinaryDiffEq.jl timestepping docs: PredictiveController
  (Gustafsson acceleration) is the default for (E)SDIRK and
  Rosenbrock methods; PI is the explicit-RK default.

## Verification

- CUDASIM: `test_step_algorithms.py::test_tableau_controller_defaults`,
  `test_SingleIntegratorRunCore.py`, `step_control/test_init.py` —
  86 passed.
- Real GPU: same selection passed; end-to-end `Solver.solve` smoke
  with default controllers for `dormand-prince-54`,
  `l_stable_sdirk_4`, `radau`, `ros3p`, and `crank_nicolson` —
  correct controller selected, finite results, clean status.
- `flake8 --select=E9,F63,F7,F82`: clean.

## Performance gate

`benchmarks/lorenz_mean_runtime.py`, script defaults, A = `main`
(24d850f), B = this branch. The benchmark pins its own controller
settings (`step_controller="pid"`, explicit gains), so both sides
compile identical kernels; this change is host-side default
selection only.

| Config | A (main) mean ± std | B (PR) mean ± std | Welch z | Verdict |
|---|---|---|---|---|
| fixed (classical-rk4), 4.2M traj × 100 | 63.20 ± 0.78 ms | 63.28 ± 0.30 ms | +1.01 | no significant difference |
| adaptive (tsit5), 16.8M traj × 100 | 25.40 ± 0.29 ms | 25.10 ± 0.35 ms | −6.67 | means differ — improvement (run-to-run drift; kernels identical) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
