### PR TITLE
feat: measured heuristics choose buffer memory locations by system size

### DIFF
--- a/benchmarks/memory_location_sweep.py
+++ b/benchmarks/memory_location_sweep.py
@@ -1,0 +1,622 @@
+#!/usr/bin/env python
+"""Overnight sweep: buffer memory locations across sizes and algorithms.
+
+Measures kernel runtime for placement variants of every registered
+buffer group (loop arrays, algorithm work buffers, nonlinear/linear
+solver vectors) over a grid of system sizes (states, parameters,
+drivers, observables, baked constants) and algorithm families. The
+results feed the size-based location heuristics tracked by issue
+#329.
+
+Each configuration runs in a fresh subprocess so the kernel is
+compiled for exactly that placement. Results append to a JSONL file;
+re-running skips configurations already recorded, so the sweep is
+resumable.
+
+Usage::
+
+    python benchmarks/memory_location_sweep.py            # full sweep
+    python benchmarks/memory_location_sweep.py --phase core
+    python benchmarks/memory_location_sweep.py --single '<config json>'
+
+The single-config mode is internal: the driver invokes it in a
+subprocess per configuration.
+
+Timing follows benchmarks/lorenz_mean_runtime.py: kernel-only CUDA
+event times (per-chunk ``kernel_chunk_i`` events), one warm-up solve
+to absorb JIT compilation, then ``repeats`` timed solves.
+"""
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import subprocess
+import sys
+import time
+import warnings
+
+import numpy as np
+
+RESULTS_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "memory_location_sweep_results.jsonl",
+)
+REPEATS = 5
+NRUNS = 32768
+BLOCKSIZE = 256
+DURATION = 0.05
+DT = 1e-3
+
+# Buffer-location kwargs per placement group. Loop groups apply to
+# every algorithm; algorithm and solver groups are keyed by family.
+LOOP_GROUPS = {
+    "state": ["state_location", "proposed_state_location"],
+    "params": ["parameters_location"],
+    "drivers": ["drivers_location", "proposed_drivers_location"],
+    "obs": ["observables_location", "proposed_observables_location"],
+}
+ALGO_GROUPS = {
+    "euler": [],
+    "tsit5": ["stage_rhs_location", "stage_accumulator_location"],
+    "dirk": [
+        "stage_increment_location",
+        "stage_base_location",
+        "accumulator_location",
+        "stage_rhs_location",
+    ],
+    "firk": [
+        "stage_increment_location",
+        "stage_driver_stack_location",
+        "stage_state_location",
+    ],
+    "rosenbrock": [
+        "stage_rhs_location",
+        "stage_store_location",
+        "cached_auxiliaries_location",
+    ],
+    "backwards_euler": ["increment_cache_location"],
+    "crank_nicolson": ["dxdt_location"],
+}
+SOLVER_GROUPS = {
+    "euler": [],
+    "tsit5": [],
+    "dirk": [
+        "delta_location",
+        "residual_location",
+        "residual_temp_location",
+        "stage_base_bt_location",
+        "preconditioned_vec_location",
+        "temp_location",
+    ],
+    "firk": [
+        "delta_location",
+        "residual_location",
+        "residual_temp_location",
+        "stage_base_bt_location",
+        "preconditioned_vec_location",
+        "temp_location",
+    ],
+    "rosenbrock": ["preconditioned_vec_location", "temp_location"],
+    "backwards_euler": [
+        "delta_location",
+        "residual_location",
+        "residual_temp_location",
+        "stage_base_bt_location",
+        "preconditioned_vec_location",
+        "temp_location",
+    ],
+    "crank_nicolson": [
+        "delta_location",
+        "residual_location",
+        "residual_temp_location",
+        "stage_base_bt_location",
+        "preconditioned_vec_location",
+        "temp_location",
+    ],
+}
+IMPLICIT = {"dirk", "firk", "rosenbrock", "backwards_euler",
+            "crank_nicolson"}
+
+
+def variant_kwargs(algorithm, variant, n_drivers, n_observables):
+    """Return the ``*_location`` kwargs for a named placement variant.
+
+    Returns None when the variant does not apply to this
+    configuration (e.g. solver placement on an explicit algorithm).
+    """
+    groups = []
+    if variant == "local":
+        return {}
+    elif variant == "state_shared":
+        groups = [LOOP_GROUPS["state"]]
+    elif variant == "params_shared":
+        groups = [LOOP_GROUPS["params"]]
+    elif variant == "drivers_shared":
+        if n_drivers == 0:
+            return None
+        groups = [LOOP_GROUPS["drivers"]]
+    elif variant == "obs_shared":
+        if n_observables == 0:
+            return None
+        groups = [LOOP_GROUPS["obs"]]
+    elif variant == "state_params_shared":
+        groups = [LOOP_GROUPS["state"], LOOP_GROUPS["params"]]
+    elif variant == "algo_shared":
+        if not ALGO_GROUPS[algorithm]:
+            return None
+        groups = [ALGO_GROUPS[algorithm]]
+    elif variant == "solver_shared":
+        if algorithm not in IMPLICIT:
+            return None
+        groups = [SOLVER_GROUPS[algorithm]]
+    elif variant == "all_shared":
+        groups = [
+            LOOP_GROUPS["state"],
+            LOOP_GROUPS["params"],
+            ALGO_GROUPS[algorithm],
+            SOLVER_GROUPS[algorithm],
+        ]
+        if n_drivers:
+            groups.append(LOOP_GROUPS["drivers"])
+        if n_observables:
+            groups.append(LOOP_GROUPS["obs"])
+    else:
+        raise ValueError(f"unknown variant {variant}")
+    return {key: "shared" for group in groups for key in group}
+
+
+def make_system(cfg):
+    """Build the synthetic benchmark system for a configuration.
+
+    Nonlinear nearest-neighbour chain: every state couples to its
+    ring neighbours with one nonlinear term, parameters cycle over
+    the equations, drivers force the first equations additively, and
+    observables are pairwise products. Baked constants are unique
+    literals so codegen cannot fold them together.
+    """
+    from cubie import create_ODE_system
+
+    n = cfg["n_states"]
+    n_params = cfg["n_params"]
+    n_drivers = cfg["n_drivers"]
+    n_obs = cfg["n_observables"]
+    consts_per_eq = cfg["consts_per_eq"]
+    precision = np.float32 if cfg["precision"] == "f32" else np.float64
+
+    rng = np.random.default_rng(1234)
+    eqs = []
+    constants = {}
+    for i in range(n):
+        im1 = (i - 1) % n
+        ip1 = (i + 1) % n
+        terms = [f"0.2*x{im1} + 0.3*x{ip1}"]
+        for c in range(consts_per_eq):
+            cname = f"k{i}_{c}"
+            constants[cname] = float(rng.uniform(0.5, 5.0))
+            if c == 0:
+                terms.append(f"-{cname}*x{i}")
+            else:
+                terms.append(f"+ {cname}*x{ip1}/(1.0 + x{i}*x{i})")
+        if n_params:
+            pj = i % n_params
+            terms.append(f"+ 0.05*p{pj}*x{i}*x{ip1}")
+        if n_drivers:
+            dj = i % n_drivers
+            terms.append(f"+ 0.1*d{dj}")
+        eqs.append(f"dx{i} = " + " ".join(terms))
+    for j in range(n_obs):
+        a = j % n
+        b = (j * 7 + 1) % n
+        eqs.append(f"o{j} = x{a}*x{b}")
+
+    system = create_ODE_system(
+        dxdt=eqs,
+        states={f"x{i}": 0.5 for i in range(n)},
+        parameters={f"p{j}": 1.0 for j in range(n_params)},
+        constants=constants,
+        drivers=[f"d{j}" for j in range(n_drivers)] or None,
+        observables=[f"o{j}" for j in range(n_obs)] or None,
+        precision=precision,
+        name=(
+            f"sweep_{n}s_{n_params}p_{n_drivers}d_{n_obs}o_"
+            f"{consts_per_eq}c_{cfg['precision']}"
+        ),
+    )
+    return system, precision
+
+
+def solver_stats(solver):
+    """Return launch-geometry and register stats for a built solver."""
+    bsk = solver.kernel
+    pad = 4 if bsk.shared_memory_needs_padding else 0
+    bytes_per_run = bsk.shared_memory_bytes + pad
+    smem = int(bytes_per_run * min(NRUNS, BLOCKSIZE))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        eff_blocksize, smem = bsk.limit_blocksize(
+            BLOCKSIZE, smem, bytes_per_run, NRUNS
+        )
+    regs = lmem = None
+    try:
+        kernel = bsk.kernel
+        regs = list(kernel.get_regs_per_thread().values())[0]
+        lmem = list(kernel.get_local_mem_per_thread().values())[0]
+    except Exception:
+        pass
+    return dict(
+        regs_per_thread=regs,
+        local_mem_per_thread=lmem,
+        shared_bytes_per_run=int(bytes_per_run),
+        eff_blocksize=int(eff_blocksize),
+        dynamic_shared_per_block=int(smem),
+    )
+
+
+def timed_solve(solver, y0, p, solve_kwargs):
+    """Run one solve and return its kernel CUDA-event total (ms)."""
+    with contextlib.redirect_stdout(io.StringIO()):
+        result = solver.solve(y0, p, **solve_kwargs)
+    events = solver.kernel._cuda_events
+    ms = sum(
+        e.elapsed_time_ms()
+        for e in events
+        if e.name.startswith("kernel_chunk")
+    )
+    return ms, result
+
+
+def run_single(cfg):
+    """Run one paired baseline/variant configuration; print JSON.
+
+    The benchmark GPU also drives a desktop, and background load can
+    inflate whole windows of measurements uniformly, which no
+    per-config variance filter can detect. Timing is therefore
+    paired: the all-local baseline solver and the variant solver
+    alternate solves within the same process, and the reported ratio
+    compares minima over interleaved samples, so slow drifts in
+    outside load cancel instead of masquerading as placement
+    effects.
+    """
+    from cubie.batchsolving.solver import Solver
+    from cubie.time_logger import default_timelogger
+
+    default_timelogger.set_verbosity("default")
+    system, precision = make_system(cfg)
+
+    loc_kwargs = variant_kwargs(
+        cfg["algorithm"], cfg["variant"], cfg["n_drivers"],
+        cfg["n_observables"],
+    )
+    if loc_kwargs is None or cfg["variant"] == "local":
+        print(json.dumps({"skip": True}))
+        return
+
+    base_kwargs = dict(
+        dt=DT,
+        step_controller="fixed",
+        save_every=DURATION,
+        output_types=["state"],
+        time_logging_level="default",
+        algorithm=cfg["algorithm"],
+    )
+    if cfg["algorithm"] in IMPLICIT:
+        base_kwargs["krylov_max_iters"] = 100
+
+    n = cfg["n_states"]
+    y0 = {
+        f"x{i}": np.full(NRUNS, 0.5, dtype=precision) for i in range(n)
+    }
+    p = {"p0": np.full(NRUNS, 1.0, dtype=precision)}
+    solve_kwargs = dict(
+        duration=DURATION, grid_type="verbatim", blocksize=BLOCKSIZE,
+    )
+    if cfg["n_drivers"]:
+        t_samples = np.linspace(
+            0.0, DURATION, 16, dtype=precision
+        )
+        drivers = {
+            f"d{j}": np.sin(
+                2 * np.pi * (j + 1) * t_samples / DURATION
+            ).astype(precision)
+            for j in range(cfg["n_drivers"])
+        }
+        drivers["dt"] = precision(DURATION / 15)
+        drivers["wrap"] = False
+        solve_kwargs["drivers"] = drivers
+
+    caught = []
+    t0 = time.perf_counter()
+    with warnings.catch_warnings(record=True) as wlist:
+        warnings.simplefilter("always")
+        solver_local = Solver(system, **base_kwargs)
+        solver_variant = Solver(system, **base_kwargs, **loc_kwargs)
+        # Warm-up both (JIT compilation / cache load) and capture
+        # outputs for a placement-invariance check: buffer location
+        # must never change results.
+        _, result_local = timed_solve(
+            solver_local, y0, p, solve_kwargs
+        )
+        _, result_variant = timed_solve(
+            solver_variant, y0, p, solve_kwargs
+        )
+        caught = sorted({str(w.message)[:80] for w in wlist})
+    compile_s = time.perf_counter() - t0
+
+    out_local = np.asarray(result_local.time_domain_array)
+    out_variant = np.asarray(result_variant.time_domain_array)
+    if out_local.shape == out_variant.shape:
+        diff = float(
+            np.nanmax(np.abs(out_local - out_variant))
+        )
+    else:
+        diff = float("nan")
+
+    local_ms = []
+    variant_ms = []
+    while True:
+        for _ in range(REPEATS):
+            ms, _ = timed_solve(solver_local, y0, p, solve_kwargs)
+            local_ms.append(ms)
+            ms, _ = timed_solve(solver_variant, y0, p, solve_kwargs)
+            variant_ms.append(ms)
+        pair_ratios = np.asarray(variant_ms) / np.asarray(local_ms)
+        if len(local_ms) >= 3 * REPEATS:
+            break
+        if pair_ratios.std(ddof=1) <= 0.05 * pair_ratios.mean():
+            break
+
+    local_arr = np.asarray(local_ms)
+    variant_arr = np.asarray(variant_ms)
+    record = dict(cfg)
+    record.update(
+        ratio_min=float(variant_arr.min() / local_arr.min()),
+        ratio_median_pairwise=float(
+            np.median(variant_arr / local_arr)
+        ),
+        local_ms_min=float(local_arr.min()),
+        variant_ms_min=float(variant_arr.min()),
+        local_ms=list(map(float, local_arr)),
+        variant_ms=list(map(float, variant_arr)),
+        compile_s=round(compile_s, 2),
+        local_stats=solver_stats(solver_local),
+        variant_stats=solver_stats(solver_variant),
+        out_maxdiff=diff,
+        warnings=caught,
+    )
+    print(json.dumps(record))
+
+
+def core_matrix():
+    """Yield the core sweep: sizes x algorithms x placement variants."""
+    variants = [
+        "local",
+        "state_shared",
+        "params_shared",
+        "state_params_shared",
+        "algo_shared",
+        "solver_shared",
+        "all_shared",
+    ]
+    # rosenbrock is excluded: auxiliary-cache planning
+    # (_search_group_combinations) does not terminate for chain
+    # systems at n_states >= 16, so its kernels cannot be built.
+    algorithms = [
+        "euler",
+        "tsit5",
+        "dirk",
+        "firk",
+        "backwards_euler",
+    ]
+    for n in [4, 16, 64, 128, 256]:
+        for algorithm in algorithms:
+            if algorithm == "firk" and n > 64:
+                continue
+            for variant in variants:
+                yield dict(
+                    phase="core",
+                    algorithm=algorithm,
+                    n_states=n,
+                    n_params=2,
+                    n_drivers=0,
+                    n_observables=0,
+                    consts_per_eq=3,
+                    precision="f32",
+                    variant=variant,
+                )
+
+
+def dims_matrix():
+    """Yield the size-dimension sweep on two representative algorithms."""
+    for algorithm in ["tsit5", "backwards_euler"]:
+        for n in [16, 64, 128]:
+            for n_params in [16, 64, 128]:
+                for variant in ["local", "params_shared"]:
+                    yield dict(
+                        phase="dims",
+                        algorithm=algorithm,
+                        n_states=n,
+                        n_params=n_params,
+                        n_drivers=0,
+                        n_observables=0,
+                        consts_per_eq=3,
+                        precision="f32",
+                        variant=variant,
+                    )
+            for n_drivers in [2, 8]:
+                for variant in ["local", "drivers_shared"]:
+                    yield dict(
+                        phase="dims",
+                        algorithm=algorithm,
+                        n_states=n,
+                        n_params=2,
+                        n_drivers=n_drivers,
+                        n_observables=0,
+                        consts_per_eq=3,
+                        precision="f32",
+                        variant=variant,
+                    )
+            for n_obs in [8, 32]:
+                for variant in ["local", "obs_shared"]:
+                    yield dict(
+                        phase="dims",
+                        algorithm=algorithm,
+                        n_states=n,
+                        n_params=2,
+                        n_drivers=0,
+                        n_observables=n_obs,
+                        consts_per_eq=3,
+                        precision="f32",
+                        variant=variant,
+                    )
+
+
+def consts_matrix():
+    """Yield the baked-constants spot check (register pressure)."""
+    for algorithm in ["tsit5", "backwards_euler"]:
+        for n in [16, 64]:
+            for consts_per_eq in [1, 8]:
+                for variant in ["local", "state_params_shared"]:
+                    yield dict(
+                        phase="consts",
+                        algorithm=algorithm,
+                        n_states=n,
+                        n_params=2,
+                        n_drivers=0,
+                        n_observables=0,
+                        consts_per_eq=consts_per_eq,
+                        precision="f32",
+                        variant=variant,
+                    )
+
+
+def f64_matrix():
+    """Yield float64 spot checks."""
+    for algorithm in ["euler", "tsit5", "backwards_euler"]:
+        for n in [16, 128]:
+            for variant in [
+                "local",
+                "state_shared",
+                "params_shared",
+                "all_shared",
+            ]:
+                yield dict(
+                    phase="f64",
+                    algorithm=algorithm,
+                    n_states=n,
+                    n_params=2,
+                    n_drivers=0,
+                    n_observables=0,
+                    consts_per_eq=3,
+                    precision="f64",
+                    variant=variant,
+                )
+
+
+PHASES = {
+    "core": core_matrix,
+    "dims": dims_matrix,
+    "consts": consts_matrix,
+    "f64": f64_matrix,
+}
+
+
+def config_key(cfg):
+    """Return the deduplication key for a configuration."""
+    fields = [
+        "algorithm", "n_states", "n_params", "n_drivers",
+        "n_observables", "consts_per_eq", "precision", "variant",
+    ]
+    return tuple(cfg[f] for f in fields)
+
+
+def drive(phases):
+    """Run every configuration not yet in the results file."""
+    done = set()
+    if os.path.exists(RESULTS_FILE):
+        with open(RESULTS_FILE) as fh:
+            for line in fh:
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if "ratio_min" in rec or rec.get("error"):
+                    done.add(config_key(rec))
+
+    configs = [
+        cfg for phase in phases for cfg in PHASES[phase]()
+        if cfg["variant"] != "local"
+    ]
+    todo = [c for c in configs if config_key(c) not in done]
+    print(f"{len(configs)} configs, {len(todo)} to run")
+
+    env = dict(os.environ)
+    for idx, cfg in enumerate(todo):
+        label = "/".join(str(v) for v in config_key(cfg))
+        t0 = time.perf_counter()
+        try:
+            proc = subprocess.run(
+                [sys.executable, os.path.abspath(__file__), "--single",
+                 json.dumps(cfg)],
+                capture_output=True, text=True, timeout=900, env=env,
+            )
+        except subprocess.TimeoutExpired:
+            record = dict(cfg)
+            record["error"] = "timeout after 900 s"
+            with open(RESULTS_FILE, "a") as fh:
+                fh.write(json.dumps(record) + "\n")
+            print(f"[{idx + 1}/{len(todo)}] {label}: TIMEOUT")
+            continue
+        elapsed = time.perf_counter() - t0
+        record = None
+        for line in reversed(proc.stdout.strip().splitlines()):
+            try:
+                candidate = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if isinstance(candidate, dict):
+                record = candidate
+                break
+        if record is None:
+            record = dict(cfg)
+            record["error"] = (proc.stdout + proc.stderr)[-2000:]
+        if record.get("skip"):
+            print(f"[{idx + 1}/{len(todo)}] {label}: skipped")
+            continue
+        with open(RESULTS_FILE, "a") as fh:
+            fh.write(json.dumps(record) + "\n")
+        if "ratio_min" in record:
+            vstats = record["variant_stats"]
+            print(
+                f"[{idx + 1}/{len(todo)}] {label}: "
+                f"ratio {record['ratio_min']:.3f} "
+                f"(local {record['local_ms_min']:.2f} ms, "
+                f"variant {record['variant_ms_min']:.2f} ms, "
+                f"bs {vstats['eff_blocksize']}, "
+                f"sh {vstats['shared_bytes_per_run']} B/run, "
+                f"maxdiff {record['out_maxdiff']:.2e}) "
+                f"[{elapsed:.0f} s]"
+            )
+        else:
+            print(f"[{idx + 1}/{len(todo)}] {label}: ERROR")
+    print("SWEEP DONE")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--single", default=None)
+    parser.add_argument(
+        "--phase", default="all",
+        choices=["all"] + list(PHASES),
+    )
+    args = parser.parse_args()
+    if args.single:
+        run_single(json.loads(args.single))
+    else:
+        phases = list(PHASES) if args.phase == "all" else [args.phase]
+        drive(phases)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/memory_location_sweep.py
+++ b/benchmarks/memory_location_sweep.py
@@ -18,9 +18,19 @@ Usage::
     python benchmarks/memory_location_sweep.py            # full sweep
     python benchmarks/memory_location_sweep.py --phase core
     python benchmarks/memory_location_sweep.py --single '<config json>'
