### PR TITLE
fix: persistent local scratch array sized from the persistent layout

### DIFF
--- a/src/cubie/batchsolving/BatchSolverKernel.py
+++ b/src/cubie/batchsolving/BatchSolverKernel.py
@@ -976,9 +976,9 @@ class BatchSolverKernel(CUDAFactory):
         self.output_arrays.wait_pending()
 
     @property
-    def local_memory_elements(self) -> int:
-        """Number of precision elements required in local memory per run."""
-        return self.single_integrator.local_memory_elements
+    def persistent_local_elements(self) -> int:
+        """Number of elements in the per-thread persistent local array."""
+        return self.single_integrator.persistent_local_elements
 
     @property
     def shared_memory_elements(self) -> int:

--- a/src/cubie/buffer_registry.py
+++ b/src/cubie/buffer_registry.py
@@ -970,8 +970,8 @@ class BufferRegistry:
         Parameters
         ----------
         kernel
-            Kernel instance with `local_memory_elements` and `precision`
-            properties.
+            Kernel instance with `persistent_local_elements` and
+            `precision` properties.
 
         Returns
         -------
@@ -981,7 +981,7 @@ class BufferRegistry:
             - alloc_persistent: (shared) -> persistent local array
         """
 
-        persistent_size = max(1, kernel.local_memory_elements)
+        persistent_size = max(1, kernel.persistent_local_elements)
         precision = kernel.precision
         numba_precision = from_dtype(precision)
 

--- a/src/cubie/integrators/SingleIntegratorRun.py
+++ b/src/cubie/integrators/SingleIntegratorRun.py
@@ -78,11 +78,6 @@ class SingleIntegratorRun(SingleIntegratorRunCore):
         return element_count * itemsize
 
     @property
-    def local_memory_elements(self) -> int:
-        """Return total persistent local-memory requirement."""
-        return self._loop.local_buffer_size
-
-    @property
     def persistent_local_elements(self) -> int:
         """Return total persistent local-memory elements required by the loop."""
         return self._loop.persistent_local_buffer_size

--- a/src/cubie/integrators/step_control/AGENTS.md
+++ b/src/cubie/integrators/step_control/AGENTS.md
@@ -47,7 +47,7 @@ controllers.
   previous `dt` and norm (I and fixed keep no history). The slot count is the
   `_timestep_buffer_elements` class attribute (PI 1, PID/Gustafsson 2, fixed/I 0), which
   the base `register_buffers()` uses to register the buffer — controllers with 0 register
-  nothing. There is **no** `local_memory_elements` property; query the size the same way
+  nothing. There is **no** `persistent_local_elements` property; query the size the same way
   as any other buffer-registered factory, via the registry-derived
   `persistent_local_buffer_size`.
 

--- a/tests/batchsolving/test_SolverKernel.py
+++ b/tests/batchsolving/test_SolverKernel.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from cubie.batchsolving.BatchSolverKernel import BatchSolverKernel
+from cubie.buffer_registry import buffer_registry
 from cubie.outputhandling.output_sizes import BatchOutputSizes
 from cubie.outputhandling.output_config import OutputCompileFlags
 from cubie.batchsolving.BatchSolverConfig import ActiveOutputs
@@ -552,8 +553,6 @@ def test_persistent_array_sized_from_persistent_layout(solverkernel):
     ``persistent_local_elements``; any other sizing source lets the
     slices run past the array end and corrupt per-thread storage.
     """
-    from cubie.buffer_registry import buffer_registry
-
     loop = solverkernel.single_integrator._loop
     assert solverkernel.persistent_local_elements == (
         buffer_registry.persistent_local_buffer_size(loop)

--- a/tests/batchsolving/test_SolverKernel.py
+++ b/tests/batchsolving/test_SolverKernel.py
@@ -542,3 +542,19 @@ def test_limit_blocksize_leaves_fitting_requests_alone(solverkernel):
     )
     assert new_blocksize == 256
     assert new_smem == 16384
+
+
+def test_persistent_array_sized_from_persistent_layout(solverkernel):
+    """The persistent scratch array is sized by the persistent layout.
+
+    The loop's persistent slices index into the array that
+    ``buffer_registry.get_toplevel_allocators`` sizes from
+    ``persistent_local_elements``; any other sizing source lets the
+    slices run past the array end and corrupt per-thread storage.
+    """
+    from cubie.buffer_registry import buffer_registry
+
+    loop = solverkernel.single_integrator._loop
+    assert solverkernel.persistent_local_elements == (
+        buffer_registry.persistent_local_buffer_size(loop)
+    )

