### PR TITLE
fix[CI]: spot-only GPU runners with backoff retry for the fixed spot quota

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -5,9 +5,11 @@
 #   runs-on: "runs-on=${{ github.run_id }}/runner=<name>"
 
 images:
-  # Custom Windows 2025 + NVIDIA T4 driver AMI, baked by
+  # Custom Windows 2025 + NVIDIA GRID driver AMI, baked by
   # .github/workflows/build-windows-gpu-ami.yml. RunsOn picks the most
-  # recent AMI matching `name` owned by `self` at launch.
+  # recent AMI matching `name` owned by `self` at launch. The single AWS
+  # GRID driver package covers G4dn (T4), G5 (A10G), and G6 (L4), so one
+  # AMI runs on any of those spot families.
   cubie-win-gpu:
     platform: windows
     arch: x64
@@ -19,14 +21,20 @@ images:
 runners:
   # Linux GPU: RunsOn's managed image (driver + CUDA toolkit +
   # container toolkit prebaked; rebuilt by RunsOn ~every 15 days).
-  # g4dn.2xlarge (8 vCPU) consumes the whole 8-vCPU On-Demand G
-  # quota, so the matrix runs one job at a time; see max-parallel in
-  # ci_cuda_tests.yml.
+  # Spot-only: ap-southeast-2 has zero On-Demand G/VT vCPU quota (and it
+  # is not grantable in this region), so every runner must be spot.
+  # capacity-optimized draws from whichever spot pool has the most
+  # headroom, and listing three 8-vCPU GPU families widens the pools to
+  # cut launch misses. All three are 8 vCPU, so `-n logical` still fans
+  # the tests out to 8 workers regardless of which pool wins.
   gpu-linux:
-    family: ["g4dn.2xlarge"]
+    family: ["g4dn.2xlarge", "g5.2xlarge", "g6.2xlarge"]
     image: ubuntu24-gpu-x64
+    spot: capacity-optimized
 
-  # Windows GPU: our baked AMI (driver already installed).
+  # Windows GPU: our baked AMI (GRID driver already installed). The AWS
+  # GRID driver is multi-GPU, so the same AMI runs on the T4/A10G/L4 spot
+  # pools listed below.
   # NOTE: RunsOn's build config defines a stock `windows25-gpu-x64` image
   # (built but, as of this writing, undocumented/unannounced -- the docs
   # still say Windows GPU is unsupported). If it becomes available in your
@@ -34,5 +42,6 @@ runners:
   # build-windows-gpu-ami.yml, ci/tools/install_gpu_driver.ps1, the
   # `images:` block above) and set `image: windows25-gpu-x64` here instead.
   gpu-windows:
-    family: ["g4dn.2xlarge"]
+    family: ["g4dn.2xlarge", "g5.2xlarge", "g6.2xlarge"]
     image: cubie-win-gpu
+    spot: capacity-optimized

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -23,14 +23,18 @@ runners:
   # container toolkit prebaked; rebuilt by RunsOn ~every 15 days).
   # Spot-only: ap-southeast-2 has zero On-Demand G/VT vCPU quota (and it
   # is not grantable in this region), so every runner must be spot.
-  # capacity-optimized draws from whichever spot pool has the most
-  # headroom, and listing three 8-vCPU GPU families widens the pools to
-  # cut launch misses. All three are 8 vCPU, so `-n logical` still fans
-  # the tests out to 8 workers regardless of which pool wins.
+  # price-capacity-optimized (pco, RunsOn's default) picks a high-capacity
+  # spot pool that is also among the cheapest -- cost matters here as this
+  # is personally funded. Listing three 8-vCPU GPU families widens the
+  # pools to cut launch misses. All three are 8 vCPU, so `-n logical`
+  # still fans the tests out to 8 workers regardless of which pool wins.
+  # The shared "All G and VT Spot" vCPU quota is fixed (AWS will not raise
+  # it further), so provisioning can still fail when it is momentarily
+  # exhausted; ci_cuda_tests.yml retries failed legs with backoff.
   gpu-linux:
     family: ["g4dn.2xlarge", "g5.2xlarge", "g6.2xlarge"]
     image: ubuntu24-gpu-x64