+    python benchmarks/memory_location_sweep.py --fit      # derive rules
 
 The single-config mode is internal: the driver invokes it in a
 subprocess per configuration.
+
+``--fit`` derives the :class:`MemoryThresholds` constants in
+``cubie.integrators.memory_heuristics`` from the recorded results
+and prints a paste-ready ``THRESHOLDS_BY_ARCH`` entry plus a
+validation report, so calibrating a new card is: run the sweep
+there, run ``--fit``, and commit the emitted entry keyed by the
+card's architecture code. Records written by older sweeps lack the
+declared-size fields, so ``--fit`` reconstructs them host-side (no
+kernel compilation) and caches them beside the results file.
 
 Timing follows benchmarks/lorenz_mean_runtime.py: kernel-only CUDA
 event times (per-chunk ``kernel_chunk_i`` events), one warm-up solve
@@ -42,6 +52,10 @@ import numpy as np
 RESULTS_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     "memory_location_sweep_results.jsonl",
+)
+DECLARED_CACHE_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "memory_location_sweep_declared_cache.jsonl",
 )
 REPEATS = 5
 NRUNS = 32768
@@ -227,6 +241,49 @@ def make_system(cfg):
     return system, precision
 
 
+def baseline_kwargs(cfg):
+    """Return the all-local baseline Solver kwargs for a config.
+
+    auto_memory is off on both sides of every measurement: the
+    sweep measures pure placements, and the heuristics under
+    calibration must never leak into their own baseline.
+    """
+    kwargs = dict(
+        dt=DT,
+        step_controller="fixed",
+        save_every=DURATION,
+        output_types=["state"],
+        time_logging_level="default",
+        algorithm=cfg["algorithm"],
+        auto_memory=False,
+    )
+    if cfg["algorithm"] in IMPLICIT:
+        kwargs["krylov_max_iters"] = 100
+    return kwargs
+
+
+def declared_record(solver):
+    """Return the registry-declared sizes the placement gates use.
+
+    These are the exact quantities ``auto_memory_locations``
+    measures at construction, captured through the same helper so
+    the fit stage and the resolver can never disagree.
+    """
+    from cubie.cuda_simsafe import compute_capability_code
+    from cubie.integrators.memory_heuristics import declared_sizes
+
+    sizes = declared_sizes(solver.kernel.single_integrator)
+    return dict(
+        itemsize=sizes.itemsize,
+        is_implicit=sizes.is_implicit,
+        footprint_bytes=sizes.footprint_bytes,
+        state_pair_bytes=sizes.state_pair_bytes,
+        work_group_bytes=sizes.work_group_bytes,
+        params_bytes=sizes.params_bytes,
+        arch=compute_capability_code(),
+    )
+
+
 def solver_stats(solver):
     """Return launch-geometry and register stats for a built solver."""
     bsk = solver.kernel
