### PR TITLE
fix[CI]: right-size CUDA runners to 4 vCPU to dodge the spot-quota collision

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -25,20 +25,26 @@ runners:
   # is not grantable in this region), so every runner must be spot.
   # price-capacity-optimized (pco, RunsOn's default) picks a high-capacity
   # spot pool that is also among the cheapest -- cost matters here as this
-  # is personally funded. Listing three 8-vCPU GPU families widens the
-  # pools to cut launch misses. All three are 8 vCPU, so `-n logical`
-  # still fans the tests out to 8 workers regardless of which pool wins.
-  # The shared "All G and VT Spot" vCPU quota is fixed (AWS will not raise
-  # it further), so provisioning can still fail when it is momentarily
-  # exhausted; ci_cuda_tests.yml retries failed legs with backoff.
+  # is personally funded. Listing three GPU families widens the pools to
+  # cut launch misses.
+  # 4-vCPU (xlarge) sizing is deliberate. The "All G and VT Spot" quota is
+  # a fixed 8 vCPU (AWS will not raise it), so an 8-vCPU runner saturated
+  # it and the next serial job's spot request collided with the finishing
+  # one during teardown -> MaxSpotInstanceCountExceeded -> RunsOn's fixed
+  # 5-min on-demand snooze -> on-demand is 0 -> the leg failed. Two 4-vCPU
+  # instances fit within 8 vCPU, so the handoff no longer exceeds quota.
+  # `-n logical` fans the tests out to 4 workers (slower per leg than 8,
+  # but it removes the collision that no GitHub/RunsOn lever can space).
   gpu-linux:
-    family: ["g4dn.2xlarge", "g5.2xlarge", "g6.2xlarge"]
+    family: ["g4dn.xlarge", "g5.xlarge", "g6.xlarge"]
     image: ubuntu24-gpu-x64
     spot: price-capacity-optimized
 
   # Windows GPU: our baked AMI (GRID driver already installed). The AWS
   # GRID driver is multi-GPU, so the same AMI runs on the T4/A10G/L4 spot
-  # pools listed below.
+  # pools listed below. 4-vCPU (xlarge) for the same 8-vCPU-quota reason
+  # as gpu-linux above -- two runners fit within quota so serial handoffs
+  # do not collide.
   # NOTE: RunsOn's build config defines a stock `windows25-gpu-x64` image
   # (built but, as of this writing, undocumented/unannounced -- the docs
   # still say Windows GPU is unsupported). If it becomes available in your
@@ -46,6 +52,6 @@ runners:
   # build-windows-gpu-ami.yml, ci/tools/install_gpu_driver.ps1, the
   # `images:` block above) and set `image: windows25-gpu-x64` here instead.
   gpu-windows:
-    family: ["g4dn.2xlarge", "g5.2xlarge", "g6.2xlarge"]
+    family: ["g4dn.xlarge", "g5.xlarge", "g6.xlarge"]
     image: cubie-win-gpu
     spot: price-capacity-optimized

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -79,15 +79,17 @@ jobs:
     name: cuda (${{ matrix.os }}, ${{ matrix.python-version }}, ${{ matrix.cuda }})
     permissions:
       contents: read
-    # max-parallel: 1 keeps the matrix to one 8-vCPU GPU instance at a
-    # time. Runners are spot-only (ap-southeast-2 has zero On-Demand G/VT
-    # quota, not grantable here), so concurrency is bounded by the shared
-    # "All G and VT Spot" vCPU quota; one g4dn/g5/g6.2xlarge = 8 vCPU fits
-    # under it. That quota is fixed (AWS will not raise it), so a leg can
-    # still fail to get a spot GPU when it is momentarily exhausted -- the
-    # `retry` job re-dispatches those legs. The param-set xdist grouping
-    # (tests/conftest.py + --dist=loadgroup in addopts) keeps thread
-    # scaling near-linear, so the 8 vCPUs are fully used.
+    # max-parallel: 1 runs one 4-vCPU GPU instance at a time. Runners are
+    # spot-only (ap-southeast-2 has zero On-Demand G/VT quota, not grantable
+    # here) and the "All G and VT Spot" quota is a fixed 8 vCPU. A 4-vCPU
+    # (xlarge) runner leaves 8-4=4 vCPU of headroom, so a leg's spot request
+    # no longer collides with the previous, still-terminating leg's instance
+    # -- that collision tripped RunsOn's fixed 5-min on-demand snooze, and
+    # on-demand is 0, so the leg failed. GitHub/RunsOn expose no lever to
+    # space serial jobs, so right-sizing is the fix. The `retry` job still
+    # re-dispatches any leg that misses a spot GPU. The param-set xdist
+    # grouping (tests/conftest.py + --dist=loadgroup in addopts) keeps
+    # thread scaling near-linear across the 4 workers.
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -169,12 +171,14 @@ jobs:
           disable_search: true
           fail_ci_if_error: false
 
