### PR TITLE
fix[CI]: correct the GRID driver name + backoff-retry spot acquisition

### DIFF
--- a/.github/workflows/build-windows-gpu-ami.yml
+++ b/.github/workflows/build-windows-gpu-ami.yml
@@ -29,20 +29,25 @@ jobs:
         run: packer init packer/windows-gpu.pkr.hcl
 
       - name: Build AMI
-        # Spot g4dn.xlarge capacity is per-Availability-Zone, and Packer
-        # pins a build to a single subnet (hence a single AZ). Sweep the
-        # default VPC's subnets (one per AZ) and take the first AZ with
-        # capacity -- automating AWS's own "choose another AZ" advice.
-        # Only an AZ-capacity error advances the sweep: any other Packer
-        # failure (WinRM timeout, driver install, security group, or a
-        # regional spot-quota miss that recurs in every AZ) short-circuits
-        # immediately, because a Windows bake can run 30-60 min per AZ and
-        # sweeping on a non-capacity error would waste hours. Set
-        # AWS_BUILD_SUBNET_ID to pin one subnet instead (e.g. no default
-        # VPC).
+        # Acquire a spot GPU instance, then bake. Two nested retries cope
+        # with this region's tight, fluctuating GPU spot capacity:
+        #  * AZ sweep (spatial): Packer pins a build to one subnet = one AZ
+        #    and capacity is per-AZ, so try each default-VPC subnet in turn.
+        #  * backoff rounds (temporal): if no AZ has capacity this round,
+        #    wait with exponential backoff and sweep again -- spot capacity
+        #    frees up over minutes.
+        # Only a spot-acquisition miss (fleet yielded no instance) retries.
+        # A post-launch failure (WinRM, driver install) exits immediately
+        # with Packer's real code -- it would recur in every AZ and a
+        # Windows bake runs 30-60 min. A regional spot-quota miss
+        # (MaxSpotInstanceCountExceeded) skips the rest of the AZ sweep (all
+        # AZs share the quota) but still backs off and retries. Set
+        # AWS_BUILD_SUBNET_ID to pin one subnet (e.g. no default VPC).
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           PINNED_SUBNET: ${{ vars.AWS_BUILD_SUBNET_ID }}
+          MAX_ROUNDS: "4"
+          BASE_BACKOFF: "120"   # seconds between rounds; doubles each round
         run: |
           set -euo pipefail
           if [ -n "${PINNED_SUBNET:-}" ]; then
@@ -60,52 +65,50 @@ jobs:
             echo "No candidate subnets found; set AWS_BUILD_SUBNET_ID." >&2
             exit 1
           fi
-          # A spot-provisioning miss = the fleet yielded no instance.
-          # Packer prints "Error waiting for fleet request" only when
-          # len(instances)==0 (step_run_spot_instance.go), and every AWS
-          # capacity phrasing ("insufficient ... capacity", "no Spot
-          # capacity available", ...) is wrapped by it -- so match the
-          # wrapper, not the wording. Post-launch failures (WinRM, driver
-          # install; 30-60 min) happen in later steps with other messages
-          # and fall through to fail-fast. A regional spot-quota miss
-          # (MaxSpotInstanceCountExceeded) is checked first and NOT swept:
-          # every AZ shares that quota.
+          # "Error waiting for fleet request" is printed only when the fleet
+          # yields no instance (step_run_spot_instance.go); every AWS
+          # capacity phrasing is wrapped by it, so match the wrapper.
           FLEET_MISS_RE='Error waiting for fleet request|InsufficientInstanceCapacity|no Spot capacity available|capacity-not-available|insufficient .*capacity'
           echo "Candidate subnets (one per AZ): $SUBNETS"