@@ -293,20 +350,7 @@ def run_single(cfg):
         print(json.dumps({"skip": True}))
         return
 
-    # auto_memory off on both sides: the sweep measures pure
-    # placements, and the heuristics under calibration must never
-    # leak into their own baseline.
-    base_kwargs = dict(
-        dt=DT,
-        step_controller="fixed",
-        save_every=DURATION,
-        output_types=["state"],
-        time_logging_level="default",
-        algorithm=cfg["algorithm"],
-        auto_memory=False,
-    )
-    if cfg["algorithm"] in IMPLICIT:
-        base_kwargs["krylov_max_iters"] = 100
+    base_kwargs = baseline_kwargs(cfg)
 
     n = cfg["n_states"]
     y0 = {
@@ -335,6 +379,10 @@ def run_single(cfg):
     with warnings.catch_warnings(record=True) as wlist:
         warnings.simplefilter("always")
         solver_local = Solver(system, **base_kwargs)
+        # Capture declared sizes at construction: the stage where
+        # auto_memory_locations measures them. Builds and driver
+        # updates can enlarge child registrations afterwards.
+        declared = declared_record(solver_local)
         solver_variant = Solver(system, **base_kwargs, **loc_kwargs)
         # Warm-up both (JIT compilation / cache load) and capture
         # outputs for a placement-invariance check: buffer location
@@ -386,6 +434,7 @@ def run_single(cfg):
         compile_s=round(compile_s, 2),
         local_stats=solver_stats(solver_local),
         variant_stats=solver_stats(solver_variant),
+        declared=declared,
         out_maxdiff=diff,
         warnings=caught,
     )
@@ -607,6 +656,450 @@ def drive(phases):
     print("SWEEP DONE")
 
 
+# --- Threshold fitting ------------------------------------------------
+#
+# The fit stage captures the reasoning that turned raw sweep records
+# into the MemoryThresholds constants, so recalibrating on another
+# card is mechanical. Classification: a paired ratio <= WIN_RATIO is
+# a win, >= LOSS_RATIO a loss, anything between is noise (the paired
+# protocol's observed noise floor is ~5%).
+#
+# Size gates (state pair, work group, explicit work, params) are
+# fitted per rule from that rule's own variant records. A measured
+# size qualifies when its wins outnumber its losses across
+# configurations - single-cell losses are outvoted when the size
+# wins consistently elsewhere - and the gate is the qualifying
+# boundary with every measured size inside it also qualifying, so
+# one isolated far-out win can never drag the gate across a band of
+# losses. Gates round to the GRID unless rounding would cross a
+# disqualified measured size.
+#
+# The two footprint gates (heavy-spill and the explicit spill
+# floor) couple every rule, so they are chosen by scanning the
+# grid: for each candidate pair the size gates are refitted and
+# every measured configuration is replayed through
+# placement_candidates. The scan keeps the pair that fires on the
+# fewest measured losses (zero, on the calibration dataset), then
+# misses the fewest measured wins, then is most conservative.
+# Isolated sub-spill wins (e.g. a 0.87 on a 236-byte footprint)
+# are deliberately sacrificed by this objective: no footprint gate
+# can capture them without also firing on the losses measured
+# between them and the spilled region.
+#
+# A final validation pass reports every configuration's decision
+# against its measured ratios, including placements that fire on
+# territory the sweep never measured.
+
+WIN_RATIO = 0.95
+LOSS_RATIO = 1.05
+GRID = 512
+
+NEVER_AT_MOST = 0
+NEVER_AT_LEAST = 1 << 62
+
+DECLARED_KEY_FIELDS = [
+    "algorithm", "n_states", "n_params", "n_drivers",
+    "n_observables", "consts_per_eq", "precision",
+]
+
+VARIANT_GROUPS = {
+    "state_shared": "state",
+    "algo_shared": "work",
+    "params_shared": "params",
+}
+
+
+def declared_key(cfg):
+    """Return the per-system deduplication key (variant excluded)."""
+    return tuple(cfg[f] for f in DECLARED_KEY_FIELDS)
+
+
+def declared_for_config(cfg, cache):
+    """Return declared sizes for a config, rebuilding when absent.
+
+    Old sweep records predate the ``declared`` field; the sizes are
+    registry declarations made at construction, so rebuilding the
+    system and solver host-side (no kernel compilation) reproduces
+    them exactly. Results are cached to DECLARED_CACHE_FILE.
+    """
+    key = declared_key(cfg)
+    if key in cache:
+        return cache[key]
+
+    from cubie.batchsolving.solver import Solver
+
+    system, _ = make_system(cfg)
+    solver = Solver(system, **baseline_kwargs(cfg))
+    declared = declared_record(solver)
+    cache[key] = declared
+    with open(DECLARED_CACHE_FILE, "a") as fh:
+        fh.write(json.dumps({"key": list(key), "declared": declared})
+                 + "\n")
+    return declared
+
+
+def load_declared_cache():
+    """Load the declared-size cache written by earlier fits."""
+    cache = {}
+    if os.path.exists(DECLARED_CACHE_FILE):
+        with open(DECLARED_CACHE_FILE) as fh:
+            for line in fh:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                cache[tuple(entry["key"])] = entry["declared"]
+    return cache
+
+
+def qualifying_sizes(recs, field):
+    """Vote each measured size: True when wins outnumber losses."""
+    votes = {}
+    for rec in recs:
+        size = rec["declared"][field]
+        win_count, loss_count = votes.get(size, (0, 0))
+        if rec["ratio_min"] <= WIN_RATIO:
+            win_count += 1
+        elif rec["ratio_min"] >= LOSS_RATIO:
+            loss_count += 1
+        votes[size] = (win_count, loss_count)
+    return {
+        size: win_count > loss_count and win_count > 0
+        for size, (win_count, loss_count) in votes.items()
+    }
+
+
+def fit_at_most_gate(recs, field):
+    """Fit an 'at most' gate: fire when size <= threshold.
+
+    The threshold is the largest qualifying measured size whose
+    smaller measured sizes all qualify too, rounded up to the grid
+    unless rounding would cross a disqualified size. Returns the
+    never-fire sentinel when nothing qualifies.
+    """
+    votes = qualifying_sizes(recs, field)
+    threshold = None
+    for size in sorted(votes):
+        if votes[size]:
+            threshold = size
+        else:
+            break
+    if threshold is None:
+        return NEVER_AT_MOST
+    rounded = -(-threshold // GRID) * GRID
+    disqualified = [s for s, ok in votes.items() if not ok]
+    if disqualified and rounded >= min(disqualified):
+        return threshold
+    return rounded
+
+
+def fit_at_least_gate(recs, field):
+    """Fit an 'at least' gate: fire when value >= threshold.
+
+    The threshold is the smallest qualifying measured size whose
+    larger measured sizes all qualify too, rounded down to the grid
+    unless rounding would cross a disqualified size. Returns the
+    never-fire sentinel when nothing qualifies.
+    """
+    votes = qualifying_sizes(recs, field)
+    threshold = None
+    for size in sorted(votes, reverse=True):
+        if votes[size]:
+            threshold = size
+        else:
+            break
+    if threshold is None:
+        return NEVER_AT_LEAST
+    rounded = (threshold // GRID) * GRID
+    disqualified = [s for s, ok in votes.items() if not ok]
+    if disqualified and rounded <= max(disqualified):
+        return threshold
+    return rounded
+
+
+def measured_family(algorithm):
+    """Return True when the heuristics cover this algorithm family."""
+    from cubie.integrators.algorithms import resolve_alias
+    from cubie.integrators.memory_heuristics import MEASURED_STEP_TYPES
+
+    step_type, _ = resolve_alias(algorithm)
+    return issubclass(step_type, MEASURED_STEP_TYPES)
+
+
+def load_fit_records(results_file):
+    """Load measured records and attach declared sizes to each."""
+    records = []
+    with open(results_file) as fh:
+        for line in fh:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if "ratio_min" in rec and not rec.get("error"):
+                records.append(rec)
+
+    cache = load_declared_cache()
+    missing = {
+        declared_key(rec): rec for rec in records
+        if "declared" not in rec
+    }
+    if missing:
+        print(
+            f"reconstructing declared sizes for {len(missing)} "
+            "configurations (host-side build, no kernel compile)"
+        )
+    for idx, (key, rec) in enumerate(sorted(missing.items())):
+        declared_for_config(rec, cache)
+        print(f"  [{idx + 1}/{len(missing)}] {'/'.join(map(str, key))}")
+    for rec in records:
+        if "declared" not in rec:
+            rec["declared"] = cache[declared_key(rec)]
+    return records
+
+
+def gates_for(f32_records, heavy, floor):
+    """Fit the four size gates for one footprint-gate candidate."""
+
+    def cells(variant, implicit=None, band=None):
+        out = []
+        for rec in f32_records:
+            if rec["variant"] != variant:
+                continue
+            dec = rec["declared"]
+            if implicit is not None and dec["is_implicit"] != implicit:
+                continue
+            footprint = dec["footprint_bytes"]
+            if band == "spilled" and footprint < heavy:
+                continue
+            if band == "mid" and not (floor <= footprint < heavy):
+                continue
+            out.append(rec)
+        return out
+
+    return dict(
+        heavy_spill_bytes=heavy,
+        spill_floor_bytes=floor,
+        state_pair_max_bytes=fit_at_most_gate(
+            cells("state_shared", band="spilled"),
+            "state_pair_bytes",
+        ),
+        work_group_max_bytes=fit_at_most_gate(
+            cells("algo_shared", implicit=True, band="spilled"),
+            "work_group_bytes",
+        ),
+        explicit_work_max_bytes=fit_at_most_gate(
+            cells("algo_shared", implicit=False, band="mid"),
+            "work_group_bytes",
+        ),
+        params_min_bytes=fit_at_least_gate(
+            cells("params_shared", band="spilled"),
+            "params_bytes",
+        ),
+    )
+
+
+def build_configs(records):
+    """Group records into per-system configs with per-group ratios."""
+    configs = {}
+    for rec in records:
+        entry = configs.setdefault(
+            declared_key(rec),
+            dict(
+                declared=rec["declared"],
+                algorithm=rec["algorithm"],
+                ratios={},
+            ),
+        )
+        group = VARIANT_GROUPS.get(rec["variant"])
+        if group is not None:
+            entry["ratios"][group] = rec["ratio_min"]
+    return configs
+
+
+def choose_group(config, thresholds):
+    """Return the group the resolver would relocate for a config."""
+    from cubie.integrators.memory_heuristics import (
+        DeclaredSizes,
+        PARAMS_KEYS,
+        STATE_PAIR_KEYS,
+        placement_candidates,
+    )
+
+    if not measured_family(config["algorithm"]):
+        return None
+    dec = config["declared"]
+    sizes = DeclaredSizes(
+        itemsize=dec["itemsize"],
+        is_implicit=dec["is_implicit"],
+        footprint_bytes=dec["footprint_bytes"],
+        state_pair_bytes=dec["state_pair_bytes"],
+        work_group_bytes=dec["work_group_bytes"],
+        params_bytes=dec["params_bytes"],
+        work_location_keys=("work_location",),
+    )
+    candidates = placement_candidates(sizes, thresholds)
+    if not candidates:
+        return None
+    first = candidates[0]
+    if first == STATE_PAIR_KEYS:
+        return "state"
+    if first == PARAMS_KEYS:
+        return "params"
+    return "work"
+
+
+def score_thresholds(configs, thresholds):
+    """Count fired losses and missed wins over every configuration."""
+    fired_losses = missed_wins = 0
+    for config in configs.values():
+        chosen = choose_group(config, thresholds)
+        ratios = config["ratios"]
+        chosen_ratio = ratios.get(chosen) if chosen else None
+        if chosen_ratio is not None and chosen_ratio >= LOSS_RATIO:
+            fired_losses += 1
+        has_win = any(r <= WIN_RATIO for r in ratios.values())
+        chose_win = (
+            chosen_ratio is not None and chosen_ratio <= WIN_RATIO
+        )
+        if has_win and not chose_win:
+            missed_wins += 1
+    return fired_losses, missed_wins
+
+
+def fit_thresholds(records):
+    """Derive MemoryThresholds values from measured records.
+
+    Only f32 records fit the size gates: the f64 spot checks steer
+    the structural rules (explicit-only state pair at scaled size),
+    which live in placement_candidates, not in the constants. The
+    footprint-gate scan replays configurations of both precisions.
+    """
+    from cubie.integrators.memory_heuristics import MemoryThresholds
+
+    f32 = [r for r in records if r["precision"] == "f32"]
+    configs = build_configs(records)
+
+    footprints = sorted(
+        {r["declared"]["footprint_bytes"] for r in records}
+    )
+    ceilings = {
+        -(-footprint // GRID) * GRID for footprint in footprints
+    }
+    grid_stops = sorted(
+        ceilings | {stop + GRID for stop in ceilings} | {GRID}
+    )
+
+    best = None
+    for heavy in grid_stops:
+        for floor in [g for g in grid_stops if g <= heavy]:
+            fitted = gates_for(f32, heavy, floor)
+            score = score_thresholds(
+                configs, MemoryThresholds(**fitted)
+            )
+            ranking = (*score, -heavy, -floor)
+            if best is None or ranking < best[0]:
+                best = (ranking, fitted)
+
+    fitted = best[1]
+    fired_losses, missed_wins = best[0][:2]
+    print(
+        f"footprint-gate scan: heavy_spill_bytes="
+        f"{fitted['heavy_spill_bytes']}, spill_floor_bytes="
+        f"{fitted['spill_floor_bytes']} "
+        f"({fired_losses} fired losses, {missed_wins} missed wins)"
+    )
+    return fitted
+
+
+def validate_thresholds(records, fitted):
+    """Replay every configuration through the fitted gates.
+
+    Groups records by system configuration, asks
+    placement_candidates which group the resolver would relocate,
+    and compares that decision with the measured ratios for every
+    variant of the configuration.
+    """
+    from cubie.integrators.memory_heuristics import MemoryThresholds
+
+    thresholds = MemoryThresholds(**fitted)
+    configs = build_configs(records)
+
+    fired_losses = missed_wins = fired_unmeasured = 0
+    print("\nvalidation (fitted gates vs measured ratios):")
+    for key in sorted(configs):
+        config = configs[key]
+        chosen = choose_group(config, thresholds)
+        ratios = config["ratios"]
+        label = "/".join(str(k) for k in key)
+        if chosen is not None:
+            ratio = ratios.get(chosen)
+            if ratio is None:
+                fired_unmeasured += 1
+                print(f"  {label}: fires {chosen} (UNMEASURED)")
+            elif ratio >= LOSS_RATIO:
+                fired_losses += 1
+                print(
+                    f"  {label}: fires {chosen} on a LOSS "
+                    f"(ratio {ratio:.2f})"
+                )
+            elif ratio <= WIN_RATIO:
+                print(
+                    f"  {label}: fires {chosen} "
+                    f"(win, ratio {ratio:.2f})"
+                )
+            else:
+                print(
+                    f"  {label}: fires {chosen} "
+                    f"(neutral, ratio {ratio:.2f})"
+                )
+        else:
+            wins = {
+                group: ratio for group, ratio in ratios.items()
+                if ratio <= WIN_RATIO
+            }
+            if wins:
+                missed_wins += 1
+                best = min(wins.items(), key=lambda kv: kv[1])
+                print(
+                    f"  {label}: no rule fires but {best[0]} "
+                    f"measured {best[1]:.2f} (MISSED WIN)"
+                )
+    print(
+        f"\nsummary: {fired_losses} fires on losses, "
+        f"{missed_wins} missed wins, "
+        f"{fired_unmeasured} fires on unmeasured groups"
+    )
+
+
+def fit(results_file, arch=None):
+    """Derive, validate, and print the thresholds for one card."""
+    records = load_fit_records(results_file)
+    if not records:
+        print("no measured records found")
+        return
+    if arch is None:
+        arches = [
+            r["declared"].get("arch") for r in records
+            if r["declared"].get("arch")
+        ]
+        arch = arches[0] if arches else "unknown"
+
+    fitted = fit_thresholds(records)
+    validate_thresholds(records, fitted)
+
+    never = {NEVER_AT_MOST, NEVER_AT_LEAST}
+    if any(value in never for value in fitted.values()):
+        print(
+            "\nnote: gates without qualifying records emit "
+            "never-fire values"
+        )
+    print("\npaste into cubie/integrators/memory_heuristics.py:")
+    print(f'    "{arch}": MemoryThresholds(')
+    for field, value in fitted.items():
+        print(f"        {field}={value},")
+    print("    ),")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--single", default=None)
@@ -614,8 +1107,23 @@ def main():
         "--phase", default="all",
         choices=["all"] + list(PHASES),
     )
+    parser.add_argument(
+        "--fit", action="store_true",
+        help="derive MemoryThresholds from the recorded results",
+    )
+    parser.add_argument(
+        "--results", default=RESULTS_FILE,
+        help="results file to fit from (default: sweep output)",
+    )
+    parser.add_argument(
+        "--arch", default=None,
+        help="architecture code for the emitted entry "
+             "(default: from the records or the current device)",
+    )
     args = parser.parse_args()
-    if args.single:
+    if args.fit:
+        fit(args.results, args.arch)
+    elif args.single:
         run_single(json.loads(args.single))
     else:
         phases = list(PHASES) if args.phase == "all" else [args.phase]

--- a/benchmarks/memory_location_sweep.py
+++ b/benchmarks/memory_location_sweep.py
@@ -293,6 +293,9 @@ def run_single(cfg):
         print(json.dumps({"skip": True}))
         return
 
+    # auto_memory off on both sides: the sweep measures pure
+    # placements, and the heuristics under calibration must never
+    # leak into their own baseline.
     base_kwargs = dict(
         dt=DT,
         step_controller="fixed",
@@ -300,6 +303,7 @@ def run_single(cfg):
         output_types=["state"],
         time_logging_level="default",
         algorithm=cfg["algorithm"],
+        auto_memory=False,
     )
     if cfg["algorithm"] in IMPLICIT:
         base_kwargs["krylov_max_iters"] = 100

--- a/src/cubie/batchsolving/solver.py
+++ b/src/cubie/batchsolving/solver.py
@@ -61,6 +61,7 @@ from cubie.array_interpolator import ArrayInterpolator
 from cubie.integrators.algorithms.base_algorithm_step import (
     ALL_ALGORITHM_STEP_PARAMETERS,
 )
+from cubie.integrators.memory_heuristics import auto_memory_locations
 from cubie.integrators.loops.ode_loop import (
     ALL_LOOP_SETTINGS,
 )
@@ -346,6 +347,14 @@ class Solver:
     time_logging_level : str or None, default='default'
         Time logging verbosity level. Options are 'default', 'verbose',
         'debug', None, or 'None' to disable timing.
+    auto_memory : bool, default=True
+        Apply measured shared-memory placements for buffer
+        configurations where they beat the all-local defaults (see
+        :mod:`cubie.integrators.memory_heuristics`). Explicit
+        ``*_location`` arguments always take precedence; pass
+        ``False`` to keep every unspecified buffer local. Placement
+        is chosen at construction and is not revisited by later
+        :meth:`update` calls.
     **kwargs
         Additional keyword arguments forwarded to internal components. See
         "Optional Arguments" in the docs for the possibilities.
@@ -376,6 +385,7 @@ class Solver:
         loop_settings: Optional[Dict[str, object]] = None,
         time_logging_level: Optional[str] = None,
         cache: Union[bool, str, Path] = True,
+        auto_memory: bool = True,
         **kwargs: Any,
     ) -> None:
         if output_settings is None:
@@ -486,6 +496,25 @@ class Solver:
                 "Unrecognized keyword arguments: "
                 f"{set(kwargs) - recognized_kwargs}"
             )