-    spot: capacity-optimized
+    spot: price-capacity-optimized
 
   # Windows GPU: our baked AMI (GRID driver already installed). The AWS
   # GRID driver is multi-GPU, so the same AMI runs on the T4/A10G/L4 spot
@@ -44,4 +48,4 @@ runners:
   gpu-windows:
     family: ["g4dn.2xlarge", "g5.2xlarge", "g6.2xlarge"]
     image: cubie-win-gpu
-    spot: capacity-optimized
+    spot: price-capacity-optimized

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -33,15 +33,14 @@ jobs:
       contains(github.event.head_commit.message, 'test_all')
     permissions:
       contents: read
-    # max-parallel: 1 because one g4dn.2xlarge = 8 vCPU = the whole
-    # On-Demand G quota. Calibrated against the last Lightning run,
-    # a grouped 8-worker job is ~13 min and the serial 8-job matrix
-    # ~106 min at ~$2/matrix — cost-neutral with 2 x g4dn.xlarge but
-    # with the fastest per-job feedback. The param-set xdist grouping
-    # (tests/conftest.py + --dist=loadgroup in addopts) keeps thread
-    # scaling near-linear, so the 8 vCPUs are fully used. Raise
-    # max-parallel only with a quota bump (each +1 needs +8 vCPU of
-    # G quota).
+    # max-parallel: 1 keeps the matrix to one 8-vCPU GPU instance at a
+    # time. Runners are spot-only (ap-southeast-2 has zero On-Demand G/VT
+    # quota, not grantable here), so concurrency is bounded by the shared
+    # "All G and VT Spot" vCPU quota; one g4dn/g5/g6.2xlarge = 8 vCPU fits
+    # under it. The param-set xdist grouping (tests/conftest.py +
+    # --dist=loadgroup in addopts) keeps thread scaling near-linear, so
+    # the 8 vCPUs are fully used. Raise max-parallel only after confirming
+    # spot vCPU headroom (each +1 needs +8 vCPU of G/VT spot quota).
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -1,12 +1,20 @@
 name: CUDA tests
 on:
   workflow_dispatch:
+    inputs:
+      attempt:
+        description: "Retry counter (internal; leave as 1 for manual runs)."
+        default: "1"
+      legs:
+        description: >
+          JSON array of matrix legs to run (internal; empty = full matrix).
+        default: ""
   schedule:
     - cron: "0 16 * * 1,3,5"   # Mon/Wed/Fri 16:00 UTC
   push:
     branches: ["main"]
-  # PRs opt in via a maintainer comment (see the job `if`) rather than
-  # running the paid GPU matrix on every PR.
+  # PRs opt in via a maintainer comment (see the `setup` job `if`) rather
+  # than running the paid GPU matrix on every PR.
   issue_comment:
     types: [created]
 
@@ -16,7 +24,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cuda:
+  # Resolve the matrix once so the retry path can re-run a subset of legs.
+  # A fresh workflow_dispatch (attempt=1, legs="") runs the full 8-leg
+  # matrix; a retry dispatch passes only the legs that never got a GPU.
+  setup:
     # Real-GPU runs on paid AWS runners. Trigger on schedule/dispatch, on a
     # push whose commit message opts in, or when a maintainer comments
     # `/test on cuda` on a PR. The author_association gate stops external
@@ -31,32 +42,57 @@ jobs:
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       contains(github.event.head_commit.message, 'test_cuda') ||
       contains(github.event.head_commit.message, 'test_all')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+      attempt: ${{ steps.gen.outputs.attempt }}
