### PR TITLE
fix[CI]: robust spot-miss detection + multi-GPU-type fleet for the AMI bake

### DIFF
--- a/.github/workflows/build-windows-gpu-ami.yml
+++ b/.github/workflows/build-windows-gpu-ami.yml
@@ -60,10 +60,17 @@ jobs:
             echo "No candidate subnets found; set AWS_BUILD_SUBNET_ID." >&2
             exit 1
           fi
-          # Errors that mean "this AZ is out of capacity, try another". A
-          # regional spot-quota miss (MaxSpotInstanceCountExceeded) is
-          # intentionally excluded -- every AZ shares that quota.
-          CAP_RE='InsufficientInstanceCapacity|capacity-not-available|do not have sufficient .*capacity|insufficient .*capacity in the [Aa]vailability [Zz]one'
+          # A spot-provisioning miss = the fleet yielded no instance.
+          # Packer prints "Error waiting for fleet request" only when
+          # len(instances)==0 (step_run_spot_instance.go), and every AWS
+          # capacity phrasing ("insufficient ... capacity", "no Spot
+          # capacity available", ...) is wrapped by it -- so match the
+          # wrapper, not the wording. Post-launch failures (WinRM, driver
+          # install; 30-60 min) happen in later steps with other messages
+          # and fall through to fail-fast. A regional spot-quota miss
+          # (MaxSpotInstanceCountExceeded) is checked first and NOT swept:
+          # every AZ shares that quota.
+          FLEET_MISS_RE='Error waiting for fleet request|InsufficientInstanceCapacity|no Spot capacity available|capacity-not-available|insufficient .*capacity'
           echo "Candidate subnets (one per AZ): $SUBNETS"
           swept=0
           last_rc=1
@@ -81,15 +88,20 @@ jobs:
               echo "Bake succeeded in subnet $SN."
               exit 0
             fi
-            if grep -Eq "$CAP_RE" packer.out; then
-              echo "Subnet $SN: no spot capacity in its AZ (rc=$rc);" \
+            if grep -q "MaxSpotInstanceCountExceeded" packer.out; then
+              echo "Subnet $SN: regional spot quota exhausted (rc=$rc);" \
+                   "every AZ shares it, so not sweeping." >&2
+              exit "$rc"
+            fi
+            if grep -Eq "$FLEET_MISS_RE" packer.out; then
+              echo "Subnet $SN: fleet found no spot capacity (rc=$rc);" \
                    "trying the next AZ."
               swept=1
               last_rc=$rc
               continue
             fi
-            echo "Subnet $SN: Packer failed for a non-capacity reason" \
-                 "(rc=$rc); not sweeping further AZs." >&2
+            echo "Subnet $SN: Packer failed after launch / for a" \
+                 "non-capacity reason (rc=$rc); not sweeping further." >&2
             exit "$rc"
           done
           echo "Every candidate AZ was out of spot capacity (swept=$swept)." >&2

--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -15,15 +15,15 @@ variable "region" {
 }
 
 # Builder needs a physical GPU present so the driver binds during the