+
+        if auto_memory:
+            user_location_keys = {
+                key
+                for source in (
+                    kwargs,
+                    algorithm_settings,
+                    loop_settings,
+                    step_control_settings,
+                )
+                for key in source
+                if key.endswith("_location")
+            }
+            placements = auto_memory_locations(
+                self.kernel.single_integrator,
+                user_location_keys,
+            )
+            if placements:
+                self.kernel.update(placements)
 
     def convert_output_labels(
         self,

--- a/src/cubie/batchsolving/solver.py
+++ b/src/cubie/batchsolving/solver.py
@@ -350,11 +350,13 @@ class Solver:
     auto_memory : bool, default=True
         Apply measured shared-memory placements for buffer
         configurations where they beat the all-local defaults (see
-        :mod:`cubie.integrators.memory_heuristics`). Explicit
-        ``*_location`` arguments always take precedence; pass
-        ``False`` to keep every unspecified buffer local. Placement
-        is chosen at construction and is not revisited by later
-        :meth:`update` calls.
+        :mod:`cubie.integrators.memory_heuristics`). Thresholds are
+        calibrated per GPU architecture; cards without a calibrated
+        entry use the default entry. Explicit ``*_location``
+        arguments always take precedence; pass ``False`` to keep
+        every unspecified buffer local. Placement is chosen at
+        construction and is not revisited by later :meth:`update`
+        calls.
     **kwargs
         Additional keyword arguments forwarded to internal components. See
         "Optional Arguments" in the docs for the possibilities.

--- a/src/cubie/buffer_registry.py
+++ b/src/cubie/buffer_registry.py
@@ -499,6 +499,35 @@ class BufferGroup:
             return 0
         return max(s.stop for s in layout.values())
 
+    def relocatable_names(self) -> Tuple[str, ...]:
+        """Return buffer names registered directly on this group.
+
+        Excludes the ``{child}_shared`` and ``{child}_persistent``
+        roll-up entries created by
+        :meth:`BufferRegistry.register_child`, leaving only buffers
+        whose location is set through a ``{name}_location`` setting.
+        """
+        rollups = set()
+        for base in self.children:
+            rollups.add(f"{base}_shared")
+            rollups.add(f"{base}_persistent")
+        return tuple(
+            name for name in self.entries if name not in rollups
+        )
+
+    def nonaliased_elements(self, names: Tuple[str, ...]) -> int:
+        """Return total elements the named buffers would allocate.
+
+        Aliased buffers overlap their parent's allocation, so only
+        non-aliased entries contribute. Unknown names count zero.
+        """
+        total = 0
+        for name in names:
+            entry = self.entries.get(name)
+            if entry is not None and entry.aliases is None:
+                total += entry.size
+        return total
+
     def get_allocator(self, name: str, zero: bool = False) -> Callable:
         """Generate CUDA device function for buffer allocation.
 
@@ -668,6 +697,23 @@ class BufferRegistry:
         if parent in self._groups:
             self._groups[parent].invalidate_layouts()
 
+    def clear_own(self, parent: object) -> None:
+        """Remove a parent's own registrations, sparing its children.
+
+        Unlike :meth:`clear_parent` this does not cascade: children
+        keep their registrations, so a parent refreshing its own
+        entries (re-running its ``register_buffers``) does not wipe
+        the still-valid declarations of the components it hosts.
+        The parent is expected to re-record its children via
+        :meth:`register_child` afterwards.
+
+        Parameters
+        ----------
+        parent
+            Parent instance whose own registrations are removed.
+        """
+        self._groups.pop(parent, None)
+
     def clear_parent(self, parent: object) -> None:
         """Remove a parent's buffer registrations and its children's.
 
@@ -821,6 +867,86 @@ class BufferRegistry:
         if parent not in self._groups:
             return 0
         return self._groups[parent].persistent_local_buffer_size()
