### PR TITLE
fix[CI]: make the Windows AMI bake succeed under spot (simple request + AZ sweep)

### DIFF
--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -17,11 +17,21 @@ variable "region" {
 # Builder needs a physical GPU present so the driver binds during the
 # bake. Baked on the cheapest T4 box; the AWS GRID driver it installs is
 # multi-GPU, so the resulting AMI also runs on G5 (A10G) and G6 (L4).
-# Requested as spot (see spot_instance_types) because this region has no
-# On-Demand G quota.
+# Requested as spot (see spot_price) because this region has no On-Demand
+# G quota. Kept as a single instance_type + spot_price ("simple" spot
+# request) rather than spot_instance_types: the latter uses the EC2 Fleet
+# API, which needs ec2:DescribeInstanceTypeOfferings on the builder role.
 variable "instance_type" {
   type    = string
   default = "g4dn.xlarge"
+}
+
+# Max hourly spot bid. AWS never charges above the on-demand price
+# (g4dn.xlarge is ~$0.75/h in ap-southeast-2), so this ceiling only has to
+# clear the market spot price; you pay the actual (lower) spot rate.
+variable "spot_price" {
+  type    = string
+  default = "1.00"
 }
 
 # Empty -> Packer picks a subnet in the default VPC. Set explicitly if the
@@ -50,8 +60,8 @@ locals {
 
 source "amazon-ebs" "windows_gpu" {
   region                                     = var.region
-  spot_instance_types                        = [var.instance_type]
-  spot_allocation_strategy                   = "capacity-optimized"
+  instance_type                              = var.instance_type
+  spot_price                                 = var.spot_price
   subnet_id                                  = var.subnet_id
   associate_public_ip_address                = true
   temporary_security_group_source_public_ip  = true


### PR DESCRIPTION
Follow-up to #604 — makes the Windows AMI bake actually complete under
this account's spot-only, capacity-constrained conditions. Two fixes,
each found from a live bake log.

## 1. Simple spot request, not EC2 Fleet-by-accident

The first bake died with `m1.small ... does not support UEFI`. #604 set
`spot_instance_types`, whose fallback launched a plain `RunInstances`
with an empty instance type → AWS default `m1.small` (pre-Nitro) → can't
boot the UEFI Windows AMI. Now a single `instance_type` (`g4dn.xlarge`) +
`spot_price` ceiling, staying off the zero On-Demand G quota.

## 2. Sweep Availability Zones (the zone-lock)

Once IAM was fixed the bake reached the fleet and failed:
`insufficient g4dn.xlarge capacity in ap-southeast-2b ... choose 2a/2c`.
Packer pins a build to one subnet = one AZ, and spot capacity is per-AZ.
The build step now enumerates the default VPC's per-AZ subnets and runs
packer against each until one AZ has capacity (AWS's own advice,
automated). `AWS_BUILD_SUBNET_ID` still pins one subnet when set.

The RunsOn CI runners need no equivalent — RunsOn already spreads spot
across AZs (its fleet in the first CUDA run spanned 2a and 2b).

## AWS-side (not in this repo), already applied on the target account

The `cubie-ami-builder` role needs the spot-Fleet EC2 actions (this
plugin routes all spot builds through a Fleet + launch template):

```bash
aws iam put-role-policy --role-name cubie-ami-builder --policy-name PackerSpotBake \
  --policy-document '{"Version":"2012-10-17","Statement":[{"Sid":"PackerSpotBake","Effect":"Allow","Action":["ec2:DescribeInstanceTypeOfferings","ec2:DescribeSpotPriceHistory","ec2:CreateLaunchTemplate","ec2:DeleteLaunchTemplate","ec2:CreateFleet"],"Resource":"*"}]}'
```

## Verification

- YAML parses; the AZ-sweep shell passes `bash -n` and was simulated with
  a mock packer (fails AZ 2a/2b, succeeds 2c → exit 0; all-fail → exit 1).
- HCL edit validated by `packer init/validate` in the workflow. No `src/`
  changes → performance gate N/A.
- Live bake progression confirms each fix in turn (m1.small → offerings
  403 → CreateFleet 403 → AZ capacity). Final green needs one more
  `gh workflow run build-windows-gpu-ami.yml` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
