### PR TITLE
fix[CI]: sweep AZs when baking the Windows GPU AMI (spot zone-lock)

### DIFF
--- a/.github/workflows/build-windows-gpu-ami.yml
+++ b/.github/workflows/build-windows-gpu-ami.yml
@@ -30,12 +30,16 @@ jobs:
 
       - name: Build AMI
         # Spot g4dn.xlarge capacity is per-Availability-Zone, and Packer
-        # pins a build to a single subnet (hence a single AZ). A run that
-        # lands in an AZ with no spot capacity fails the fleet request, so
-        # sweep the default VPC's subnets (one per AZ) and take the first
-        # AZ that has capacity -- automating AWS's own "choose another AZ"
-        # advice. Set AWS_BUILD_SUBNET_ID to pin one subnet instead (e.g.
-        # an account with no default VPC).
+        # pins a build to a single subnet (hence a single AZ). Sweep the
+        # default VPC's subnets (one per AZ) and take the first AZ with
+        # capacity -- automating AWS's own "choose another AZ" advice.
+        # Only an AZ-capacity error advances the sweep: any other Packer
+        # failure (WinRM timeout, driver install, security group, or a
+        # regional spot-quota miss that recurs in every AZ) short-circuits
+        # immediately, because a Windows bake can run 30-60 min per AZ and
+        # sweeping on a non-capacity error would waste hours. Set
+        # AWS_BUILD_SUBNET_ID to pin one subnet instead (e.g. no default
+        # VPC).
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           PINNED_SUBNET: ${{ vars.AWS_BUILD_SUBNET_ID }}
@@ -56,23 +60,40 @@ jobs:
             echo "No candidate subnets found; set AWS_BUILD_SUBNET_ID." >&2
             exit 1
           fi
+          # Errors that mean "this AZ is out of capacity, try another". A
+          # regional spot-quota miss (MaxSpotInstanceCountExceeded) is
+          # intentionally excluded -- every AZ shares that quota.
+          CAP_RE='InsufficientInstanceCapacity|capacity-not-available|do not have sufficient .*capacity|insufficient .*capacity in the [Aa]vailability [Zz]one'
           echo "Candidate subnets (one per AZ): $SUBNETS"
+          swept=0
+          last_rc=1
           for SN in $SUBNETS; do
             echo "::group::packer build on subnet $SN"
-            if packer build \
-                 -var "region=$AWS_REGION" \
-                 -var "subnet_id=$SN" \
-                 packer/windows-gpu.pkr.hcl; then
-              echo "::endgroup::"
+            set +e
+            packer build \
+              -var "region=$AWS_REGION" \
+              -var "subnet_id=$SN" \
+              packer/windows-gpu.pkr.hcl 2>&1 | tee packer.out
+            rc=${PIPESTATUS[0]}
+            set -e
+            echo "::endgroup::"
+            if [ "$rc" -eq 0 ]; then
               echo "Bake succeeded in subnet $SN."
               exit 0
             fi
-            echo "::endgroup::"
-            echo "Subnet $SN failed (likely no spot capacity in its AZ);" \
-                 "trying the next AZ."
+            if grep -Eq "$CAP_RE" packer.out; then
+              echo "Subnet $SN: no spot capacity in its AZ (rc=$rc);" \
+                   "trying the next AZ."
+              swept=1
+              last_rc=$rc
+              continue
+            fi
+            echo "Subnet $SN: Packer failed for a non-capacity reason" \
+                 "(rc=$rc); not sweeping further AZs." >&2
+            exit "$rc"
           done
-          echo "No AZ had spot capacity for the bake instance." >&2
-          exit 1
+          echo "Every candidate AZ was out of spot capacity (swept=$swept)." >&2
+          exit "$last_rc"
 
       - name: Deregister superseded cubie-win-gpu AMIs
         # Keep the most recent AMI; deregister older ones (and their

--- a/.github/workflows/build-windows-gpu-ami.yml
+++ b/.github/workflows/build-windows-gpu-ami.yml
@@ -29,13 +29,50 @@ jobs:
         run: packer init packer/windows-gpu.pkr.hcl
 
       - name: Build AMI