+
+    def relocatable_buffer_names(self, parent: object) -> Tuple[str, ...]:
+        """Return buffer names registered directly on a parent.
+
+        Excludes child roll-up entries, leaving the buffers whose
+        location is set through a ``{name}_location`` setting.
+        Parents with no registered group return an empty tuple.
+
+        Parameters
+        ----------
+        parent
+            Parent instance to query.
+
+        Returns
+        -------
+        Tuple[str, ...]
+            Names of the parent's own registered buffers.
+        """
+        if parent not in self._groups:
+            return ()
+        return self._groups[parent].relocatable_names()
+
+    def nonaliased_elements(
+        self,
+        parent: object,
+        names: Tuple[str, ...],
+    ) -> int:
+        """Return total elements the named buffers would allocate.
+
+        Aliased buffers overlap their parent's allocation, so only
+        non-aliased entries contribute. Unknown parents or names
+        count zero.
+
+        Parameters
+        ----------
+        parent
+            Parent instance to query.
+        names
+            Buffer names registered on the parent.
+
+        Returns
+        -------
+        int
+            Total non-aliased elements across the named buffers.
+        """
+        if parent not in self._groups:
+            return 0
+        return self._groups[parent].nonaliased_elements(names)
+
+    def declared_local_elements(self, parent: object) -> int:
+        """Return the declared per-thread local footprint in elements.
+
+        Sums plain-local buffer sizes across the parent and every
+        child recorded by :meth:`register_child`, recursively, plus
+        the parent's persistent-local total (children's persistent
+        totals already roll up into the parent's child entries).
+
+        Parameters
+        ----------
+        parent
+            Parent instance to query.
+
+        Returns
+        -------
+        int
+            Declared local plus persistent elements per thread.
+        """
+        group = self._groups.get(parent)
+        if group is None:
+            return 0
+
+        def plain_local(current: BufferGroup) -> int:
+            total = current.local_buffer_size()
+            for child in current.children.values():
+                child_group = self._groups.get(child)
+                if child_group is not None:
+                    total += plain_local(child_group)
+            return total
+
+        return plain_local(group) + group.persistent_local_buffer_size()
 
     def get_allocator(
         self,

--- a/src/cubie/cuda_simsafe.py
+++ b/src/cubie/cuda_simsafe.py
@@ -395,6 +395,21 @@ def is_cudasim_enabled() -> bool:
     return CUDA_SIMULATION
 
 
+def compute_capability_code() -> Optional[str]:
+    """Return the current device's compute capability as ``"M.m"``.
+
+    Returns
+    -------
+    str or None
+        Architecture code such as ``"8.9"``, or ``None`` under
+        CUDASIM, where no physical architecture exists.
+    """
+    if CUDA_SIMULATION:  # pragma: no cover - simulated
+        return None
+    major, minor = cuda.get_current_device().compute_capability
+    return f"{major}.{minor}"
+
+
 def max_shared_memory_per_block() -> int:
     """Return the device's dynamic shared-memory limit per block.
 
@@ -418,6 +433,7 @@ __all__ = [
     "activemask",
     "all_sync",
     "compile_kwargs",
+    "compute_capability_code",
     "get_jit_kwargs",
     "CUDA_SIMULATION",
     "CUDACache",

--- a/src/cubie/integrators/algorithms/generic_dirk.py
+++ b/src/cubie/integrators/algorithms/generic_dirk.py
@@ -225,8 +225,10 @@ class DIRKStep(ODEImplicitStep):
         n = config.n
         tableau = config.tableau
 
-        # Clear any existing buffer registrations
-        buffer_registry.clear_parent(self)
+        # Clear this step's own registrations only: the nonlinear
+        # solver child keeps its still-valid declarations, and
+        # register_child below re-records it with fresh sizes.
+        buffer_registry.clear_own(self)
 
         # Calculate buffer sizes
         accumulator_length = max(tableau.stage_count - 1, 0) * n

--- a/src/cubie/integrators/memory_heuristics.py
+++ b/src/cubie/integrators/memory_heuristics.py
@@ -1,11 +1,11 @@
 """Measured heuristics for default CUDA buffer memory locations.
 
 Selects shared-memory placements that beat the all-local defaults in
-paired A/B kernel benchmarks (issue #329, RTX 4070 SUPER). The rules
-fire only on configurations matching a measured winning pattern;
-everything else keeps the all-local defaults, which the same sweep
-measured as best (or within noise of best) whenever the per-thread
-working set fits on-chip.
+paired A/B kernel benchmarks (issue #329). The rules fire only on
+configurations matching a measured winning pattern; everything else
+keeps the all-local defaults, which the same sweep measured as best
+(or within noise of best) whenever the per-thread working set fits
+on-chip.
 
 Mechanism, as measured: once the per-thread local working set spills
 past the register file, kernels become DRAM-bandwidth-bound and
@@ -15,137 +15,284 @@ the block size through the kernel's 32 KiB dynamic-shared target and
 lose more residency than they save, so oversized groups stay local.
 
 All thresholds operate on registry-declared buffer sizes - the only
-quantities available before compilation. They were calibrated so
-that every winning benchmark cell fires its rule and every losing
-cell does not.
+quantities available before compilation - and are calibrated per GPU
+architecture. Each :class:`MemoryThresholds` entry in
+``THRESHOLDS_BY_ARCH`` is derived from a sweep dataset by
+``benchmarks/memory_location_sweep.py --fit``; to calibrate a new
+card, run the sweep there and paste the emitted entry. Unknown
+architectures fall back to the ``DEFAULT_ARCH`` entry.
 """
 
-from typing import Dict, List, Tuple
+from typing import Dict, FrozenSet, List, Optional, Tuple
 
+from attrs import define
 from numpy import dtype as np_dtype
 
 from cubie.buffer_registry import buffer_registry
+from cubie.cuda_simsafe import compute_capability_code
 from cubie.integrators.algorithms import (
-    BackwardsEulerPCStep,
     BackwardsEulerStep,
     DIRKStep,
     ERKStep,
     FIRKStep,
 )
 
-HEAVY_SPILL_BYTES = 3072
-"""Predicted per-thread local footprint that marks a spilled kernel.
+MEASURED_STEP_TYPES = (
+    ERKStep,
+    DIRKStep,
+    FIRKStep,
+    BackwardsEulerStep,
+)
+"""Algorithm families with benchmarked placement rules.
 
-Paired sweeps show shared placements only win once the declared
-local+persistent footprint reaches ~3.3 KiB (dirk n=64); the largest
-all-shared-losing cell sits at ~2.6 KiB (backwards Euler n=64).
-"""
-
-SPILL_FLOOR_BYTES = 512
-"""Minimum footprint for the explicit stage-buffer rule to fire.
-
-Below this the working set register-promotes and shared placement
-was measured as a pure loss (tsit5 n=4: 2.0x slower).
-"""
-
-STATE_PAIR_MAX_BYTES = 1024
-"""Largest state+proposed_state pair moved to shared.
-
-Pairs at or under 1 KiB won 1.6-2.9x on spilled kernels (tsit5,
-dirk, firk, backwards Euler at n=64-128); 2 KiB pairs collapsed the
-block size to 16 and lost up to 1.7x (n=256).
-"""
-
-WORK_GROUP_MAX_BYTES = 2560
-"""Largest algorithm work-buffer group moved to shared.
-
-The 2.5 KiB dirk n=128 group won 1.75x; the 5 KiB n=256 group lost
-1.9x.
-"""
-
-EXPLICIT_WORK_MAX_BYTES = 512
-"""Largest explicit stage-buffer group moved to shared.
-
-The 448 B tsit5 n=16 group won 1.25x; the 1.8 KiB n=64 group lost
-2.2x.
-"""
-
-PARAMS_MIN_BYTES = 512
-"""Smallest parameter buffer worth moving to shared.
-
-512 B parameter sets won 1.1-2.1x on spilled kernels; smaller sets
-were inconsistent across algorithms.
+Subclasses (e.g. the predict-correct backwards Euler step) inherit
+their base family's rules: their buffer groups are read from the
+registry, so a subclass that registers different buffers is still
+placed against its own declared sizes. Families not in this tuple
+(crank_nicolson, rosenbrock) have no measured winning placement and
+keep all-local defaults.
 """
 
 STATE_PAIR_KEYS = ("state_location", "proposed_state_location")
 
-WORK_BUFFER_LOCATION_KEYS: Dict[type, Tuple[str, ...]] = {
-    ERKStep: ("stage_rhs_location", "stage_accumulator_location"),
-    DIRKStep: (
-        "stage_increment_location",
-        "stage_base_location",
-        "accumulator_location",
-        "stage_rhs_location",
+PARAMS_KEYS = ("parameters_location",)
+
+
+@define(frozen=True)
+class MemoryThresholds:
+    """Placement gates calibrated for one GPU architecture.
+
+    All values are bytes of registry-declared buffer sizes.
+
+    Attributes
+    ----------
+    heavy_spill_bytes : int
+        Per-thread local footprint that marks a spilled kernel.
+        Shared placements only win once the declared footprint
+        passes this; the largest all-shared-losing cell sits below
+        it.
+    spill_floor_bytes : int
+        Minimum footprint for the explicit stage-buffer rule.
+        Below this the working set register-promotes and shared
+        placement was measured as a pure loss.
+    state_pair_max_bytes : int
+        Largest state+proposed_state pair moved to shared. Larger
+        pairs collapse the block size and lose.
+    work_group_max_bytes : int
+        Largest implicit algorithm work-buffer group moved to
+        shared.
+    explicit_work_max_bytes : int
+        Largest explicit stage-buffer group moved to shared.
+    params_min_bytes : int
+        Smallest parameter buffer worth moving to shared on a
+        spilled kernel; smaller sets were inconsistent.
+    """
+
+    heavy_spill_bytes: int
+    spill_floor_bytes: int
+    state_pair_max_bytes: int
+    work_group_max_bytes: int
+    explicit_work_max_bytes: int
+    params_min_bytes: int
+
+
+THRESHOLDS_BY_ARCH: Dict[str, MemoryThresholds] = {
+    # RTX 4070 SUPER, 206 paired configurations (issue #329),
+    # emitted by memory_location_sweep.py --fit. Boundary cells:
+    # footprint 3.9 KiB won vs 3.3 KiB lost; state pair 1 KiB won
+    # 1.7-2.9x vs 2 KiB lost; work group 2 KiB won 1.75x vs 4 KiB
+    # lost; explicit stage buffers 448 B won 1.25x vs 1.8 KiB
+    # lost; params 512 B won 1.1-2.1x.
+    "8.9": MemoryThresholds(
+        heavy_spill_bytes=3584,
+        spill_floor_bytes=512,
+        state_pair_max_bytes=1024,
+        work_group_max_bytes=2048,
+        explicit_work_max_bytes=512,
+        params_min_bytes=512,
     ),
-    FIRKStep: (
-        "stage_increment_location",
-        "stage_driver_stack_location",
-        "stage_state_location",
-    ),
-    BackwardsEulerStep: ("increment_cache_location",),
-    BackwardsEulerPCStep: ("increment_cache_location",),
 }
-"""Work-buffer location kwargs per measured algorithm family.
 
-Families absent from this mapping (crank_nicolson, rosenbrock) have
-no measured winning placement and keep all-local defaults.
-"""
+DEFAULT_ARCH = "8.9"
+"""Fallback architecture for cards without a calibrated entry."""
 
 
-def _chain_local_bytes(loop, itemsize: int) -> int:
-    """Return the declared per-thread local footprint in bytes.
+def resolve_thresholds(
+    arch: Optional[str] = None,
+) -> MemoryThresholds:
+    """Return the thresholds calibrated for a GPU architecture.
 
-    Sums plain-local buffer sizes across the loop and every child
-    component recorded in the registry, plus the loop's persistent
-    total (children's persistent totals already roll up into the
-    loop's child entries).
+    Parameters
+    ----------
+    arch
+        Compute-capability code such as ``"8.9"``. When None, the
+        current device is queried (CUDASIM reports no
+        architecture and receives the default entry).
+
+    Returns
+    -------
+    MemoryThresholds
+        The calibrated entry for ``arch``, falling back to
+        ``DEFAULT_ARCH`` when the architecture has no entry.
     """
-    groups = buffer_registry._groups
-
-    def local_elements(parent) -> int:
-        group = groups.get(parent)
-        if group is None:
-            return 0
-        total = group.local_buffer_size()
-        for child in group.children.values():
-            total += local_elements(child)
-        return total
-
-    persistent = buffer_registry.persistent_local_buffer_size(loop)
-    return (local_elements(loop) + persistent) * itemsize
+    if arch is None:
+        arch = compute_capability_code()
+    if arch is None or arch not in THRESHOLDS_BY_ARCH:
+        arch = DEFAULT_ARCH
+    return THRESHOLDS_BY_ARCH[arch]
 
 
-def _group_bytes(parent, keys: Tuple[str, ...], itemsize: int) -> int:
-    """Return the shared bytes a location-key group would occupy.
+@define(frozen=True)
+class DeclaredSizes:
+    """Registry-declared quantities the placement gates operate on.
 
-    Aliased buffers overlap their parent's allocation, so only
-    non-aliased entries contribute.
+    Attributes
+    ----------
+    itemsize : int
+        Bytes per element of the run's precision.
+    is_implicit : bool
+        Whether the algorithm step embeds a nonlinear solve.
+    footprint_bytes : int
+        Declared per-thread local plus persistent footprint.
+    state_pair_bytes : int
+        Size of the state and proposed-state pair.
+    work_group_bytes : int
+        Non-aliased size of the algorithm step's own buffers.
+    params_bytes : int
+        Size of the parameter buffer.
+    work_location_keys : Tuple[str, ...]
+        ``{name}_location`` settings for the algorithm step's own
+        registered buffers, read from the registry so renamed or
+        restructured buffers are picked up automatically.
     """
-    group = buffer_registry._groups.get(parent)
-    if group is None:
-        return 0
-    total = 0
-    for key in keys:
-        name = key.removesuffix("_location")
-        entry = group.entries.get(name)
-        if entry is not None and entry.aliases is None:
-            total += entry.size
-    return total * itemsize
+
+    itemsize: int
+    is_implicit: bool
+    footprint_bytes: int
+    state_pair_bytes: int
+    work_group_bytes: int
+    params_bytes: int
+    work_location_keys: Tuple[str, ...]
+
+
+def declared_sizes(single_integrator_run) -> DeclaredSizes:
+    """Measure the declared buffer sizes of a constructed run.
+
+    Parameters
+    ----------
+    single_integrator_run
+        Constructed integrator core whose loop, algorithm step, and
+        solver chain have registered their buffers.
+
+    Returns
+    -------
+    DeclaredSizes
+        Registry-declared quantities for the placement gates.
+    """
+    loop = single_integrator_run._loop
+    algo_step = single_integrator_run._algo_step
+    itemsize = np_dtype(single_integrator_run.precision).itemsize
+
+    work_names = buffer_registry.relocatable_buffer_names(algo_step)
+    work_elements = buffer_registry.nonaliased_elements(
+        algo_step, work_names
+    )
+    footprint_elements = buffer_registry.declared_local_elements(loop)
+
+    n_states = loop.compile_settings.n_states
+    n_parameters = loop.compile_settings.n_parameters
+
+    return DeclaredSizes(
+        itemsize=itemsize,
+        is_implicit=algo_step.is_implicit,
+        footprint_bytes=footprint_elements * itemsize,
+        state_pair_bytes=2 * n_states * itemsize,
+        work_group_bytes=work_elements * itemsize,
+        params_bytes=n_parameters * itemsize,
+        work_location_keys=tuple(
+            f"{name}_location" for name in work_names
+        ),
+    )
+
+
+def placement_candidates(
+    sizes: DeclaredSizes,
+    thresholds: MemoryThresholds,
+) -> List[Tuple[str, ...]]:
+    """Return the placement groups whose gates fire, best first.
+
+    Parameters
+    ----------
+    sizes
+        Registry-declared quantities for one configuration.
+    thresholds
+        Calibrated gates for the target architecture.
+
+    Returns
+    -------
+    List[Tuple[str, ...]]
+        ``*_location`` key groups measured faster than all-local,
+        in priority order. Empty when all-local is the measured
+        best.
+    """
+    itemsize = sizes.itemsize
+    footprint = sizes.footprint_bytes
+    candidates: List[Tuple[bool, Tuple[str, ...]]] = []
+
+    if sizes.is_implicit:
+        if footprint < thresholds.heavy_spill_bytes:
+            return []
+        candidates = [
+            (
+                itemsize == 4
+                and sizes.state_pair_bytes
+                <= thresholds.state_pair_max_bytes,
+                STATE_PAIR_KEYS,
+            ),
+            (
+                0
+                < sizes.work_group_bytes
+                <= thresholds.work_group_max_bytes,
+                sizes.work_location_keys,
+            ),
+            (
+                itemsize == 4
+                and sizes.params_bytes >= thresholds.params_min_bytes,
+                PARAMS_KEYS,
+            ),
+        ]
+    else:
+        if footprint >= thresholds.heavy_spill_bytes:
+            candidates = [
+                (
+                    sizes.state_pair_bytes
+                    <= thresholds.state_pair_max_bytes
+                    * (itemsize // 4),
+                    STATE_PAIR_KEYS,
+                ),
+                (
+                    itemsize == 4
+                    and sizes.params_bytes
+                    >= thresholds.params_min_bytes,
+                    PARAMS_KEYS,
+                ),
+            ]
+        elif footprint >= thresholds.spill_floor_bytes:
+            candidates = [
+                (
+                    0
+                    < sizes.work_group_bytes
+                    <= thresholds.explicit_work_max_bytes,
+                    sizes.work_location_keys,
+                ),
+            ]
+
+    return [keys for fires, keys in candidates if fires]
 
 
 def auto_memory_locations(
     single_integrator_run,
-    user_location_keys=frozenset(),
+    user_location_keys: FrozenSet[str] = frozenset(),
 ) -> Dict[str, str]:
     """Return shared placements measured faster than all-local.
 
@@ -164,67 +311,17 @@ def auto_memory_locations(
     Dict[str, str]
         ``*_location`` settings to apply, empty when the all-local
         defaults are already the measured best. At most one buffer
-        group is selected so every returned placement corresponds to
+        group is selected so every applied placement corresponds to
         a benchmarked operating point.
     """
-    loop = single_integrator_run._loop
     algo_step = single_integrator_run._algo_step
-    itemsize = np_dtype(single_integrator_run.precision).itemsize
-
-    work_keys: Tuple[str, ...] = ()
-    for step_type, keys in WORK_BUFFER_LOCATION_KEYS.items():
-        if type(algo_step) is step_type:
-            work_keys = keys
-            break
-    else:
+    if not isinstance(algo_step, MEASURED_STEP_TYPES):
         return {}
 
-    footprint = _chain_local_bytes(loop, itemsize)
-    n_states = loop.compile_settings.n_states
-    n_parameters = loop.compile_settings.n_parameters
-    state_pair_bytes = 2 * n_states * itemsize
-    work_bytes = _group_bytes(algo_step, work_keys, itemsize)
-    params_bytes = n_parameters * itemsize
+    sizes = declared_sizes(single_integrator_run)
+    thresholds = resolve_thresholds()
 
-    candidates: List[Tuple[bool, Tuple[str, ...]]] = []
-    if algo_step.is_implicit:
-        if footprint < HEAVY_SPILL_BYTES:
-            return {}
-        candidates = [
-            (
-                itemsize == 4
-                and state_pair_bytes <= STATE_PAIR_MAX_BYTES,
-                STATE_PAIR_KEYS,
-            ),
-            (0 < work_bytes <= WORK_GROUP_MAX_BYTES, work_keys),
-            (
-                itemsize == 4 and params_bytes >= PARAMS_MIN_BYTES,
-                ("parameters_location",),
-            ),
-        ]
-    else:
-        if footprint >= HEAVY_SPILL_BYTES:
-            candidates = [
-                (
-                    state_pair_bytes <= STATE_PAIR_MAX_BYTES * (
-                        itemsize // 4
-                    ),
-                    STATE_PAIR_KEYS,
-                ),
-                (
-                    itemsize == 4 and params_bytes >= PARAMS_MIN_BYTES,
-                    ("parameters_location",),
-                ),
-            ]
-        elif footprint >= SPILL_FLOOR_BYTES:
-            candidates = [
-                (
-                    0 < work_bytes <= EXPLICIT_WORK_MAX_BYTES,
-                    work_keys,
-                ),
-            ]
-
-    for fires, keys in candidates:
-        if fires and not (set(keys) & set(user_location_keys)):
+    for keys in placement_candidates(sizes, thresholds):
+        if not (set(keys) & set(user_location_keys)):
             return {key: "shared" for key in keys}
     return {}

--- a/src/cubie/integrators/memory_heuristics.py
+++ b/src/cubie/integrators/memory_heuristics.py
@@ -1,0 +1,230 @@
+"""Measured heuristics for default CUDA buffer memory locations.
+
+Selects shared-memory placements that beat the all-local defaults in
+paired A/B kernel benchmarks (issue #329, RTX 4070 SUPER). The rules
+fire only on configurations matching a measured winning pattern;
+everything else keeps the all-local defaults, which the same sweep
+measured as best (or within noise of best) whenever the per-thread
+working set fits on-chip.
+
+Mechanism, as measured: once the per-thread local working set spills
+past the register file, kernels become DRAM-bandwidth-bound and
+moving a bounded slice of the hottest buffers into shared memory
+relieves the spill traffic. Placements above ~2.5 KiB per run shrink
+the block size through the kernel's 32 KiB dynamic-shared target and
+lose more residency than they save, so oversized groups stay local.
+
+All thresholds operate on registry-declared buffer sizes - the only
+quantities available before compilation. They were calibrated so
+that every winning benchmark cell fires its rule and every losing
+cell does not.
+"""
+
+from typing import Dict, List, Tuple
+
+from numpy import dtype as np_dtype
+
+from cubie.buffer_registry import buffer_registry
+from cubie.integrators.algorithms import (
+    BackwardsEulerPCStep,
+    BackwardsEulerStep,
+    DIRKStep,
+    ERKStep,
+    FIRKStep,
+)
+
+HEAVY_SPILL_BYTES = 3072
+"""Predicted per-thread local footprint that marks a spilled kernel.
+
+Paired sweeps show shared placements only win once the declared
+local+persistent footprint reaches ~3.3 KiB (dirk n=64); the largest
+all-shared-losing cell sits at ~2.6 KiB (backwards Euler n=64).
+"""
+
+SPILL_FLOOR_BYTES = 512
+"""Minimum footprint for the explicit stage-buffer rule to fire.
+
+Below this the working set register-promotes and shared placement
+was measured as a pure loss (tsit5 n=4: 2.0x slower).
+"""
+
+STATE_PAIR_MAX_BYTES = 1024
+"""Largest state+proposed_state pair moved to shared.
+
+Pairs at or under 1 KiB won 1.6-2.9x on spilled kernels (tsit5,
+dirk, firk, backwards Euler at n=64-128); 2 KiB pairs collapsed the
+block size to 16 and lost up to 1.7x (n=256).
+"""
+
+WORK_GROUP_MAX_BYTES = 2560
+"""Largest algorithm work-buffer group moved to shared.
+
+The 2.5 KiB dirk n=128 group won 1.75x; the 5 KiB n=256 group lost
+1.9x.
+"""
+
+EXPLICIT_WORK_MAX_BYTES = 512
+"""Largest explicit stage-buffer group moved to shared.
+
+The 448 B tsit5 n=16 group won 1.25x; the 1.8 KiB n=64 group lost
+2.2x.
+"""
+
+PARAMS_MIN_BYTES = 512
+"""Smallest parameter buffer worth moving to shared.
+
+512 B parameter sets won 1.1-2.1x on spilled kernels; smaller sets
+were inconsistent across algorithms.
+"""
+
+STATE_PAIR_KEYS = ("state_location", "proposed_state_location")
+
+WORK_BUFFER_LOCATION_KEYS: Dict[type, Tuple[str, ...]] = {
+    ERKStep: ("stage_rhs_location", "stage_accumulator_location"),
+    DIRKStep: (
+        "stage_increment_location",
+        "stage_base_location",
+        "accumulator_location",
+        "stage_rhs_location",
+    ),
+    FIRKStep: (
+        "stage_increment_location",
+        "stage_driver_stack_location",
+        "stage_state_location",
+    ),
+    BackwardsEulerStep: ("increment_cache_location",),
+    BackwardsEulerPCStep: ("increment_cache_location",),
+}
+"""Work-buffer location kwargs per measured algorithm family.
+
+Families absent from this mapping (crank_nicolson, rosenbrock) have
+no measured winning placement and keep all-local defaults.
+"""
+
+
+def _chain_local_bytes(loop, itemsize: int) -> int:
+    """Return the declared per-thread local footprint in bytes.
+
+    Sums plain-local buffer sizes across the loop and every child
+    component recorded in the registry, plus the loop's persistent
+    total (children's persistent totals already roll up into the
+    loop's child entries).
+    """
+    groups = buffer_registry._groups
+
+    def local_elements(parent) -> int:
+        group = groups.get(parent)
+        if group is None:
+            return 0
+        total = group.local_buffer_size()
+        for child in group.children.values():
+            total += local_elements(child)
+        return total
+
+    persistent = buffer_registry.persistent_local_buffer_size(loop)
+    return (local_elements(loop) + persistent) * itemsize
+
+
+def _group_bytes(parent, keys: Tuple[str, ...], itemsize: int) -> int:
+    """Return the shared bytes a location-key group would occupy.
+
+    Aliased buffers overlap their parent's allocation, so only
+    non-aliased entries contribute.
+    """
+    group = buffer_registry._groups.get(parent)
+    if group is None:
+        return 0
+    total = 0
+    for key in keys:
+        name = key.removesuffix("_location")
+        entry = group.entries.get(name)
+        if entry is not None and entry.aliases is None:
+            total += entry.size
+    return total * itemsize
+
+
+def auto_memory_locations(
+    single_integrator_run,
+    user_location_keys=frozenset(),
+) -> Dict[str, str]:
+    """Return shared placements measured faster than all-local.
+
+    Parameters
+    ----------
+    single_integrator_run
+        Constructed integrator core whose loop, algorithm step, and
+        solver chain have registered their buffers.
+    user_location_keys
+        ``*_location`` settings the user supplied explicitly. A
+        buffer group containing any of these keys is skipped whole:
+        partially relocated groups were never benchmarked.
+
+    Returns
+    -------
+    Dict[str, str]
+        ``*_location`` settings to apply, empty when the all-local
+        defaults are already the measured best. At most one buffer
+        group is selected so every returned placement corresponds to
+        a benchmarked operating point.
+    """
+    loop = single_integrator_run._loop
+    algo_step = single_integrator_run._algo_step
+    itemsize = np_dtype(single_integrator_run.precision).itemsize
+
+    work_keys: Tuple[str, ...] = ()
+    for step_type, keys in WORK_BUFFER_LOCATION_KEYS.items():
+        if type(algo_step) is step_type:
+            work_keys = keys
+            break
+    else:
+        return {}
+
+    footprint = _chain_local_bytes(loop, itemsize)
+    n_states = loop.compile_settings.n_states
+    n_parameters = loop.compile_settings.n_parameters
+    state_pair_bytes = 2 * n_states * itemsize
+    work_bytes = _group_bytes(algo_step, work_keys, itemsize)
+    params_bytes = n_parameters * itemsize
+
+    candidates: List[Tuple[bool, Tuple[str, ...]]] = []
+    if algo_step.is_implicit:
+        if footprint < HEAVY_SPILL_BYTES:
+            return {}
+        candidates = [
+            (
+                itemsize == 4
+                and state_pair_bytes <= STATE_PAIR_MAX_BYTES,
+                STATE_PAIR_KEYS,
+            ),
+            (0 < work_bytes <= WORK_GROUP_MAX_BYTES, work_keys),
+            (
+                itemsize == 4 and params_bytes >= PARAMS_MIN_BYTES,
+                ("parameters_location",),
+            ),
+        ]
+    else:
+        if footprint >= HEAVY_SPILL_BYTES:
+            candidates = [
+                (
+                    state_pair_bytes <= STATE_PAIR_MAX_BYTES * (
+                        itemsize // 4
+                    ),
+                    STATE_PAIR_KEYS,
+                ),
+                (
+                    itemsize == 4 and params_bytes >= PARAMS_MIN_BYTES,
+                    ("parameters_location",),
+                ),
+            ]
+        elif footprint >= SPILL_FLOOR_BYTES:
+            candidates = [
+                (
+                    0 < work_bytes <= EXPLICIT_WORK_MAX_BYTES,
+                    work_keys,
+                ),
+            ]
+
+    for fires, keys in candidates:
+        if fires and not (set(keys) & set(user_location_keys)):
+            return {key: "shared" for key in keys}
+    return {}

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -1629,8 +1629,11 @@ def test_solver_set_verbosity(solver_mutable):
         "output_types": ["state"],
         "saved_observable_indices": [],
         "summarised_observable_indices": [],
-        # The baseline must stay genuinely all-local: auto memory
-        # heuristics would move buffers to shared on this system.
+        # This test compares an all-local reference against a
+        # fully-shared solver to prove placement never changes
+        # results. Auto placement would move this system's state
+        # pair to shared on both sides, shrinking the local-vs-
+        # shared contrast the comparison exists to exercise.
         "auto_memory": False,
     }],
     indirect=True,

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -1620,6 +1620,29 @@ def test_solver_set_verbosity(solver_mutable):
     assert default_timelogger.verbosity is None
 
 
+MOVABLE_LOCATION_KEYS = (
+    "state_location",
+    "proposed_state_location",
+    "parameters_location",
+    "drivers_location",
+    "proposed_drivers_location",
+    "observables_location",
+    "proposed_observables_location",
+    "error_location",
+    "stage_increment_location",
+    "stage_base_location",
+    "accumulator_location",
+    "stage_rhs_location",
+)
+"""Every movable loop and DIRK work-buffer location setting.
+
+Pinning all of them makes both solvers fully explicit: every auto
+placement group contains a user-set key, so the heuristics are
+blocked on both sides and each solver's layout is exactly what the
+test states.
+"""
+
+
 @pytest.mark.parametrize(
     "solver_settings_override",
     [{
@@ -1629,12 +1652,7 @@ def test_solver_set_verbosity(solver_mutable):
         "output_types": ["state"],
         "saved_observable_indices": [],
         "summarised_observable_indices": [],
-        # This test compares an all-local reference against a
-        # fully-shared solver to prove placement never changes
-        # results. Auto placement would move this system's state
-        # pair to shared on both sides, shrinking the local-vs-
-        # shared contrast the comparison exists to exercise.
-        "auto_memory": False,
+        **{key: "local" for key in MOVABLE_LOCATION_KEYS},
     }],
     indirect=True,
 )
@@ -1648,27 +1666,23 @@ def test_shared_loop_buffers_leave_results_unchanged(
     simple_initial_values,
     simple_parameters,
 ):
-    """Buffer placement is storage-only: moving every movable loop
+    """Buffer placement is storage-only: moving every movable
     buffer to shared memory reproduces the all-local trajectories.
 
-    On the 100-state system these placements shrink the loop's
-    plain-local pool far below the DIRK step's persistent
-    requirement, so this fails loudly if the persistent scratch
-    array is ever again sized from the plain-local total instead
-    of the persistent layout. The all-local baseline is the shared
-    ``solver`` fixture; only the relocated comparison solver is
-    built fresh, because buffer placement is a construction
-    setting.
+    Both solvers pin every movable location explicitly - all local
+    on the reference, all shared on the comparison - so the auto
+    placement heuristics are blocked on both sides and the pair
+    differs only in buffer placement. On the 100-state system the
+    shared placements shrink the loop's plain-local pool far below
+    the DIRK step's persistent requirement, so this fails loudly if
+    the persistent scratch array is ever again sized from the
+    plain-local total instead of the persistent layout. The
+    all-local reference is the shared ``solver`` fixture; only the
+    relocated comparison solver is built fresh, because buffer
+    placement is a construction setting.
     """
     shared_locations = {
-        "state_location": "shared",
-        "proposed_state_location": "shared",
-        "parameters_location": "shared",
-        "drivers_location": "shared",
-        "proposed_drivers_location": "shared",
-        "observables_location": "shared",
-        "proposed_observables_location": "shared",
-        "error_location": "shared",
+        key: "shared" for key in MOVABLE_LOCATION_KEYS
     }
 
     def run_solve(active_solver):

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -1629,6 +1629,9 @@ def test_solver_set_verbosity(solver_mutable):
         "output_types": ["state"],
         "saved_observable_indices": [],
         "summarised_observable_indices": [],
+        # The baseline must stay genuinely all-local: auto memory
+        # heuristics would move buffers to shared on this system.
+        "auto_memory": False,
     }],
     indirect=True,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -486,6 +486,7 @@ def solver_settings(solver_settings_override, system, precision):
         "deadband_max": precision(1.05),
         "fix_singularities": True,
         "voltage_variable": None,
+        "auto_memory": True,
     }
 
     float_keys = {

--- a/tests/integrators/test_memory_heuristics.py
+++ b/tests/integrators/test_memory_heuristics.py
@@ -1,0 +1,133 @@
+"""Tests for measured auto buffer-placement heuristics."""
+
+import pytest
+
+from cubie.buffer_registry import buffer_registry
+from cubie.integrators.memory_heuristics import auto_memory_locations
+
+
+def loop_and_algo_shared_buffers(solver):
+    """Return non-child shared buffer names for the loop and step."""
+    run = solver.kernel.single_integrator
+    names = set()
+    for parent in (run._loop, run._algo_step):
+        group = buffer_registry._groups.get(parent)
+        if group is None:
+            continue
+        for name, entry in group.entries.items():
+            if name.endswith(("_shared", "_persistent")):
+                continue
+            if entry.location == "shared" and entry.size > 0:
+                names.add(name)
+    return names
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [
+        {"algorithm": "euler"},
+        {"algorithm": "tsit5"},
+        {"algorithm": "backwards_euler"},
+    ],
+    indirect=True,
+)
+def test_small_system_keeps_all_buffers_local(solver):
+    """No placement fires below the spill gate: small systems stay
+    all-local, where shared placements measured neutral-to-slower."""
+    assert loop_and_algo_shared_buffers(solver) == set()
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [
+        {
+            "system_type": "large",
+            "algorithm": "tsit5",
+            "output_types": ["state"],
+            "saved_observable_indices": [],
+            "summarised_observable_indices": [],
+        },
+        {
+            "system_type": "large",
+            "algorithm": "dirk",
+            "output_types": ["state"],
+            "saved_observable_indices": [],
+            "summarised_observable_indices": [],
+        },
+        {
+            "system_type": "large",
+            "algorithm": "backwards_euler",
+            "output_types": ["state"],
+            "saved_observable_indices": [],
+            "summarised_observable_indices": [],
+        },
+    ],
+    indirect=True,
+)
+def test_large_system_moves_state_pair_to_shared(solver):
+    """Heavily spilled kernels with a sub-1-KiB state pair get the
+    measured state/proposed_state shared placement."""
+    assert loop_and_algo_shared_buffers(solver) == {
+        "state",
+        "proposed_state",
+    }
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{
+        "system_type": "large",
+        "algorithm": "tsit5",
+        "output_types": ["state"],
+        "saved_observable_indices": [],
+        "summarised_observable_indices": [],
+        "state_location": "local",
+    }],
+    indirect=True,
+)
+def test_user_location_key_blocks_whole_group(solver):
+    """Pinning one key of a placement group keeps the whole group
+    local: partially relocated groups were never benchmarked."""
+    assert loop_and_algo_shared_buffers(solver) == set()
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{
+        "system_type": "large",
+        "algorithm": "tsit5",
+        "output_types": ["state"],
+        "saved_observable_indices": [],
+        "summarised_observable_indices": [],
+        "auto_memory": False,
+    }],
+    indirect=True,
+)
+def test_auto_memory_false_keeps_all_buffers_local(solver):
+    """auto_memory=False disables every heuristic placement."""
+    assert loop_and_algo_shared_buffers(solver) == set()
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{
+        "system_type": "large",
+        "algorithm": "backwards_euler",
+        "output_types": ["state"],
+        "saved_observable_indices": [],
+        "summarised_observable_indices": [],
+        "state_location": "local",
+    }],
+    indirect=True,
+)
+def test_blocked_group_falls_through_to_next_candidate(solver):
+    """When the user pins the state pair local, the next measured
+    candidate (the work-buffer group) fires instead."""
+    assert loop_and_algo_shared_buffers(solver) == {"increment_cache"}
+
+
+def test_resolver_skips_unmeasured_families(solver):
+    """The resolver returns nothing for the default euler config and
+    respects explicitly supplied keys."""
+    run = solver.kernel.single_integrator
+    assert auto_memory_locations(run) == {}

--- a/tests/integrators/test_memory_heuristics.py
+++ b/tests/integrators/test_memory_heuristics.py
@@ -3,7 +3,12 @@
 import pytest
 
 from cubie.buffer_registry import buffer_registry
-from cubie.integrators.memory_heuristics import auto_memory_locations
+from cubie.integrators.memory_heuristics import (
+    DEFAULT_ARCH,
+    THRESHOLDS_BY_ARCH,
+    auto_memory_locations,
+    resolve_thresholds,
+)
 
 
 def loop_and_algo_shared_buffers(solver):
@@ -14,9 +19,8 @@ def loop_and_algo_shared_buffers(solver):
         group = buffer_registry._groups.get(parent)
         if group is None:
             continue
-        for name, entry in group.entries.items():
-            if name.endswith(("_shared", "_persistent")):
-                continue
+        for name in buffer_registry.relocatable_buffer_names(parent):
+            entry = group.entries[name]
             if entry.location == "shared" and entry.size > 0:
                 names.add(name)
     return names
@@ -57,6 +61,13 @@ def test_small_system_keeps_all_buffers_local(solver):
         {
             "system_type": "large",
             "algorithm": "backwards_euler",
+            "output_types": ["state"],
+            "saved_observable_indices": [],
+            "summarised_observable_indices": [],
+        },
+        {
+            "system_type": "large",
+            "algorithm": "backwards_euler_pc",
             "output_types": ["state"],
             "saved_observable_indices": [],
             "summarised_observable_indices": [],
@@ -131,3 +142,11 @@ def test_resolver_skips_unmeasured_families(solver):
     respects explicitly supplied keys."""
     run = solver.kernel.single_integrator
     assert auto_memory_locations(run) == {}
+
+
+def test_unknown_architecture_falls_back_to_default():
+    """Cards without a calibrated entry receive the default
+    architecture's thresholds."""
+    default = THRESHOLDS_BY_ARCH[DEFAULT_ARCH]
+    assert resolve_thresholds("0.0") == default
+    assert resolve_thresholds(DEFAULT_ARCH) == default


### PR DESCRIPTION
Closes #329.

## What this adds

`Solver` now applies measured shared-memory buffer placements at construction (`auto_memory=True`, the default). The resolver (`cubie.integrators.memory_heuristics`) fires only on configurations matching a winning pattern from a paired A/B benchmark sweep; every other configuration keeps the all-local defaults, which the same sweep measured as best (or within noise) whenever the per-thread working set stays on-chip. Explicit `*_location` arguments always win; a group containing any user-set key is skipped whole; `auto_memory=False` disables placement entirely.

The thresholds live in a per-architecture table (`THRESHOLDS_BY_ARCH`, keyed by compute-capability code, falling back to the default entry on uncalibrated cards), and every constant is derived programmatically from the sweep dataset by `benchmarks/memory_location_sweep.py --fit` — calibrating a new card is: run the sweep there, run `--fit`, commit the emitted entry. Work-buffer groups are read from the buffer registry (`relocatable_buffer_names`), not hard-coded, so renamed or restructured algorithm buffers are picked up automatically and `backwards_euler_pc` inherits the backwards-Euler rules.

## Method

`benchmarks/memory_location_sweep.py` (included) measures each placement variant against an interleaved all-local baseline in the same process, so background GPU load cancels in the ratio, and asserts output equality between placements on every record. 206 paired configurations over: n_states {4,16,64,128,256} x {euler, tsit5, dirk, firk, backwards_euler} x placement groups (loop state pair, parameters, drivers, observables, algorithm work buffers, solver vectors, all-shared), plus parameter/driver/observable-count sweeps, baked-constant checks, and f64 controls. RTX 4070 SUPER, 32768 runs/launch.

Measured mechanism: once the declared per-thread local footprint spills past the register file, kernels go DRAM-bound and moving a bounded slice of hot buffers to shared wins; oversized placements collapse the block size through the 32 KiB dynamic-shared target and lose (all-shared: up to 10x slower).

## Threshold derivation (`--fit`)

Sweep records embed the registry-declared sizes captured at `Solver` construction — the same instant `auto_memory_locations` measures them — plus the device architecture; older datasets are reconstructed host-side (no kernel compilation) with a cache. The fit encodes the calibration reasoning:

- wins are paired ratios <= 0.95, losses >= 1.05 (the paired protocol's noise floor);
- each size gate is fitted from its own variant records: a measured size qualifies when its wins outnumber its losses, the gate is the qualifying boundary with all smaller (or larger) measured sizes also qualifying, rounded to a 512 B grid unless rounding crosses a disqualified size;
- the two footprint gates couple every rule, so they are chosen by a grid scan that replays all configurations through `placement_candidates` and keeps the pair firing on the fewest measured losses (zero on this dataset), then missing the fewest measured wins, then most conservative;
- a validation report replays every configuration against its measured ratios, including fires into unmeasured territory.

On the calibration dataset the fit reproduces four hand-derived constants exactly and corrects two, because the hand analysis worked from approximate sizes while the fit uses exact registry declarations:

- `work_group_max_bytes` 2560 → **2048**: dirk/128's winning group is 2048 B declared (the "2.5 KiB" was an estimate); the losing dirk/256 group is 4096 B.
- `heavy_spill_bytes` 3072 → **3584**: the measured boundary is a win at 3900 B against losses up to 3380 B. The old 3072 fired state placements on BE/64 with >=64 parameters — cells where every measured placement lost 1.6–1.8x — violating the calibration's own must-not-fire list; 3584 excludes them.

The committed table equals the `--fit` output byte-for-byte.

## Rules (all thresholds on registry-declared sizes, available pre-compile; f32 values for CC 8.9)

| Rule | Fires when | Evidence (kernel-time ratio vs all-local) |
|---|---|---|
| state+proposed_state -> shared | footprint >= 3.5 KiB and pair <= 1 KiB | tsit5/128 **0.35**, BE/128 **0.52**, firk/64 **0.58**, dirk/128 0.59, dirk/64 0.64 |
| algorithm work buffers -> shared (implicit; fallback when state pair blocked/oversized) | footprint >= 3.5 KiB and group <= 2 KiB | dirk/128 0.57, firk/64 0.64, dirk/64 0.74, BE/128 0.83, BE/256 0.91 |
| ERK stage buffers -> shared | footprint in [512 B, 3.5 KiB) and group <= 512 B | tsit5/16 0.80 |
| parameters -> shared | footprint >= 3.5 KiB and params >= 512 B | tsit5/128+128p **0.48**, BE/128+128p 0.88 |
| f64: state pair (explicit algorithms only) <= 2 KiB | same gate | f64 tsit5/128 0.78 |

Must-not-fire cells confirmed as losses and correctly excluded by the gates: BE/64 and dirk/16 (any placement, including BE/64's parameter placements at 64–128 params), tsit5/64 stage buffers (2.2x loss), tsit5/256 and dirk/256 state (1.6-1.7x loss), euler everywhere, drivers/observables groups (inconsistent, <=5%).

At most one group fires per configuration, so every applied placement corresponds to a benchmarked operating point. The validation report also lists the fires that land on unmeasured territory (e.g. the implicit work rule reaches f64 BE/128, whose sweep cells exceeded the paired-protocol timeout); these are inherited from the calibrated f32 behaviour and listed for future measurement.

## Bugs found by the sweep

- #603: rosenbrock kernel builds hang in auxiliary-cache planning for n>=16 (filed; rosenbrock is excluded from the sweep and gets no placements).
- #610 (merged): the persistent scratch array was sized from the wrong total, silently corrupting per-thread memory under shared placements. All sweep cells were re-measured post-fix and are bit-exact (`out_maxdiff == 0.0`).
- `DIRKStep.register_buffers` cleared its registrations through `clear_parent`, whose cascade also wiped the Newton–Krylov child's declarations; whether the solver's work vectors (half of dirk's declared footprint) were visible at placement time depended on update ordering. Fixed with a non-cascading `BufferRegistry.clear_own`; declared sizes are now deterministic.

Unmeasured and left rule-less: f64 implicit families (f64 BE/128 cells exceed the paired-protocol timeout at ~25 s/solve); crank_nicolson and rosenbrock work groups; datacenter (full-rate FP64) GPUs — thresholds were calibrated on one CC 8.9 GeForce card, and new cards get their own `THRESHOLDS_BY_ARCH` entries via `--fit`. The sweep script is resumable for exactly that purpose; the raw 190-record dataset behind the thresholds is preserved at https://gist.github.com/ccam80/a04e43bfbb9d34a7356dda1aaf2d29a8 (`*.jsonl` is gitignored repo-wide, so it is not committed).

## Tests

- `tests/integrators/test_memory_heuristics.py`: small systems stay all-local; the 100-state system moves the state pair for tsit5/dirk/backwards_euler/backwards_euler_pc; a user-pinned key blocks its whole group and falls through to the next candidate; `auto_memory=False` disables placement; unknown architectures fall back to the default thresholds entry.
- `auto_memory` has a default (`True`) in the central `solver_settings` fixture. The placement-invariance test pins every movable location explicitly — all local on the reference, all shared (loop and DIRK work buffers) on the comparison — which blocks auto placement on both sides group-by-group, so the pair differs only in buffer placement and no `auto_memory` pin is needed.
- CUDASIM: 321 passed over batchsolving/integrators/buffer-registry/algorithm areas. Real GPU: 322 passed over the same areas.

## Performance gate (`benchmarks/lorenz_mean_runtime.py`)

Lorenz is 3 states — far below every placement gate, so no rule fires and the gate checks for regression only. Verified host-side: `auto_memory_locations` returns `{}` for both benchmark configs and `shared_memory_bytes == 0` on both trees, so the B kernels are configurationally identical to A's. Re-verified after the review-response changes (thresholds table, registry-derived groups, `clear_own`): both configs still return `{}` placements and 0 shared bytes.

The first round flagged the fixed config (z = +3.61 on a 0.27% delta), so the pair was rerun with the order swapped. The sign followed run order, not code: the fixed-config time rose monotonically across all four runs (62.57 → 62.74 → 62.81 → 62.88 ms) whichever tree ran — a ~0.5% thermal drift, not a regression.

| round | config | A (main, fc95105) | B (this PR) | Welch z | verdict |
|---|---|---|---|---|---|
| 1 (A first) | fixed (classical-rk4), 2^22 | 62.57 ± 0.27 ms | 62.74 ± 0.40 ms | +3.61 | flagged (drift, see above) |
| 1 (A first) | adaptive (tsit5), 2^24 | 24.77 ± 0.27 ms | 24.80 ± 0.21 ms | +0.83 | no significant difference |
| 2 (B first) | fixed (classical-rk4), 2^22 | 62.88 ± 0.39 ms | 62.81 ± 0.36 ms | +1.32 (A vs B ref) | no significant difference |
| 2 (B first) | adaptive (tsit5), 2^24 | 25.02 ± 0.20 ms | 24.95 ± 0.24 ms | +2.29 (A vs B ref) | no significant difference |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