-          swept=0
-          last_rc=1
-          for SN in $SUBNETS; do
-            echo "::group::packer build on subnet $SN"
-            set +e
-            packer build \
-              -var "region=$AWS_REGION" \
-              -var "subnet_id=$SN" \
-              packer/windows-gpu.pkr.hcl 2>&1 | tee packer.out
-            rc=${PIPESTATUS[0]}
-            set -e
-            echo "::endgroup::"
-            if [ "$rc" -eq 0 ]; then
-              echo "Bake succeeded in subnet $SN."
-              exit 0
-            fi
-            if grep -q "MaxSpotInstanceCountExceeded" packer.out; then
-              echo "Subnet $SN: regional spot quota exhausted (rc=$rc);" \
-                   "every AZ shares it, so not sweeping." >&2
+          for round in $(seq 1 "$MAX_ROUNDS"); do
+            echo "===== spot-acquisition round $round/$MAX_ROUNDS ====="
+            for SN in $SUBNETS; do
+              echo "::group::packer build on subnet $SN (round $round)"
+              set +e
+              packer build \
+                -var "region=$AWS_REGION" \
+                -var "subnet_id=$SN" \
+                packer/windows-gpu.pkr.hcl 2>&1 | tee packer.out
+              rc=${PIPESTATUS[0]}
+              set -e
+              echo "::endgroup::"
+              if [ "$rc" -eq 0 ]; then
+                echo "Bake succeeded in subnet $SN."
+                exit 0
+              fi
+              if grep -q "MaxSpotInstanceCountExceeded" packer.out; then
+                echo "Subnet $SN: regional spot quota exhausted (rc=$rc);" \
+                     "all AZs share it -- backing off." >&2
+                break
+              fi
+              if grep -Eq "$FLEET_MISS_RE" packer.out; then
+                echo "Subnet $SN: no spot capacity now (rc=$rc);" \
+                     "trying the next AZ."
+                continue
+              fi
+              echo "Subnet $SN: Packer failed after launch / for a" \
+                   "non-capacity reason (rc=$rc); not retrying." >&2
               exit "$rc"
+            done
+            if [ "$round" -lt "$MAX_ROUNDS" ]; then
+              backoff=$(( BASE_BACKOFF * (2 ** (round - 1)) ))
+              echo "Round $round: no AZ had spot GPU capacity;" \
+                   "retrying in ${backoff}s..."
+              sleep "$backoff"
             fi
-            if grep -Eq "$FLEET_MISS_RE" packer.out; then
-              echo "Subnet $SN: fleet found no spot capacity (rc=$rc);" \
-                   "trying the next AZ."
-              swept=1
-              last_rc=$rc
-              continue
-            fi
-            echo "Subnet $SN: Packer failed after launch / for a" \
-                 "non-capacity reason (rc=$rc); not sweeping further." >&2
-            exit "$rc"
           done
-          echo "Every candidate AZ was out of spot capacity (swept=$swept)." >&2
-          exit "$last_rc"
+          echo "No spot GPU capacity after $MAX_ROUNDS rounds." >&2
+          exit 1
 
       - name: Deregister superseded cubie-win-gpu AMIs
         # Keep the most recent AMI; deregister older ones (and their

--- a/.github/workflows/build-windows-gpu-ami.yml
+++ b/.github/workflows/build-windows-gpu-ami.yml
@@ -29,25 +29,27 @@ jobs:
         run: packer init packer/windows-gpu.pkr.hcl
 
       - name: Build AMI
-        # Acquire a spot GPU instance, then bake. Two nested retries cope
-        # with this region's tight, fluctuating GPU spot capacity:
+        # Acquire a spot GPU instance, then bake. GPU spot capacity here is
+        # tight and shows up in brief, random windows (freed when some other
+        # load ends), so two nested retries chase it:
         #  * AZ sweep (spatial): Packer pins a build to one subnet = one AZ
         #    and capacity is per-AZ, so try each default-VPC subnet in turn.