--- a/tests/batchsolving/test_config_plumbing.py
+++ b/tests/batchsolving/test_config_plumbing.py
@@ -296,7 +296,7 @@ def assert_singleintegratorrun_config(single_integrator, settings, tolerance):
 
     # Not tested (runtime/computed values):
     # - numba_precision, algorithm_key: aliases/derived
-    # - shared_memory_elements, local_memory_elements: computed
+    # - shared_memory_elements, persistent_local_elements: computed
     # - compiled_loop_function, threads_per_loop: compiled artifacts
     # - _algo_step, _step_controller, _loop, _output_functions: tested separately
 

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -3,6 +3,8 @@ from typing import Iterable
 import pytest
 import numpy as np
 
+from tests._utils import _build_solver_instance
+
 from cubie import create_ODE_system
 from cubie.batchsolving.solver import Solver, solve_ivp
 from cubie.batchsolving.solveresult import SolveResult, SolveSpec
@@ -1620,12 +1622,23 @@ def test_solver_set_verbosity(solver_mutable):
 
 @pytest.mark.parametrize(
     "solver_settings_override",
-    [{"system_type": "large"}],
+    [{
+        "system_type": "large",
+        "algorithm": "dirk",
+        "duration": 0.02,
+        "output_types": ["state"],
+        "saved_observable_indices": [],
+        "summarised_observable_indices": [],
+    }],
     indirect=True,
 )
 def test_shared_loop_buffers_leave_results_unchanged(
+    solver,
+    solver_settings,
     system,
+    driver_array,
     driver_settings,
+    thread_mem_manager,
     simple_initial_values,
     simple_parameters,
 ):
