### PR TITLE
fix: compiled-kernel cache stamps carry an environment hash

### DIFF
--- a/src/cubie/cubie_cache.py
+++ b/src/cubie/cubie_cache.py
@@ -17,6 +17,9 @@ as the module is not imported in that mode.
 """
 
 import os
+from functools import cache
+from hashlib import sha256
+from importlib.metadata import distributions
 from shutil import rmtree
 from warnings import warn
 from pathlib import Path
@@ -80,6 +83,32 @@ filter kwargs before forwarding.
 """
 
 
+@cache
+def environment_hash() -> str:
+    """Return a hash of every installed distribution's name and version.
+
+    Returns
+    -------
+    str
+        Hex digest fingerprinting the Python environment.
+
+    Notes
+    -----
+    Folded into the cache source stamp so cached kernels are
+    invalidated when any installed package changes — compiled
+    artifacts depend on the whole toolchain (numba-cuda, numba,
+    numpy, CUDA bindings), not just cubie's own configuration.
+    Computed once per process; editable installs whose source changes
+    without a version bump are not detected.
+    """
+    entries = []
+    for distribution in distributions():
+        name = distribution.metadata["Name"] or "unknown"
+        entries.append(f"{name}=={distribution.version}")
+    joined = "\n".join(sorted(entries))
+    return sha256(joined.encode("utf-8")).hexdigest()
+
+
 class CUBIECacheLocator(_CacheLocator):
     """Locate cache files in CuBIE's generated directory structure.
 
@@ -134,9 +163,10 @@ class CUBIECacheLocator(_CacheLocator):
         Returns
         -------
         str
-            The system hash acts as the freshness indicator.
+            The system hash combined with the environment hash, so a
+            change to any installed package invalidates the cache.
         """
-        return self._system_hash
+        return f"{self._system_hash}-{environment_hash()}"
 
     def get_disambiguator(self) -> str:
         """Return a string to disambiguate similar functions.

--- a/src/cubie/cubie_cache.py
+++ b/src/cubie/cubie_cache.py
@@ -104,7 +104,8 @@ def environment_hash() -> str:
     entries = []
     for distribution in distributions():
         name = distribution.metadata["Name"] or "unknown"
-        entries.append(f"{name}=={distribution.version}")
+        version = distribution.metadata["Version"] or "unknown"
+        entries.append(f"{name}=={version}")
     joined = "\n".join(sorted(entries))
     return sha256(joined.encode("utf-8")).hexdigest()
 

--- a/tests/test_cubie_cache.py
+++ b/tests/test_cubie_cache.py
@@ -1,5 +1,7 @@
 """Tests for cubie_cache module."""
 
+from hashlib import sha256
+from importlib.metadata import distributions
 from pathlib import Path
 
 import pytest
@@ -14,6 +16,7 @@ from cubie.cubie_cache import (
     CubieCacheHandler,
     CacheConfig,
     ALL_CACHE_PARAMETERS,
+    environment_hash,
 )
 from cubie._utils import package_source_hash
 
@@ -70,13 +73,32 @@ def test_cache_locator_get_cache_path():
 
 
 def test_cache_locator_get_source_stamp():
-    """Verify source stamp returns system_hash."""
+    """Verify source stamp combines system_hash and environment hash."""
     locator = CUBIECacheLocator(
         system_name="test_system",
         system_hash="abc123",
         compile_settings_hash="def456",
     )
-    assert locator.get_source_stamp() == "abc123"
+    assert locator.get_source_stamp() == f"abc123-{environment_hash()}"
+
+
+def test_environment_hash_is_stable_hex_digest():
+    """Verify the environment hash is a deterministic sha256 digest."""
+    digest = environment_hash()
+    assert len(digest) == 64
+    assert int(digest, 16) >= 0
+    assert environment_hash() == digest
+
+
+def test_environment_hash_covers_installed_packages():
+    """Verify the hash is built from every installed distribution."""
+    entries = []
+    for distribution in distributions():
+        name = distribution.metadata["Name"] or "unknown"
+        entries.append(f"{name}=={distribution.version}")
+    joined = "\n".join(sorted(entries))
+    expected = sha256(joined.encode("utf-8")).hexdigest()
+    assert environment_hash() == expected
 
 
 def test_cache_locator_get_disambiguator():
@@ -269,7 +291,7 @@ def test_cache_locator_instantiation_works():
     )
     # Path operations should work
     assert locator.get_cache_path() is not None
-    assert locator.get_source_stamp() == "abc123"
+    assert locator.get_source_stamp() == f"abc123-{environment_hash()}"
     assert locator.get_disambiguator() == "def456"
 
 

--- a/tests/test_cubie_cache.py
+++ b/tests/test_cubie_cache.py
@@ -86,7 +86,7 @@ def test_environment_hash_is_stable_hex_digest():
     """Verify the environment hash is a deterministic sha256 digest."""
     digest = environment_hash()
     assert len(digest) == 64
-    assert int(digest, 16) >= 0
+    assert all(c in "0123456789abcdef" for c in digest)
     assert environment_hash() == digest
 
 
@@ -95,7 +95,8 @@ def test_environment_hash_covers_installed_packages():
     entries = []
     for distribution in distributions():
         name = distribution.metadata["Name"] or "unknown"
-        entries.append(f"{name}=={distribution.version}")
+        version = distribution.metadata["Version"] or "unknown"
+        entries.append(f"{name}=={version}")
     joined = "\n".join(sorted(entries))
     expected = sha256(joined.encode("utf-8")).hexdigest()
     assert environment_hash() == expected


### PR DESCRIPTION
## Summary
- The compiled-kernel cache source stamp combines the system hash with `environment_hash()` — a sha256 over every installed distribution's name and version — so cached kernels are invalidated whenever any package in the environment changes.
- Compiled artifacts depend on the whole toolchain (numba-cuda, numba, numpy, CUDA bindings), not just cubie's own configuration; previously a toolchain upgrade replayed stale kernels.
- Computed once per process (`functools.cache`). Editable installs whose source changes without a version bump are not detected (cubie's own source is covered separately by `package_source_hash`).

## Tests
- `tests/test_cubie_cache.py`: source-stamp assertions updated; two new tests cover digest stability and coverage of all installed distributions. 41 passed on a real GPU (RTX 4070 SUPER).

## Performance gate (`benchmarks/lorenz_mean_runtime.py`)
The change cannot alter compiled kernels (host-side cache stamping only). Initial A/B flagged z=+4.02 on the fixed config, but the verdict flipped sign on a rerun; an order-swapped pair (per the drift protocol) shows no significant difference:

| run | fixed (classical-rk4) | adaptive (tsit5) | z vs counterpart | verdict |
|---|---|---|---|---|
| A1 `main` | 64.49 ± 0.67 ms | 25.50 ± 0.41 ms | — | reference |
| B1 PR | 65.32 ± 1.96 ms | 25.59 ± 0.41 ms | +4.02 / +1.53 vs A1 | drift (warm-up) |
| B2 PR | 63.71 ± 0.76 ms | 25.18 ± 0.46 ms | −7.69 / −5.10 vs A1 | drift (sign flip) |
| A2 `main` (order swap) | 63.78 ± 0.69 ms | 25.36 ± 0.61 ms | +0.72 / +2.33 vs B2 | **no significant difference** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)