+    steps:
+      - name: Resolve matrix and attempt
+        id: gen
+        env:
+          IN_LEGS: ${{ inputs.legs }}
+          IN_ATTEMPT: ${{ inputs.attempt }}
+        run: |
+          set -euo pipefail
+          if [ -n "${IN_LEGS:-}" ]; then
+            MATRIX="$IN_LEGS"
+          else
+            MATRIX='[
+              {"os":"linux","python-version":"3.10","cuda":"12","extra":"dev12","runner":"gpu-linux"},
+              {"os":"linux","python-version":"3.10","cuda":"13","extra":"dev13","runner":"gpu-linux"},
+              {"os":"linux","python-version":"3.14","cuda":"12","extra":"dev12","runner":"gpu-linux"},
+              {"os":"linux","python-version":"3.14","cuda":"13","extra":"dev13","runner":"gpu-linux"},
+              {"os":"windows","python-version":"3.10","cuda":"12","extra":"dev12","runner":"gpu-windows"},
+              {"os":"windows","python-version":"3.10","cuda":"13","extra":"dev13","runner":"gpu-windows"},
+              {"os":"windows","python-version":"3.14","cuda":"12","extra":"dev12","runner":"gpu-windows"},
+              {"os":"windows","python-version":"3.14","cuda":"13","extra":"dev13","runner":"gpu-windows"}
+            ]'
+          fi
+          MATRIX=$(printf '%s' "$MATRIX" | jq -c '.')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "attempt=${IN_ATTEMPT:-1}" >> "$GITHUB_OUTPUT"
+
+  cuda:
+    needs: setup
+    name: cuda (${{ matrix.os }}, ${{ matrix.python-version }}, ${{ matrix.cuda }})
     permissions:
       contents: read
     # max-parallel: 1 keeps the matrix to one 8-vCPU GPU instance at a
     # time. Runners are spot-only (ap-southeast-2 has zero On-Demand G/VT
     # quota, not grantable here), so concurrency is bounded by the shared
     # "All G and VT Spot" vCPU quota; one g4dn/g5/g6.2xlarge = 8 vCPU fits
-    # under it. The param-set xdist grouping (tests/conftest.py +
-    # --dist=loadgroup in addopts) keeps thread scaling near-linear, so
-    # the 8 vCPUs are fully used. Raise max-parallel only after confirming
-    # spot vCPU headroom (each +1 needs +8 vCPU of G/VT spot quota).
+    # under it. That quota is fixed (AWS will not raise it), so a leg can
+    # still fail to get a spot GPU when it is momentarily exhausted -- the
+    # `retry` job re-dispatches those legs. The param-set xdist grouping
+    # (tests/conftest.py + --dist=loadgroup in addopts) keeps thread
+    # scaling near-linear, so the 8 vCPUs are fully used.
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        os: [linux, windows]
-        python-version: ["3.10", "3.14"]
-        cuda: ["12", "13"]
-        include:
-          - cuda: "12"
-            extra: dev12
-          - cuda: "13"
-            extra: dev13
-          - os: linux
-            runner: gpu-linux
-          - os: windows
-            runner: gpu-windows
+        include: ${{ fromJSON(needs.setup.outputs.matrix) }}
     runs-on: "runs-on=${{ github.run_id }}/runner=${{ matrix.runner }}"
 
     steps:
@@ -73,6 +109,20 @@ jobs:
 
       - name: GPU sanity check
         run: nvidia-smi
+
+      # A leg that reaches here got a real GPU, so any later failure is a
+      # genuine test failure, not a spot-provisioning miss. The `retry` job
+      # re-runs only legs WITHOUT this marker, so real failures stay red
+      # and are never wastefully re-run on the GPU.
+      - name: Mark GPU acquired
+        if: success()
+        run: echo ok > gpu-marker.txt
+      - name: Upload GPU marker
+        if: success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gpu-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}
+          path: gpu-marker.txt
 
       - name: Install cubie (${{ matrix.extra }})
         run: |
@@ -118,3 +168,70 @@ jobs:
           flags: ${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}
           disable_search: true
           fail_ci_if_error: false