-        # AWS_BUILD_SUBNET_ID is optional: leave the repo variable unset to
-        # let Packer pick a subnet in the default VPC.
-        run: >
-          packer build
-          -var "region=${{ vars.AWS_REGION }}"
-          -var "subnet_id=${{ vars.AWS_BUILD_SUBNET_ID }}"
-          packer/windows-gpu.pkr.hcl
+        # Spot g4dn.xlarge capacity is per-Availability-Zone, and Packer
+        # pins a build to a single subnet (hence a single AZ). A run that
+        # lands in an AZ with no spot capacity fails the fleet request, so
+        # sweep the default VPC's subnets (one per AZ) and take the first
+        # AZ that has capacity -- automating AWS's own "choose another AZ"
+        # advice. Set AWS_BUILD_SUBNET_ID to pin one subnet instead (e.g.
+        # an account with no default VPC).
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          PINNED_SUBNET: ${{ vars.AWS_BUILD_SUBNET_ID }}
+        run: |
+          set -euo pipefail
+          if [ -n "${PINNED_SUBNET:-}" ]; then
+            SUBNETS="$PINNED_SUBNET"
+          else
+            VPC=$(aws ec2 describe-vpcs --region "$AWS_REGION" \
+              --filters Name=isDefault,Values=true \
+              --query 'Vpcs[0].VpcId' --output text)
+            SUBNETS=$(aws ec2 describe-subnets --region "$AWS_REGION" \
+              --filters "Name=vpc-id,Values=$VPC" \
+                        "Name=default-for-az,Values=true" \
+              --query 'Subnets[].SubnetId' --output text)
+          fi
+          if [ -z "${SUBNETS// /}" ]; then
+            echo "No candidate subnets found; set AWS_BUILD_SUBNET_ID." >&2
+            exit 1
+          fi
+          echo "Candidate subnets (one per AZ): $SUBNETS"
+          for SN in $SUBNETS; do
+            echo "::group::packer build on subnet $SN"
+            if packer build \
+                 -var "region=$AWS_REGION" \
+                 -var "subnet_id=$SN" \
+                 packer/windows-gpu.pkr.hcl; then
+              echo "::endgroup::"
+              echo "Bake succeeded in subnet $SN."
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "Subnet $SN failed (likely no spot capacity in its AZ);" \
+                 "trying the next AZ."
+          done
+          echo "No AZ had spot capacity for the bake instance." >&2
+          exit 1
 
       - name: Deregister superseded cubie-win-gpu AMIs
         # Keep the most recent AMI; deregister older ones (and their


### PR DESCRIPTION
## Why

Follow-up to #606. With the simple-spot request and Fleet IAM in place,
the bake reached the spot fleet and then failed:

```
Error waiting for fleet request to become ready: We currently do not have
sufficient g4dn.xlarge capacity in the Availability Zone you requested
(ap-southeast-2b). ... choose ap-southeast-2a, ap-southeast-2c.
```

Packer pins a build to a single subnet — hence a single AZ — and spot
capacity is per-AZ. Packer has no "span all AZs" option: `subnet_id` and
`subnet_filter` both resolve to exactly one subnet.

## Fix

Automate AWS's advice at the workflow level: enumerate the default VPC's
per-AZ subnets and run `packer build` against each until one AZ has
capacity. `AWS_BUILD_SUBNET_ID` still pins one subnet when set. Needs no
new IAM (`DescribeVpcs`/`DescribeSubnets` are already used by Packer's own
inference).

**Only capacity errors sweep.** Each attempt's output is captured and
matched against the AZ-capacity signatures (`InsufficientInstanceCapacity`,
`capacity-not-available`, "do not have sufficient … capacity in the
Availability Zone"). Any other failure — WinRM timeout, driver install,
security group, or a regional `MaxSpotInstanceCountExceeded` quota miss
that recurs in every AZ — exits immediately with Packer's real exit code,
rather than relaunching (30-60 min per AZ) and ending with a misleading
"no capacity" message.

The RunsOn CI runners need no equivalent — RunsOn already spreads spot
across AZs (its fleet in the first CUDA run spanned 2a and 2b).

## Verification

- YAML parses; the sweep shell passes `bash -n`.
- Branching simulated with a mock packer: capacity-then-ok → sweeps 2a/2b,
  succeeds 2c (exit 0); WinRM-timeout → stops on 2a, no sweep (exit 1);
  all-capacity-limited → sweeps all, exit 1. The `packer` call runs under
  `set +e` with its exit code captured, so a failed AZ neither aborts the
  loop nor is misread.
- The capacity regex was checked against real error strings: it matches
  the AWS capacity message, `InsufficientInstanceCapacity`, and
  `capacity-not-available`; it does NOT match WinRM timeout,
  `MaxSpotInstanceCountExceeded`, or `UnauthorizedOperation`.
- No `src/` changes → performance gate N/A. Final green needs one
  `gh workflow run build-windows-gpu-ami.yml` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