@@ -1636,7 +1649,10 @@ def test_shared_loop_buffers_leave_results_unchanged(
     plain-local pool far below the DIRK step's persistent
     requirement, so this fails loudly if the persistent scratch
     array is ever again sized from the plain-local total instead
-    of the persistent layout.
+    of the persistent layout. The all-local baseline is the shared
+    ``solver`` fixture; only the relocated comparison solver is
+    built fresh, because buffer placement is a construction
+    setting.
     """
     shared_locations = {
         "state_location": "shared",
@@ -1649,28 +1665,26 @@ def test_shared_loop_buffers_leave_results_unchanged(
         "error_location": "shared",
     }
 
-    def build_and_solve(locations):
-        solver = Solver(
-            system,
-            algorithm="dirk",
-            dt=0.01,
-            step_controller="fixed",
-            output_types=["state"],
-            **locations,
-        )
-        result = solver.solve(
+    def run_solve(active_solver):
+        result = active_solver.solve(
             initial_values=simple_initial_values,
             parameters=simple_parameters,
             drivers=driver_settings,
-            duration=0.02,
-            save_every=0.02,
-            blocksize=32,
-            grid_type="verbatim",
+            duration=solver_settings["duration"],
         )
         return np.asarray(result.time_domain_array)
 
-    local_output = build_and_solve({})
-    shared_output = build_and_solve(shared_locations)
+    local_output = run_solve(solver)
+
+    shared_settings = dict(solver_settings)
+    shared_settings.update(shared_locations)
+    shared_solver = _build_solver_instance(
+        system=system,
+        solver_settings=shared_settings,
+        driver_array=driver_array,
+        memory_manager=thread_mem_manager,
+    )
+    shared_output = run_solve(shared_solver)
 
     assert np.all(np.isfinite(local_output))
     np.testing.assert_array_equal(shared_output, local_output)

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -1616,3 +1616,61 @@ def test_solver_set_verbosity(solver_mutable):
     assert default_timelogger.verbosity == "verbose"
     solver.set_verbosity(None)
     assert default_timelogger.verbosity is None
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{"system_type": "large"}],
+    indirect=True,
+)
+def test_shared_loop_buffers_leave_results_unchanged(
+    system,
+    driver_settings,
+    simple_initial_values,
+    simple_parameters,
+):
+    """Buffer placement is storage-only: moving every movable loop
+    buffer to shared memory reproduces the all-local trajectories.
+
+    On the 100-state system these placements shrink the loop's
+    plain-local pool far below the DIRK step's persistent
+    requirement, so this fails loudly if the persistent scratch
+    array is ever again sized from the plain-local total instead
+    of the persistent layout.
+    """
+    shared_locations = {
+        "state_location": "shared",
+        "proposed_state_location": "shared",
+        "parameters_location": "shared",
+        "drivers_location": "shared",
+        "proposed_drivers_location": "shared",
+        "observables_location": "shared",
+        "proposed_observables_location": "shared",
+        "error_location": "shared",
+    }
+
+    def build_and_solve(locations):
+        solver = Solver(
+            system,
+            algorithm="dirk",
+            dt=0.01,
+            step_controller="fixed",
+            output_types=["state"],
+            **locations,
+        )
+        result = solver.solve(
+            initial_values=simple_initial_values,
+            parameters=simple_parameters,
+            drivers=driver_settings,
+            duration=0.02,
+            save_every=0.02,
+            blocksize=32,
+            grid_type="verbatim",
+        )
+        return np.asarray(result.time_domain_array)
+
+    local_output = build_and_solve({})
+    shared_output = build_and_solve(shared_locations)
+
+    assert np.all(np.isfinite(local_output))
+    np.testing.assert_array_equal(shared_output, local_output)

--- a/tests/integrators/test_SingleIntegratorRun.py
+++ b/tests/integrators/test_SingleIntegratorRun.py
@@ -40,7 +40,6 @@ def test_loop_forwarding(single_integrator_run):
     loop = run._loop
 
     assert run.shared_memory_elements == loop.shared_buffer_size
-    assert run.local_memory_elements == loop.local_buffer_size
     assert run.persistent_local_elements == loop.persistent_local_buffer_size
 
     assert run.save_every == loop.save_every


### PR DESCRIPTION
## Root cause

`buffer_registry.get_toplevel_allocators` sizes the kernel's per-thread persistent scratch array from the kernel's sizing property (`buffer_registry.py:984`), but `SingleIntegratorRun.local_memory_elements` returned **`self._loop.local_buffer_size`** — the sum of the loop's *plain-local* buffer sizes — instead of the persistent-layout total its docstring promised. The correctly-named property, `persistent_local_elements`, existed three lines below with zero consumers.

With default all-local placements the plain-local sum happens to exceed the persistent requirement for every algorithm, so the array was oversized and the bug invisible. Any shared buffer placement that shrinks the plain-local pool below the persistent requirement (e.g. `state_location="shared"` with dirk: plain-local 30 elements vs `algorithm_persistent [0,32)`) makes every persistent slice run past the end of the array:

- **Real GPU:** silent per-thread corruption — all-NaN trajectories for dirk/firk with state buffers in shared memory, ~1e-6..1e-2 output drift for backwards_euler and larger dirk systems.
- **CUDASIM:** `IndexError: index 30 is out of bounds for axis 0 with size 30` in the allocator zero-init (`buffer_registry.py:148`).

Found while benchmarking buffer placements for #329: every corrupted sweep cell was a `state`/`proposed_state`-shared placement on a Newton-implicit algorithm, and the underflow arithmetic reproduces each observed failure exactly.

## Fix

The kernel persistent array is sized from `persistent_local_elements` (the loop's persistent-layout total). The broken `local_memory_elements` property is removed from `SingleIntegratorRun` and `BatchSolverKernel`; `get_toplevel_allocators` reads `kernel.persistent_local_elements`.

## Tests

- `test_persistent_array_sized_from_persistent_layout` pins the sizing contract (kernel sizing quantity == persistent layout requirement).
- `test_shared_loop_buffers_leave_results_unchanged` solves the 100-state system with dirk twice (all-local vs every movable loop buffer in shared) and asserts identical trajectories. Verified to **fail on pre-fix source** (CUDASIM, 1 failed) and pass with the fix.
- Real GPU: 226 tests across `test_solver.py`, `test_SolverKernel.py`, `test_config_plumbing.py`, `test_SingleIntegratorRun.py`, `test_buffer_registry.py`, `test_buffer_settings.py` all pass.

## Performance gate (`benchmarks/lorenz_mean_runtime.py`)

| config | A (main 38c7654) | B (this PR) | Welch z | verdict |
|---|---|---|---|---|
| fixed (classical-rk4), 2^22 runs | 63.20 ± 0.60 ms | 63.19 ± 0.51 ms | −0.17 | no significant difference |
| adaptive (tsit5), 2^24 runs | 25.17 ± 0.51 ms | 25.13 ± 0.32 ms | −0.64 | no significant difference |

🤖 Generated with [Claude Code](https://claude.com/claude-code)