+
+  # Re-dispatch legs that never got a spot GPU, with exponential backoff.
+  # This is the resilience layer for the fixed, un-raisable spot quota:
+  # RunsOn falls back to on-demand (which is 0 here, so it fails) for 5 min
+  # after a spot-quota miss, so the backoff starts at 5 min to outlast that
+  # snooze, and each retry is a fresh run (attempt resets on the runner, so
+  # RunsOn tries spot again rather than being forced onto on-demand).
+  retry:
+    needs: [setup, cuda]
+    if: always() && needs.setup.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Download GPU markers
+        # Do not fail the retry when zero legs got a GPU (no markers to
+        # download) -- that total-failure case is exactly when we must
+        # still re-dispatch. The compute step treats "no markers" as
+        # "every leg is retryable".
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          pattern: gpu-*
+          path: markers
+      - name: Re-dispatch legs that never got a GPU
+        env:
+          MATRIX: ${{ needs.setup.outputs.matrix }}
+          ATTEMPT: ${{ needs.setup.outputs.attempt }}
+          MAX_ATTEMPTS: "5"
+          BASE_BACKOFF: "300"   # seconds; first retry waits out the 5-min snooze
+          MAX_BACKOFF: "1200"   # cap at 20 min
+          REF: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Markers are artifacts named gpu-<os>-py<pyver>-cuda<cuda>; a leg
+          # with a marker acquired a GPU and is not a provisioning failure.
+          if [ -d markers ]; then
+            ls markers | sed -n 's/^gpu-//p' | sort -u > acquired.txt
+          else
+            : > acquired.txt
+          fi
+          RETRYABLE=$(printf '%s' "$MATRIX" | jq -c --rawfile s acquired.txt '
+            ($s | split("\n") | map(select(length > 0))) as $ok
+            | map(select(
+                (.os + "-py" + (."python-version") + "-cuda" + .cuda) as $k
+                | ($ok | index($k)) == null))')
+          COUNT=$(printf '%s' "$RETRYABLE" | jq 'length')
+          echo "Attempt ${ATTEMPT}: ${COUNT} leg(s) never acquired a GPU."
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No spot-provisioning failures to retry."
+            exit 0
+          fi
+          if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+            echo "Reached MAX_ATTEMPTS=${MAX_ATTEMPTS}; leaving the run red."
+            exit 0
+          fi
+          BACKOFF=$(( BASE_BACKOFF * (2 ** (ATTEMPT - 1)) ))
+          [ "$BACKOFF" -gt "$MAX_BACKOFF" ] && BACKOFF="$MAX_BACKOFF"
+          echo "Retrying these legs in ${BACKOFF}s:"
+          printf '%s' "$RETRYABLE" | jq .
+          sleep "$BACKOFF"
+          gh workflow run ci_cuda_tests.yml \
+            --ref "$REF" \
+            -f attempt="$(( ATTEMPT + 1 ))" \
+            -f legs="$RETRYABLE"

--- a/ci/tools/install_gpu_driver.ps1
+++ b/ci/tools/install_gpu_driver.ps1
@@ -1,10 +1,11 @@
 ##  Install and verify the NVIDIA GPU driver for the cubie Windows GPU CI
 ##  AMI. Adapted from runs-on/runner-images-for-aws (Install-GPU.ps1).
 ##
-##  Installs the AWS GRID driver for G4dn (T4) on Windows Server 2025 --
-##  the AWS-supported driver for these instances. The CUDA toolkit is NOT
-##  installed here: cubie resolves the toolkit from pip wheels
-##  (numba-cuda[cu12]/[cu13]); only the kernel driver is needed on the host.
+##  Installs the AWS GRID driver on Windows Server 2025 -- one package
+##  that covers G4dn (T4), G5 (A10G), and G6 (L4), so the single AMI runs
+##  on any of those spot families. The CUDA toolkit is NOT installed here:
+##  cubie resolves the toolkit from pip wheels (numba-cuda[cu12]/[cu13]);
+##  only the kernel driver is needed on the host.
 ##
 ##  Called twice by the Packer build with a windows-restart between: the
 ##  first run installs the driver, the second (marker present) verifies

--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -14,7 +14,11 @@ variable "region" {
   default = "ap-southeast-2"
 }
 
-# Builder needs a physical T4 present so the driver binds during the bake.
+# Builder needs a physical GPU present so the driver binds during the
+# bake. Baked on the cheapest T4 box; the AWS GRID driver it installs is
+# multi-GPU, so the resulting AMI also runs on G5 (A10G) and G6 (L4).
+# Requested as spot (see spot_instance_types) because this region has no
+# On-Demand G quota.
 variable "instance_type" {
   type    = string
   default = "g4dn.xlarge"
@@ -46,7 +50,8 @@ locals {
 
 source "amazon-ebs" "windows_gpu" {
   region                                     = var.region
-  instance_type                              = var.instance_type
+  spot_instance_types                        = [var.instance_type]
+  spot_allocation_strategy                   = "capacity-optimized"
   subnet_id                                  = var.subnet_id
   associate_public_ip_address                = true
   temporary_security_group_source_public_ip  = true


### PR DESCRIPTION
## Why

The first AWS/RunsOn CUDA run failed on both OSes. The job logs (scheduled
run `29272506339`) plus the RunsOn alert email pin the cause:

- **The matrix ran serially** (`max-parallel: 1` worked). Parallelism was
  never the problem.
- **Linux legs died on spot-quota exhaustion.** RunsOn emailed
  `MaxSpotInstanceCountExceeded` (family g4dn). On a spot-quota miss RunsOn
  disables spot account-wide for 5 min and uses **on-demand** — but
  On-Demand G in `ap-southeast-2` is **0** (`VcpuLimitExceeded … limit of
  0`), so the leg fails on a non-GPU fallback at `nvidia-smi`. The one leg
  that launched while spot was live got a spot g4dn.2xlarge and passed.
- **Windows legs: the AMI never existed** (`cubie-win-gpu-*` unresolved) —
  `build-windows-gpu-ami.yml` has never run, and the bake used on-demand,
  blocked by the same 0 quota.

The spot G/VT vCPU quota is **fixed** — AWS has denied further increases —
and On-Demand G is 0 and not grantable here. RunsOn exposes **no** knob to
disable on-demand fallback, shorten the hard-coded 5-min snooze, or wait
for spot ([spot-pricing docs](https://runs-on.com/docs/costs/spot-pricing/)).
So reliability has to come from the workflow.

## What changed

**Spot-only runners, cost-first** (`.github/runs-on.yml`)
- Both runners `spot: price-capacity-optimized` (pco — RunsOn's default,
  cheapest-with-capacity) since this is personally funded.
- Widened pool `["g4dn.2xlarge","g5.2xlarge","g6.2xlarge"]` (all 8 vCPU) so
  spot draws from more T4/A10G/L4 pools. (Note: this cuts *capacity*
  misses; it does not raise the shared vCPU quota.)

**Backoff retry pipeline** (`.github/workflows/ci_cuda_tests.yml`) — now
`setup → cuda → retry`:
- `setup` resolves the matrix (full 8 legs, or a subset on retry).
- Each `cuda` leg uploads a **GPU marker** once `nvidia-smi` passes.
- `retry` re-dispatches **only legs that never got a GPU** (spot-
  provisioning misses) as a **fresh** `workflow_dispatch`. Freshness
  matters: an in-place job re-run sets attempt > 1, which makes RunsOn
  force on-demand (= 0 = fail); a new run tries spot again. Backoff is
  exponential from **5 min** (outlasting the snooze) → 10 → 20 (capped),
  up to 4 retries.
- Legs that reached a real GPU and then failed **tests** are never re-run
  — they stay red, so genuine failures aren't masked or billed twice.

**Windows AMI is multi-GPU** (`packer/windows-gpu.pkr.hcl`,
`ci/tools/install_gpu_driver.ps1`) — bake runs on spot; the AWS GRID
driver it installs already covers T4/A10G/L4
([AWS GRID driver families](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvidia-GRID-driver.html)),
so one AMI serves all three Windows spot families.

## Still needed out-of-band

**Bake the Windows AMI** after merge: `gh workflow run
build-windows-gpu-ami.yml`, then confirm `aws ec2 describe-images
--owners self --filters "Name=name,Values=cubie-win-gpu-*"` returns an
image. The 14-day cron keeps it fresh after that. (No spot-quota action —
you've maxed it; the retry pipeline is the mitigation.)

## Verification

- Both YAML files parse; the `retry` job's leg-selection logic (marker
  name ↔ jq key, failed-subset filter, backoff schedule 5/10/20 min) was
  re-implemented in Python and checked against pass/fail scenarios.
- Committed blob is LF (autocrlf normalizes), so the `run:` shell blocks
  are safe on the runners.
- End-to-end (spot miss → backoff → re-dispatch → green) can only be
  confirmed by a live dispatch on the branch: `gh workflow run
  ci_cuda_tests.yml --ref ci-spot-gpu-runners`. Self-dispatch uses
  `github.ref_name`, so retries stay on whichever branch started them.
- Performance gate: N/A — CI-config only, no `src/` changes.

## Known trade-off

If one attempt has both a real test failure and a spot miss, the retry
re-runs only the spot miss; the real failure is visible in that attempt's
(red) run, not carried into the next. Each attempt is its own run, so the
history stays honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