-  # Re-dispatch legs that never got a spot GPU, with exponential backoff.
-  # This is the resilience layer for the fixed, un-raisable spot quota:
-  # RunsOn falls back to on-demand (which is 0 here, so it fails) for 5 min
-  # after a spot-quota miss, so the backoff starts at 5 min to outlast that
-  # snooze, and each retry is a fresh run (attempt resets on the runner, so
-  # RunsOn tries spot again rather than being forced onto on-demand).
+  # Re-dispatch legs that never got a spot GPU, at a fixed interval. With
+  # the runners right-sized (runs-on.yml) the quota-collision that tripped
+  # RunsOn's 5-min on-demand snooze is gone, so this is now a thin safety
+  # net for genuine transient capacity misses -- which appear in brief
+  # windows, so a fixed short interval catches them better than an ever-
+  # growing backoff (the same reasoning as the AMI-bake retry). Each retry
+  # is a fresh run (attempt resets on the runner, so RunsOn tries spot
+  # again rather than on-demand).
   retry:
     needs: [setup, cuda]
     if: always() && needs.setup.result == 'success'
@@ -198,8 +202,7 @@ jobs:
           MATRIX: ${{ needs.setup.outputs.matrix }}
           ATTEMPT: ${{ needs.setup.outputs.attempt }}
           MAX_ATTEMPTS: "5"
-          BASE_BACKOFF: "300"   # seconds; first retry waits out the 5-min snooze
-          MAX_BACKOFF: "1200"   # cap at 20 min
+          RETRY_INTERVAL: "180"   # seconds; fixed (capacity returns in brief windows)
           REF: ${{ github.ref_name }}
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -226,11 +229,9 @@ jobs:
             echo "Reached MAX_ATTEMPTS=${MAX_ATTEMPTS}; leaving the run red."
             exit 0
           fi
-          BACKOFF=$(( BASE_BACKOFF * (2 ** (ATTEMPT - 1)) ))
-          [ "$BACKOFF" -gt "$MAX_BACKOFF" ] && BACKOFF="$MAX_BACKOFF"
-          echo "Retrying these legs in ${BACKOFF}s:"
+          echo "Retrying these legs in ${RETRY_INTERVAL}s:"
           printf '%s' "$RETRYABLE" | jq .
-          sleep "$BACKOFF"
+          sleep "$RETRY_INTERVAL"
           gh workflow run ci_cuda_tests.yml \
             --ref "$REF" \
             -f attempt="$(( ATTEMPT + 1 ))" \


### PR DESCRIPTION
## Why

The CUDA legs fail on `MaxSpotInstanceCountExceeded`. Confirmed root cause:
the "All G and VT Spot" quota is a **fixed 8 vCPU**, the runners were
8-vCPU (`*.2xlarge`), and `max-parallel: 1` serializes the matrix — but
nothing spaces the handoff, so the next leg's spot request collides with
the previous leg's still-terminating instance. That trips RunsOn's **fixed
5-minute on-demand snooze**, and On-Demand G is 0, so the leg dies.

Verified there is **no lever to space serial jobs**:
- GitHub Actions has [no native delay between matrix jobs](https://github.com/orgs/community/discussions/26774) — `max-parallel` gates concurrency only. An in-job `sleep` runs on the live instance, so it holds the quota *longer*.
- RunsOn's [stack config](https://runs-on.com/configuration/stack-config/) offers `RunnerMaxRuntime` (a cap, not a teardown gap) and a private-mode NAT delay (irrelevant). No teardown-cooldown / provisioning-delay knob.
- The only mechanism that would insert a real gap is abandoning the matrix for a hand-built GPU-job → cooldown-job chain — far more complexity than the fix below.

## Fix

Right-size the runners to **4-vCPU `xlarge`** (`g4dn.xlarge`, `g5.xlarge`,
`g6.xlarge`). Two 4-vCPU instances (finishing + launching = 8) fit within
the 8-vCPU quota, so the handoff no longer exceeds it and the snooze
cascade stops. `-n logical` fans out to 4 workers per leg (slower per leg
than 8; the accepted cost for removing the collision).

Also **flatten the leg-retry**: with the collision — and thus the 5-min
snooze — gone, the retry no longer needs to outlast a snooze, so it uses a
fixed **180s** interval instead of exponential 300→1200s. Brief, random
capacity windows are caught by frequent polling, not by ever-growing
backoff (the same reasoning we applied to the AMI-bake retry). Both are
env vars at the top of the step.

## Verification

- `runs-on.yml` and `ci_cuda_tests.yml` parse; retry shell passes `bash -n`;
  env is `MAX_ATTEMPTS=5`, `RETRY_INTERVAL=180`, `BASE_BACKOFF` removed.
- Windows AMI (`ami-05ef3f0d...`, baked in #612's run) is multi-GPU, so the
  `xlarge` g5/g6 Windows runners boot from it fine.
- No `src/` changes → performance gate N/A. End-to-end confirmation is a
  `ci_cuda_tests.yml` dispatch once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