-        #  * backoff rounds (temporal): if no AZ has capacity this round,
-        #    wait with exponential backoff and sweep again -- spot capacity
-        #    frees up over minutes.
+        #  * short fixed-interval rounds (temporal): a dry fleet fails in
+        #    ~6s, so poll frequently at a constant interval to catch a brief
+        #    window -- exponential backoff would just miss it by waiting
+        #    ever longer.
         # Only a spot-acquisition miss (fleet yielded no instance) retries.
         # A post-launch failure (WinRM, driver install) exits immediately
         # with Packer's real code -- it would recur in every AZ and a
         # Windows bake runs 30-60 min. A regional spot-quota miss
-        # (MaxSpotInstanceCountExceeded) skips the rest of the AZ sweep (all
-        # AZs share the quota) but still backs off and retries. Set
+        # (MaxSpotInstanceCountExceeded) skips the rest of that round's AZ
+        # sweep (all AZs share the quota) but still retries. Set
         # AWS_BUILD_SUBNET_ID to pin one subnet (e.g. no default VPC).
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           PINNED_SUBNET: ${{ vars.AWS_BUILD_SUBNET_ID }}
-          MAX_ROUNDS: "4"
-          BASE_BACKOFF: "120"   # seconds between rounds; doubles each round
+          MAX_ROUNDS: "40"
+          RETRY_INTERVAL: "20"   # seconds between rounds; short and frequent
         run: |
           set -euo pipefail
           if [ -n "${PINNED_SUBNET:-}" ]; then
@@ -88,7 +90,7 @@ jobs:
               fi
               if grep -q "MaxSpotInstanceCountExceeded" packer.out; then
                 echo "Subnet $SN: regional spot quota exhausted (rc=$rc);" \
-                     "all AZs share it -- backing off." >&2
+                     "all AZs share it -- skipping to the next round." >&2
                 break
               fi
               if grep -Eq "$FLEET_MISS_RE" packer.out; then
@@ -101,10 +103,9 @@ jobs:
               exit "$rc"
             done
             if [ "$round" -lt "$MAX_ROUNDS" ]; then
-              backoff=$(( BASE_BACKOFF * (2 ** (round - 1)) ))
               echo "Round $round: no AZ had spot GPU capacity;" \
-                   "retrying in ${backoff}s..."
-              sleep "$backoff"
+                   "retrying in ${RETRY_INTERVAL}s..."
+              sleep "$RETRY_INTERVAL"
             fi
           done
           echo "No spot GPU capacity after $MAX_ROUNDS rounds." >&2

--- a/ci/tools/install_gpu_driver.ps1
+++ b/ci/tools/install_gpu_driver.ps1
@@ -42,36 +42,9 @@ function Invoke-ExternalCommand {
     return $process.ExitCode
 }
 