-# bake. Baked on the cheapest T4 box; the AWS GRID driver it installs is
-# multi-GPU, so the resulting AMI also runs on G5 (A10G) and G6 (L4).
-# Requested as spot (see spot_price) because this region has no On-Demand
-# G quota. Kept as a single instance_type + spot_price ("simple" spot
-# request) rather than spot_instance_types: the latter uses the EC2 Fleet
-# API, which needs ec2:DescribeInstanceTypeOfferings on the builder role.
-variable "instance_type" {
-  type    = string
-  default = "g4dn.xlarge"
+# bake. The AWS GRID driver it installs is multi-GPU (T4/A10G/L4), so any
+# of these families bakes a working AMI; listing several lets the spot
+# fleet take whichever GPU pool has capacity (g4dn.xlarge spot is often
+# dry across whole AZs). Requested as spot because this region has no
+# On-Demand G quota. Uses the Fleet IAM actions (CreateFleet,
+# CreateLaunchTemplate, DeleteLaunchTemplate) on the builder role.
+variable "spot_instance_types" {
+  type    = list(string)
+  default = ["g4dn.xlarge", "g4dn.2xlarge", "g5.xlarge", "g6.xlarge"]
 }
 
 # Max hourly spot bid. AWS never charges above the on-demand price
@@ -60,7 +60,8 @@ locals {
 
 source "amazon-ebs" "windows_gpu" {
   region                                     = var.region
-  instance_type                              = var.instance_type
+  spot_instance_types                        = var.spot_instance_types
+  spot_allocation_strategy                   = "capacity-optimized"
   spot_price                                 = var.spot_price
   subnet_id                                  = var.subnet_id
   associate_public_ip_address                = true
@@ -107,7 +108,7 @@ New-NetFirewallRule -DisplayName "Windows Remote Management (HTTPS-In)" -Name "W
 EOF
 
   ami_name        = "cubie-win-gpu-${local.timestamp}"
-  ami_description = "RunsOn Windows 2025 + NVIDIA T4 GRID driver for cubie CUDA CI"
+  ami_description = "RunsOn Windows 2025 + NVIDIA GRID driver (T4/A10G/L4) for cubie CUDA CI"
 
   launch_block_device_mappings {
     device_name           = "/dev/sda1"


### PR DESCRIPTION
Follow-up to #607. Two live bakes kept failing on spot capacity; this
makes the bake robust instead of guessing at error wording.

## 1. Retry signal keyed on Packer's fleet marker, not capacity wording

#607 matched a hand-listed set of capacity strings. AWS used a second
phrasing — `There is no Spot capacity available that matches your
request` — which wasn't in the list, so the sweep treated it as a
non-capacity failure and fail-fasted on the **first** AZ, never trying
the others.

Verified in Packer's source (`step_run_spot_instance.go`): it prints
`Error waiting for fleet request` **only** when the fleet returns zero
instances, and every AWS capacity phrasing is wrapped by it. The sweep
now keys on that marker. Branching is three-way:

- `MaxSpotInstanceCountExceeded` (regional quota) → **fail fast** (every
  AZ shares the quota).
- fleet yielded no instance → **try next AZ**.
- anything else, incl. post-launch WinRM/driver failures (30-60 min) →
  **fail fast** (never sweeps a config error across AZs).

## 2. Multi-GPU-type fleet so capacity is findable

g4dn.xlarge spot was dry across AZs. Now that the builder role has the
Fleet IAM actions, the bake requests a fleet of several GPU types
(`g4dn.xlarge`, `g4dn.2xlarge`, `g5.xlarge`, `g6.xlarge`) with
`capacity-optimized` allocation, taking whichever pool has capacity. The
AWS GRID driver is multi-GPU (T4/A10G/L4), so any of them bakes a valid
AMI. The sweep passes an explicit subnet, so there's no subnet inference
and no `m1.small` fallback (the failure mode from #604).

## Preflight (read-only, run before baking)

Confirms where GPU spot capacity is, so we don't bake blind:

```bash
aws ec2 get-spot-placement-scores --region ap-southeast-2 \
  --instance-types g4dn.xlarge g4dn.2xlarge g5.xlarge g6.xlarge \
  --target-capacity 1 --single-availability-zone \
  --query 'SpotPlacementScores[].{AZ:AvailabilityZoneId,Score:Score}' \
  --output table
```

Score is 1-10 (10 = very likely). If several AZ/type pools score well the
bake will land; if everything scores 1-2, GPU spot is dry region-wide and
no config change helps (wait / rethink) — either way, no wasted bake.

## Verification

- YAML parses; sweep shell passes `bash -n`.
- Three-way branch simulated with a mock packer against the REAL strings:
  "no Spot capacity available" → sweeps 2a/2b, succeeds 2c (exit 0);
  `MaxSpotInstanceCountExceeded` → fail fast; WinRM timeout → fail fast.
- Pattern checked against real error strings: matches
  `Error waiting for fleet request`, `InsufficientInstanceCapacity`, and
  the "insufficient ... capacity" wording; ignores WinRM and the quota
  miss.
- Packer HCL: `spot_instance_types` + `capacity-optimized` + `spot_price`,
  no stray `instance_type`; validated by `packer validate` in the
  workflow. No `src/` changes → performance gate N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
