### PR TITLE
fix[CI]: raise AMI-bake spot ceiling so pricier GPU types aren't excluded

### DIFF
--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -26,12 +26,17 @@ variable "spot_instance_types" {
   default = ["g4dn.xlarge", "g4dn.2xlarge", "g5.xlarge", "g6.xlarge"]
 }
 
-# Max hourly spot bid. AWS never charges above the on-demand price
-# (g4dn.xlarge is ~$0.75/h in ap-southeast-2), so this ceiling only has to
-# clear the market spot price; you pay the actual (lower) spot rate.
+# Max hourly spot bid. A ceiling only EXCLUDES pools -- AWS always charges
+# the live spot rate (itself capped at on-demand), never this number, so
+# it must clear the on-demand price of every type in spot_instance_types
+# or those types are dropped from the fleet ("Unable to fulfill capacity
+# due to your request configuration"). These are Windows instances (spot
+# carries a licensing premium) and g4dn.2xlarge/g5.xlarge on-demand are
+# ~$1.1-1.3/h, so 1.00 silently excluded them. 3.00 clears all four with
+# margin; the actual charge is still the (far lower) market spot rate.
 variable "spot_price" {
   type    = string
-  default = "1.00"
+  default = "3.00"
 }
 
 # Empty -> Packer picks a subnet in the default VPC. Set explicitly if the


### PR DESCRIPTION
Follow-up to #608. The bake fleet failed with:

```
Error waiting for fleet request (...) to become ready: Unable to fulfill
capacity due to your request configuration. Please adjust your request
and try again.
```

## Cause (documented, not guessed)

Per [AWS Spot troubleshooting](https://repost.aws/knowledge-center/ec2-spot-instance-insufficient-capacity):
"If your max price is set too low, it can restrict which instance types
are available to fulfill your request." A spot max price is only a
ceiling — AWS always charges the live spot rate (itself capped at
on-demand), never the ceiling — so setting it low only *excludes* pools.

`spot_price = "1.00"` was below the on-demand price of most of the fleet's
types. These are **Windows** instances (spot carries a licensing premium),
and g4dn.2xlarge / g5.xlarge on-demand run ~$1.1-1.3/h, so only
g4dn.xlarge was priced in — and g4dn.xlarge is the pool with no capacity.
Net: nothing fulfillable.

## Fix

Raise the ceiling to `3.00`, clearing all four types' on-demand with
margin. The actual charge is still the market spot rate (far lower).

## Preflight (read-only) — run these before the next bake

They turn "bake and see" into a lookup. **Current Windows spot prices** —
confirms which types clear the ceiling:

```bash
aws ec2 describe-spot-price-history --region ap-southeast-2 \
  --instance-types g4dn.xlarge g4dn.2xlarge g5.xlarge g6.xlarge \
  --product-descriptions Windows \
  --start-time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
  --query 'SpotPriceHistory[].[AvailabilityZone,InstanceType,SpotPrice]' \
  --output table
```

**Capacity per AZ** — confirms a bake can land at all:

```bash
aws ec2 get-spot-placement-scores --region ap-southeast-2 \
  --instance-types g4dn.xlarge g4dn.2xlarge g5.xlarge g6.xlarge \
  --target-capacity 1 --single-availability-zone \
  --query 'SpotPlacementScores[].{AZ:AvailabilityZoneId,Score:Score}' \
  --output table
```

If placement scores are all 1-2, GPU spot is dry region-wide and no
config change bakes an AMI right now — see the PR discussion for the
strategic options (schedule-retry vs dropping the Windows GPU leg).

## Verification

One-line HCL value change (`spot_price` default 1.00 → 3.00) plus comment;
validated by `packer validate` in the workflow. No `src/` changes →
performance gate N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