-function Invoke-WithRetry {
-    # Retry a network action with exponential backoff. The bucket listing
-    # and the driver download are the transient-failure points here.
-    param(
-        [Parameter(Mandatory = $true)][scriptblock]$Action,
-        [string]$Description = 'operation',
-        [int]$MaxAttempts = 5,
-        [int]$BaseDelaySeconds = 5
-    )
-    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
-        try {
-            return & $Action
-        }
-        catch {
-            if ($attempt -eq $MaxAttempts) {
-                throw "Failed $Description after $MaxAttempts attempts: $($_.Exception.Message)"
-            }
-            $delay = $BaseDelaySeconds * [math]::Pow(2, $attempt - 1)
-            Write-Host ("Attempt {0}/{1} for {2} failed: {3}. Retrying in {4}s..." -f `
-                $attempt, $MaxAttempts, $Description, $_.Exception.Message, $delay)
-            Start-Sleep -Seconds $delay
-        }
-    }
-}
-
 function Get-LatestAwsGridDriverKey {
-    $listing = Invoke-WithRetry -Description "list $driverBucketUrl/latest/" -Action {
-        [xml](Invoke-WebRequest -Uri "$driverBucketUrl/?prefix=latest/" `
-            -UseBasicParsing).Content
-    }
+    [xml]$listing = (Invoke-WebRequest -Uri "$driverBucketUrl/?prefix=latest/" `
+        -UseBasicParsing).Content
     $keys = @($listing.ListBucketResult.Contents | ForEach-Object { $_.Key })
 
     # AWS ships one GRID DCH driver, e.g.
@@ -105,10 +78,7 @@ function Ensure-AwsGridDriverInstaller {
     $driverKey = Get-LatestAwsGridDriverKey
     $driverUri = "$driverBucketUrl/$driverKey"
     Write-Host "Downloading AWS GRID driver from $driverUri"
-    Invoke-WithRetry -Description "download $driverUri" -Action {
-        Invoke-WebRequest -Uri $driverUri -OutFile $driverInstaller `
-            -UseBasicParsing
-    }
+    Invoke-WebRequest -Uri $driverUri -OutFile $driverInstaller -UseBasicParsing
 }
 
 function Install-AwsGridDriver {

--- a/ci/tools/install_gpu_driver.ps1
+++ b/ci/tools/install_gpu_driver.ps1
@@ -42,20 +42,52 @@ function Invoke-ExternalCommand {
     return $process.ExitCode
 }
 
+function Invoke-WithRetry {
+    # Retry a network action with exponential backoff. The bucket listing
+    # and the driver download are the transient-failure points here.
+    param(
+        [Parameter(Mandatory = $true)][scriptblock]$Action,
+        [string]$Description = 'operation',
+        [int]$MaxAttempts = 5,
+        [int]$BaseDelaySeconds = 5
+    )
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        try {
+            return & $Action
+        }
+        catch {
+            if ($attempt -eq $MaxAttempts) {
+                throw "Failed $Description after $MaxAttempts attempts: $($_.Exception.Message)"
+            }
+            $delay = $BaseDelaySeconds * [math]::Pow(2, $attempt - 1)
+            Write-Host ("Attempt {0}/{1} for {2} failed: {3}. Retrying in {4}s..." -f `
+                $attempt, $MaxAttempts, $Description, $_.Exception.Message, $delay)
+            Start-Sleep -Seconds $delay
+        }
+    }
+}
+
 function Get-LatestAwsGridDriverKey {
-    [xml]$listing = (Invoke-WebRequest -Uri "$driverBucketUrl/?prefix=latest/" -UseBasicParsing).Content
+    $listing = Invoke-WithRetry -Description "list $driverBucketUrl/latest/" -Action {
+        [xml](Invoke-WebRequest -Uri "$driverBucketUrl/?prefix=latest/" `
+            -UseBasicParsing).Content
+    }
     $keys = @($listing.ListBucketResult.Contents | ForEach-Object { $_.Key })
 
+    # AWS ships one GRID DCH driver, e.g.
+    #   latest/596.36_grid_win10_win11_server2022_64bit_dch_international_aws_swl.exe
+    # It is a multi-OS DCH package that runs on Server 2025 too (there is no
+    # separate "server2025" build), so match any GRID .exe rather than a
+    # specific Windows version. The post-install Assert-CudaAtLeast13 guards
+    # against an unexpectedly old driver.
     $matchingKey = $keys |
-        Where-Object { $_ -match '^latest/.+server2025.+\.exe$' } |
+        Where-Object { $_ -match '^latest/.*grid.*\.exe$' } |
         Select-Object -First 1
 
-    # Fail loudly rather than fall back to an arbitrary .exe, which could be
-    # a wrong-OS (e.g. Server 2022) driver on this Server 2025 base.
     if (-not $matchingKey) {
         Write-Host "Available driver keys under latest/:"
         $keys | ForEach-Object { Write-Host "  $_" }
-        throw "No Windows Server 2025 GRID driver found under $driverBucketUrl/latest/."
+        throw "No AWS GRID driver (.exe) found under $driverBucketUrl/latest/."
     }
 
     return $matchingKey
@@ -73,7 +105,10 @@ function Ensure-AwsGridDriverInstaller {
     $driverKey = Get-LatestAwsGridDriverKey
     $driverUri = "$driverBucketUrl/$driverKey"
     Write-Host "Downloading AWS GRID driver from $driverUri"
-    Invoke-WebRequest -Uri $driverUri -OutFile $driverInstaller -UseBasicParsing
+    Invoke-WithRetry -Description "download $driverUri" -Action {
+        Invoke-WebRequest -Uri $driverUri -OutFile $driverInstaller `
+            -UseBasicParsing
+    }
 }
 
 function Install-AwsGridDriver {

--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -23,15 +23,20 @@ variable "region" {
 # CreateLaunchTemplate, DeleteLaunchTemplate) on the builder role.
 variable "spot_instance_types" {
   type    = list(string)
-  default = ["g4dn.xlarge", "g4dn.2xlarge", "g5.xlarge", "g6.xlarge"]
+  default = [
+    "g4dn.xlarge", "g4dn.2xlarge",
+    "g5.xlarge", "g5.2xlarge",
+    "g6.xlarge", "g6.2xlarge",
+  ]
 }
 
-# Max hourly spot bid. AWS never charges above the on-demand price
-# (g4dn.xlarge is ~$0.75/h in ap-southeast-2), so this ceiling only has to
-# clear the market spot price; you pay the actual (lower) spot rate.
+# Max hourly spot bid. A ceiling only EXCLUDES pools -- AWS charges the
+# live spot rate (itself capped at on-demand), never this number -- so it
+# just needs to clear every listed type's market spot price (all well
+# under $0.65 for these xlarge/2xlarge GPU types). 1.50 leaves headroom.
 variable "spot_price" {
   type    = string
-  default = "1.00"
+  default = "1.50"
 }
 
 # Empty -> Packer picks a subnet in the default VPC. Set explicitly if the


### PR DESCRIPTION
Makes the Windows AMI bake complete under this region's tight, bursty GPU
spot capacity. The multi-AZ/multi-type fleet already proved it can launch
an instance and reach the driver install; this series fixes what blocked
completion.

## 1. Correct the GRID driver filename filter

`Get-LatestAwsGridDriverKey` filtered for `server2025`, but AWS ships one
GRID DCH driver named `...win10_win11_server2022...dch...aws_swl.exe` --
a multi-OS package that runs on Server 2025 (no server2025-specific
build). Now matches any GRID `.exe` under `latest/`; `Assert-CudaAtLeast13`
still fails an unexpectedly old driver.

## 2. Chase spot capacity with short, frequent retries

Live logs show GPU spot capacity appears in brief, random windows (freed
when other loads end), not a slow recovery -- so exponential backoff
misses it. Instead:

- **AZ sweep (spatial):** all types are tried in every AZ each round (the
  CreateFleet override list carries every type; AWS returns one result per
  type per AZ).
- **Short fixed-interval rounds (temporal):** a dry fleet fails in ~6s, so
  poll at a constant 20s, up to 40 rounds (~25 min), to catch a window.
- Six pools -- g4dn/g5/g6 in xlarge and 2xlarge -- so capacity-optimized
  can grab whichever frees up.
- Spot bid ceiling 1.50 (all these types' spot is under ~$0.65; a ceiling
  only excludes pools, it is never charged).
- Post-launch failures (WinRM, driver install) still exit immediately; a
  regional quota miss skips the round's remaining AZs but still retries.

## Verification

- Driver script parses; regex matches the real key, rejects non-GRID.
- Workflow YAML parses, sweep shell passes `bash -n`; env is MAX_ROUNDS=40,
  RETRY_INTERVAL=20 (exponential backoff removed).
- Round/AZ control flow simulated earlier (success-after-rounds, post-
  launch fail-fast, quota break, exhaustion).
- Being exercised live by a branch dispatch of build-windows-gpu-ami.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
