### PR TITLE
perf: native pooled arrays + async transfers; cut per-solve host overhead

### DIFF
--- a/src/cubie/batchsolving/arrays/AGENTS.md
+++ b/src/cubie/batchsolving/arrays/AGENTS.md
@@ -41,8 +41,10 @@ field name. Iterate both via `_iter_managed_arrays` (device then host), one cont
 
 ### Lifecycle
 `from_solver(...)` builds a manager with sizes only (no allocation). `update(...)` refreshes
-sizes/precision/run-count, sets host arrays (`update_host_arrays`), and calls `allocate()`,
-which queues `ArrayRequest`s with the memory manager. The memory manager later drives
+sizes/precision/run-count, sets host arrays (`update_host_arrays` — same-shape updates copy
+values into the existing host buffer in place and queue `_needs_overwrite`; shape changes
+stage into a buffer of the slot's memory type and queue reallocation), and calls
+`allocate()`, which queues `ArrayRequest`s with the memory manager. The memory manager later drives
 `_on_allocation_complete(response)`: attach device arrays, record
 `chunked_shape`/`chunk_length`/`num_chunks`, set `_chunks`, and convert host arrays to pinned
 (non-chunked) or plain numpy (chunked). `_invalidate_hook` drops device refs and re-marks
@@ -52,9 +54,10 @@ everything for reallocation.
 - `initialise(chunk_index)` — pre-launch. `InputArrays`: H2D (non-chunked copies the
   `_needs_overwrite` arrays; chunked stages each run-axis slice through a `ChunkBufferPool`
   pinned buffer). `OutputArrays`: no-op.
-- `finalise(chunk_index)` — post-launch. `OutputArrays`: D2H; chunked copies into a pooled
-  pinned buffer and submits a `PendingBuffer` to the `WritebackWatcher`; non-chunked transfers
-  immediately (still async). `InputArrays`: releases its staging buffers.
+- `finalise(chunk_index)` — post-launch. `OutputArrays`: D2H for the outputs the compile
+  flags enable (placeholder arrays are skipped); chunked copies into a pooled pinned buffer
+  and submits a `PendingBuffer` to the `WritebackWatcher`; non-chunked transfers immediately
+  (still async). `InputArrays`: releases its staging buffers.
 
 ### Memory types
 Host arrays are `"pinned"` (page-locked → async transfer) for non-chunked runs, converted to

--- a/src/cubie/batchsolving/arrays/BaseArrayManager.py
+++ b/src/cubie/batchsolving/arrays/BaseArrayManager.py
@@ -734,7 +734,6 @@ class BaseArrayManager(ABC):
         current_array: Optional[NDArray],
         label: str,
         shape_only: bool = False,
-        always_overwrite: bool = False,
     ) -> None:
         """
         Mark host arrays for overwrite or reallocation based on updates.
@@ -742,50 +741,50 @@ class BaseArrayManager(ABC):
         Parameters
         ----------
         new_array
-            Updated array that should replace the stored host array.
+            Updated array whose values should land in the host buffer.
         current_array
             Previously stored host array or ``None``.
         label
             Array name used to index tracking lists.
         shape_only
-            Only check shape equality when comparing arrays. Faster for
-            output arrays that will be overwritten. Defaults to ``False``.
-        always_overwrite
-            Skip the value comparison and always queue a host->device copy
-            when the shape matches. Used for inputs: comparing values is an
-            O(n) host scan that only pays off for identical re-submitted
-            arrays, whereas re-submitting equally-sized arrays with new
-            values is the common case and must go straight to an (async) h2d.
+            The stored buffer only needs to match ``new_array``'s shape;
+            values are ignored. Used for output arrays, which the kernel
+            overwrites.
 
         Raises
         ------
         ValueError
             If ``new_array`` is ``None``.
 
+        Notes
+        -----
+        When the stored buffer already matches in shape and dtype, values
+        are copied into it in place and a host-to-device copy is queued
+        (unless ``shape_only``). Values are never compared: re-submitted
+        same-size arrays usually carry new values, and the copy is cheaper
+        than an element-wise comparison. Otherwise the array is staged
+        into a fresh buffer of the slot's memory type and queued for
+        reallocation.
         """
         if new_array is None:
             raise ValueError("New array is None")
         managed = self.host.get_managed_array(label)
-        # Fast path: if current exists and arrays have matching shape/dtype
-        # (and optionally content when shape_only=False), skip update
+
         if (
-            not always_overwrite
-            and current_array is not None
-            and self._arrays_equal(
-                new_array, current_array, shape_only=shape_only
-            )
+            current_array is not None
+            and current_array.shape == new_array.shape
+            and current_array.dtype == managed.dtype
         ):
+            if not shape_only:
+                current_array[...] = new_array
+                if label not in self._needs_overwrite:
+                    self._needs_overwrite.append(label)
             return None
 
-        # Handle new array (current is None)
         if current_array is None:
             self._needs_reallocation.append(label)
             self._needs_overwrite.append(label)
-            self.host.attach(label, new_array)
-            return None
-
-        # Arrays differ; determine if shape changed or just values
-        if current_array.shape != new_array.shape:
+        else:
             if label not in self._needs_reallocation:
                 self._needs_reallocation.append(label)
             if label not in self._needs_overwrite:
@@ -793,9 +792,16 @@ class BaseArrayManager(ABC):
             if 0 in new_array.shape:
                 newshape = (1,) * len(current_array.shape)
                 new_array = np_zeros(newshape, dtype=managed.dtype)
-        else:
-            self._needs_overwrite.append(label)
 
+        if not shape_only and managed.memory_type == "pinned":
+            # Incoming arrays are external; copy into a buffer of the
+            # slot's declared memory type so device transfers can run
+            # asynchronously from pinned memory.
+            staged = self._memory_manager.create_host_array(
+                new_array.shape, managed.dtype, "pinned"
+            )
+            staged[...] = new_array
+            new_array = staged
         self.host.attach(label, new_array)
         return None
 
@@ -803,7 +809,6 @@ class BaseArrayManager(ABC):
         self,
         new_arrays: Dict[str, NDArray],
         shape_only: bool = False,
-        always_overwrite: bool = False,
     ) -> None:
         """
         Update host arrays and record allocation requirements.
@@ -813,11 +818,9 @@ class BaseArrayManager(ABC):
         new_arrays
             Dictionary mapping array names to new host arrays.
         shape_only
-            Only check shape equality when comparing arrays. Faster for
-            output arrays that will be overwritten. Defaults to ``False``.
-        always_overwrite
-            Forwarded to :meth:`_update_host_array`; skip value comparison and
-            always queue a copy when the shape matches (used for inputs).
+            Stored buffers only need to match the new arrays' shapes;
+            values are ignored. Used for output arrays, which the kernel
+            overwrites. Defaults to ``False``.
 
         """
         host_names = set(self.host.array_names())
@@ -846,7 +849,6 @@ class BaseArrayManager(ABC):
                 current_array,
                 array_name,
                 shape_only=shape_only,
-                always_overwrite=always_overwrite,
             )
 
     def allocate(self) -> None:

--- a/src/cubie/batchsolving/arrays/BaseArrayManager.py
+++ b/src/cubie/batchsolving/arrays/BaseArrayManager.py
@@ -344,6 +344,9 @@ class BaseArrayManager(ABC):
     _needs_overwrite: list[str] = field(factory=list, init=False)
     _memory_manager: MemoryManager = field(default=default_memmgr)
     num_runs: int = field(default=1, validator=getype_validator(int, 1))
+    # Signature of the solver state that determines array sizes; when
+    # unchanged, update_from_solver skips rebuilding the size objects.
+    _size_sig: object = field(default=None, init=False)
 
     def __attrs_post_init__(self) -> None:
         """
@@ -531,6 +534,9 @@ class BaseArrayManager(ABC):
         self._needs_overwrite.clear()
         self.device.delete_all()
         self._needs_reallocation.extend(self.device.array_names())
+        # Force the next update_from_solver to rebuild sizes, in case an
+        # invalidating config change altered a size the signature misses.
+        self._size_sig = None
 
     def _arrays_equal(
         self,
@@ -728,6 +734,7 @@ class BaseArrayManager(ABC):
         current_array: Optional[NDArray],
         label: str,
         shape_only: bool = False,
+        always_overwrite: bool = False,
     ) -> None:
         """
         Mark host arrays for overwrite or reallocation based on updates.
@@ -743,6 +750,12 @@ class BaseArrayManager(ABC):
         shape_only
             Only check shape equality when comparing arrays. Faster for
             output arrays that will be overwritten. Defaults to ``False``.
+        always_overwrite
+            Skip the value comparison and always queue a host->device copy
+            when the shape matches. Used for inputs: comparing values is an
+            O(n) host scan that only pays off for identical re-submitted
+            arrays, whereas re-submitting equally-sized arrays with new
+            values is the common case and must go straight to an (async) h2d.
 
         Raises
         ------
@@ -755,8 +768,12 @@ class BaseArrayManager(ABC):
         managed = self.host.get_managed_array(label)
         # Fast path: if current exists and arrays have matching shape/dtype
         # (and optionally content when shape_only=False), skip update
-        if current_array is not None and self._arrays_equal(
-            new_array, current_array, shape_only=shape_only
+        if (
+            not always_overwrite
+            and current_array is not None
+            and self._arrays_equal(
+                new_array, current_array, shape_only=shape_only
+            )
         ):
             return None
 
@@ -783,7 +800,10 @@ class BaseArrayManager(ABC):
         return None
 
     def update_host_arrays(
-        self, new_arrays: Dict[str, NDArray], shape_only: bool = False
+        self,
+        new_arrays: Dict[str, NDArray],
+        shape_only: bool = False,
+        always_overwrite: bool = False,
     ) -> None:
         """
         Update host arrays and record allocation requirements.
@@ -795,6 +815,9 @@ class BaseArrayManager(ABC):
         shape_only
             Only check shape equality when comparing arrays. Faster for
             output arrays that will be overwritten. Defaults to ``False``.
+        always_overwrite
+            Forwarded to :meth:`_update_host_array`; skip value comparison and
+            always queue a copy when the shape matches (used for inputs).
 
         """
         host_names = set(self.host.array_names())
@@ -823,6 +846,7 @@ class BaseArrayManager(ABC):
                 current_array,
                 array_name,
                 shape_only=shape_only,
+                always_overwrite=always_overwrite,
             )
 
     def allocate(self) -> None:

--- a/src/cubie/batchsolving/arrays/BatchInputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchInputArrays.py
@@ -194,31 +194,8 @@ class InputArrays(BaseArrayManager):
         if driver_coefficients is not None:
             updates_dict["driver_coefficients"] = driver_coefficients
         self.update_from_solver(solver_instance)
-        # Stage user inputs into persistent pinned buffers so the h2d is async
-        # (a pageable source forces Numba to stage per call). always_overwrite:
-        # the copy happens every solve regardless of value equality.
-        staged = {
-            name: self._stage_pinned(name, arr)
-            for name, arr in updates_dict.items()
-        }
-        self.update_host_arrays(staged, always_overwrite=True)
+        self.update_host_arrays(updates_dict)
         self.allocate()  # Will queue request if in a stream group
-
-    def _stage_pinned(self, name: str, user_array: NDArray) -> NDArray:
-        """Copy a user input into a reused pinned host buffer for async h2d."""
-        slot = self.host.get_managed_array(name)
-        dtype = slot.dtype
-        buf = slot.array
-        if (
-            buf is None
-            or buf.shape != user_array.shape
-            or buf.dtype != dtype
-        ):
-            buf = self._memory_manager.create_host_array(
-                user_array.shape, dtype, "pinned"
-            )
-        buf[:] = user_array
-        return buf
 
     @property
     def initial_values(self) -> ArrayTypes:

--- a/src/cubie/batchsolving/arrays/BatchInputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchInputArrays.py
@@ -194,8 +194,31 @@ class InputArrays(BaseArrayManager):
         if driver_coefficients is not None:
             updates_dict["driver_coefficients"] = driver_coefficients
         self.update_from_solver(solver_instance)
-        self.update_host_arrays(updates_dict)
+        # Stage user inputs into persistent pinned buffers so the h2d is async
+        # (a pageable source forces Numba to stage per call). always_overwrite:
+        # the copy happens every solve regardless of value equality.
+        staged = {
+            name: self._stage_pinned(name, arr)
+            for name, arr in updates_dict.items()
+        }
+        self.update_host_arrays(staged, always_overwrite=True)
         self.allocate()  # Will queue request if in a stream group
+
+    def _stage_pinned(self, name: str, user_array: NDArray) -> NDArray:
+        """Copy a user input into a reused pinned host buffer for async h2d."""
+        slot = self.host.get_managed_array(name)
+        dtype = slot.dtype
+        buf = slot.array
+        if (
+            buf is None
+            or buf.shape != user_array.shape
+            or buf.dtype != dtype
+        ):
+            buf = self._memory_manager.create_host_array(
+                user_array.shape, dtype, "pinned"
+            )
+        buf[:] = user_array
+        return buf
 
     @property
     def initial_values(self) -> ArrayTypes:
@@ -267,6 +290,18 @@ class InputArrays(BaseArrayManager):
             The solver instance to update from.
 
         """
+        # Input sizes are system sizes scaled by num_runs; skip the rebuild
+        # (attrs construction) when those determinants are unchanged.
+        sysz = solver_instance.system_sizes
+        sig = (
+            solver_instance.num_runs,
+            solver_instance.precision,
+            sysz.states,
+            sysz.parameters,
+            sysz.drivers,
+        )
+        if sig == self._size_sig:
+            return
         self._sizes = BatchInputSizes.from_solver(solver_instance).nonzero
         self._precision = solver_instance.precision
         self.set_array_runs(solver_instance.num_runs)
@@ -274,6 +309,7 @@ class InputArrays(BaseArrayManager):
         for name, arr_obj in self._iter_managed_arrays:
             if np_issubdtype(np_dtype(arr_obj.dtype), np_floating):
                 arr_obj.dtype = self._precision
+        self._size_sig = sig
 
     def finalise(self, chunk_index: int) -> None:
         """Release buffers back to host."""

--- a/src/cubie/batchsolving/arrays/BatchOutputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchOutputArrays.py
@@ -191,6 +191,10 @@ class OutputArrays(BaseArrayManager):
     _buffer_pool: ChunkBufferPool = field(factory=ChunkBufferPool, init=False)
     _watcher: WritebackWatcher = field(factory=WritebackWatcher, init=False)
     _pending_buffers: List[PendingBuffer] = field(factory=list, init=False)
+    # Names of outputs actually produced this run; the rest are (1, 1, 1)
+    # placeholders skipped on transfer. None before first update() -> transfer
+    # all (safe fallback).
+    _active_names: Optional[frozenset] = field(default=None, init=False)
 
     def __attrs_post_init__(self) -> None:
         """
@@ -215,6 +219,21 @@ class OutputArrays(BaseArrayManager):
             The solver instance providing configuration and sizing information.
 
         """
+        # Built from compile_flags (0.05us) rather than solver.active_outputs,
+        # which reconstructs an attrs object (~17us) every solve.
+        cf = solver_instance.compile_flags
+        active = {"status_codes"}  # always written by the kernel
+        if cf.save_state:
+            active.add("state")
+        if cf.save_observables:
+            active.add("observables")
+        if cf.summarise_state:
+            active.add("state_summaries")
+        if cf.summarise_observables:
+            active.add("observable_summaries")
+        if cf.save_counters:
+            active.add("iteration_counters")
+        self._active_names = frozenset(active)
         new_arrays = self.update_from_solver(solver_instance)
         self.update_host_arrays(new_arrays, shape_only=True)
         self.allocate()
@@ -327,6 +346,28 @@ class OutputArrays(BaseArrayManager):
             Host arrays with updated shapes for ``update_host_arrays``.
             Arrays that already match are still included for consistency.
         """
+        # Output sizes depend on num_runs, precision, the time dimensions
+        # (output_length / summaries_length, which fold in duration and the
+        # save/summarise intervals) and the per-variable heights (which fold
+        # in the output selection). Skip the rebuild when all are unchanged;
+        # the current host arrays already match.
+        h = solver_instance.output_array_heights
+        sig = (
+            solver_instance.num_runs,
+            solver_instance.precision,
+            solver_instance.output_length,
+            solver_instance.summaries_length,
+            h.state,
+            h.observables,
+            h.state_summaries,
+            h.observable_summaries,
+            h.per_variable,
+        )
+        if sig == self._size_sig:
+            return {
+                name: slot.array
+                for name, slot in self.host.iter_managed_arrays()
+            }
         self._sizes = BatchOutputSizes.from_solver(solver_instance).nonzero
         self._precision = solver_instance.precision
         self.set_array_runs(solver_instance.num_runs)
@@ -353,6 +394,7 @@ class OutputArrays(BaseArrayManager):
             dtype = slot.dtype
             if np_issubdtype(dtype, np_floating):
                 slot.dtype = self._precision
+        self._size_sig = sig
         return new_arrays
 
     def finalise(self, chunk_index: int) -> None:
@@ -375,8 +417,13 @@ class OutputArrays(BaseArrayManager):
         from_ = []
         to_ = []
         stream = self._memory_manager.get_stream(self)
+        active = self._active_names
 
         for array_name, slot in self.host.iter_managed_arrays():
+            # Skip inactive outputs: their device array is a (1, 1, 1)
+            # placeholder, so transferring it just wastes a d2h dispatch.
+            if active is not None and array_name not in active:
+                continue
             device_array = self.device.get_array(array_name)
             host_array = slot.array
 

--- a/src/cubie/batchsolving/arrays/BatchOutputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchOutputArrays.py
@@ -191,9 +191,7 @@ class OutputArrays(BaseArrayManager):
     _buffer_pool: ChunkBufferPool = field(factory=ChunkBufferPool, init=False)
     _watcher: WritebackWatcher = field(factory=WritebackWatcher, init=False)
     _pending_buffers: List[PendingBuffer] = field(factory=list, init=False)
-    # Names of outputs actually produced this run; the rest are (1, 1, 1)
-    # placeholders skipped on transfer. None before first update() -> transfer
-    # all (safe fallback).
+    # Outputs the kernel writes this run; None means transfer all.
     _active_names: Optional[frozenset] = field(default=None, init=False)
 
     def __attrs_post_init__(self) -> None:
@@ -219,8 +217,6 @@ class OutputArrays(BaseArrayManager):
             The solver instance providing configuration and sizing information.
 
         """
-        # Built from compile_flags (0.05us) rather than solver.active_outputs,
-        # which reconstructs an attrs object (~17us) every solve.
         cf = solver_instance.compile_flags
         active = {"status_codes"}  # always written by the kernel
         if cf.save_state:

--- a/src/cubie/memory/AGENTS.md
+++ b/src/cubie/memory/AGENTS.md
@@ -7,17 +7,20 @@ GPU memory management for CuBIE. `MemoryManager` is a proportion-based VRAM allo
 registers caller instances, enforces per-instance memory caps, chunks batches along the run
 axis when they exceed available VRAM, and routes host/device transfers to the right CUDA
 stream. It runs as a process-wide instance (`default_memmgr`, created in `__init__.py` at
-import) — a singleton **by convention**, not enforced via `__new__`. CuPy is the single device
-allocation provider on a real GPU (no Numba allocator fallback): device arrays come from CuPy's
-memory pool and host staging buffers from CuPy's pinned memory pool. The CUDA simulator never
-touches CuPy — it keeps its own numpy-backed fakes. Supporting pieces: `StreamGroups` (CUDA
-stream grouping), `ArrayRequest`/`ArrayResponse` (allocation metadata), `ChunkBufferPool`
-(reusable pinned staging buffers).
+import) — a singleton **by convention**, not enforced via `__new__`. CuPy's async memory pool
+is the single device allocation provider on a real GPU, plugged into Numba as an External
+Memory Manager (`cupy_emm.py`), so `cuda.device_array` returns **native** `DeviceNDArray`
+objects backed by pooled, stream-ordered allocations. Pinned host buffers come from Numba
+(`cuda.pinned_array`) and the chunk staging pool from CuPy (`cupyx.empty_pinned`). The CUDA
+simulator never touches CuPy — it keeps its own numpy-backed fakes. Supporting pieces:
+`StreamGroups` (CUDA stream grouping), `ArrayRequest`/`ArrayResponse` (allocation metadata),
+`ChunkBufferPool` (reusable pinned staging buffers).
 
 ## Key Files
 | File | Description |
 |------|-------------|
-| `__init__.py` | Instantiates `default_memmgr = MemoryManager()`; re-exports `MemoryManager`, `current_cupy_stream`. |
+| `__init__.py` | Installs the CuPy async EMM (`install_async_emm()`, before any CUDA context exists), instantiates `default_memmgr = MemoryManager()`; re-exports `MemoryManager`, `current_cupy_stream`, `CuPyAsyncNumbaManager`. |
+| `cupy_emm.py` | `CuPyAsyncNumbaManager` — Numba EMM plugin drawing device memory from `cupy.cuda.MemoryAsyncPool`; `install_async_emm()`. |
 | `mem_manager.py` | `MemoryManager` (central allocator); `InstanceMemorySettings` (per-instance registry entry); `ALL_MEMORY_MANAGER_PARAMETERS`; `MIN_AUTOPOOL_SIZE`; `current_cupy_stream` (Numba→CuPy stream forwarding); `_pinned_host_array`. |
 | `array_requests.py` | `ArrayRequest` (shape/dtype/placement spec) and `ArrayResponse` (allocated arrays + chunk metadata). |
 | `stream_groups.py` | `StreamGroups` — maps instance ids to named groups, each backed by a CUDA stream. |
@@ -31,13 +34,14 @@ stream grouping), `ArrayRequest`/`ArrayResponse` (allocation metadata), `ChunkBu
 - Two limit modes (`_mode`, default `"passive"`): `"passive"` computes caps but doesn't enforce (returns raw free VRAM); `"active"` enforces per-instance caps. Switch via `set_limit_mode()`.
 
 ### Single allocation provider
-CuPy is the only device allocator; `cupy`/`cupyx` come from `cubie.cuda_simsafe`, which imports
-them at package import on a real GPU. `allocate()` routes `"device"` requests through
-`cupy.empty` and `"pinned"` requests through `cupyx.empty_pinned`; any other placement raises
-`ValueError`. `to_device`/`from_device` use CuPy's `ndarray.set`/`ndarray.get`, wrapped in
-`current_cupy_stream` so the copy stays ordered on the instance's Numba stream. Device arrays
-must be allocated (via `allocate_queue`) before `to_device` copies into them — the copy calls
-methods on the destination array itself.
+CuPy's async pool is the only device allocator, reached through the EMM plugin; `cupy`/`cupyx`
+come from `cubie.cuda_simsafe`, which imports them at package import on a real GPU.
+`allocate()` routes `"device"` requests through `cuda.device_array` (inside
+`current_cupy_stream`, so the pool allocation is stream-ordered) and `"pinned"` requests
+through `cuda.pinned_array`; any other placement raises `ValueError`. `to_device`/`from_device`
+issue streamed `cuda.cudadrv.driver.host_to_device`/`device_to_host` copies between pinned
+host buffers and native device arrays, sized by the pinned buffer's `nbytes`. Device arrays
+must be allocated (via `allocate_queue`) before `to_device` copies into them.
 
 ### Queued / chunked allocation
 - `queue_request(instance, {label: ArrayRequest(...)})` per participating instance, then
@@ -69,12 +73,13 @@ methods on the destination array itself.
 
 ### CuPy stream forwarding
 - `current_cupy_stream` (defined in `mem_manager.py`) is a **class** context manager that
-  always forwards the given Numba stream into CuPy as an `ExternalStream` (Numba's default
-  stream, handle `0`, is left as CuPy's ambient current stream instead of wrapped).
-- `MemoryManager.allocate`/`to_device`/`from_device` wrap their CuPy calls in
-  `current_cupy_stream(stream)` so allocation and copies stay ordered on the instance's stream.
-  `get_memory_info()` still queries whole-device free/total via the Numba context, not a CuPy
-  pool's own accounting.
+  always forwards the given Numba stream into CuPy via `cupy.cuda.Stream.from_external`
+  (Numba's default stream, handle `0`, is left as CuPy's ambient current stream instead of
+  wrapped).
+- `MemoryManager.allocate` wraps device allocation in `current_cupy_stream(stream)` so the
+  async-pool allocation stays ordered on the instance's stream; `to_device`/`from_device`
+  pass the Numba stream to the driver copies directly. `get_memory_info()` still queries
+  whole-device free/total via the Numba context, not a CuPy pool's own accounting.
 
 ### ChunkBufferPool (internal, not exported)
 Reusable pinned staging buffers for chunked transfers, keyed by `(array_name, shape, dtype)`.
@@ -86,7 +91,7 @@ free); `clear` frees all (call on error paths). Thread-safe via a `Lock`. Under
 ### Testing
 `tests/memory/` (`test_memmgmt.py`, `test_array_requests.py`, `test_stream_groups.py`,
 `test_chunk_buffer_pool.py`, `test_memmgmt.py` — needs the `cupy` marker + a real GPU with
-cupy installed). CuPy-returning-array assertions and the CuPy-stream-forwarding test are marked
+cupy installed). Native-device-array assertions and the CuPy-stream-forwarding test are marked
 `nocudasim`; the `ValueError` on unsupported placements is exercised at both request
 construction and direct `allocate()` calls.
 
@@ -95,7 +100,8 @@ construction and direct `allocate()` calls.
 - `cubie.cuda_simsafe` (`Stream`, `DeviceNDArrayBase`, `CUDA_SIMULATION`, `current_mem_info`);
   `cubie._utils` (validators in `array_requests.py`).
 ### External
-- `numba`/`numba.cuda` (context/stream management, kernel launch); `attrs`; `numpy`; `cupy`
-  (required on a real GPU — single device allocation provider, imported once through
-  `cubie.cuda_simsafe`, which supplies `None` stand-ins under the CUDA simulator;
-  `cupyx.empty_pinned` for pinned host buffers).
+- `numba`/`numba.cuda` (context/stream management, kernel launch, pinned arrays, driver
+  copies); `attrs`; `numpy`; `cupy` (required on a real GPU — its async pool backs all device
+  allocation through the EMM plugin, imported once through `cubie.cuda_simsafe`, which
+  supplies `None` stand-ins under the CUDA simulator; `cupyx.empty_pinned` for the chunk
+  staging pool).

--- a/src/cubie/memory/__init__.py
+++ b/src/cubie/memory/__init__.py
@@ -2,7 +2,7 @@
 GPU memory management subsystem for cubie.
 
 This module provides GPU memory management capabilities including:
-- CuPy as the single device-allocation provider on a real GPU
+- CuPy async memory pool backing native Numba device arrays via an EMM plugin
 - Stream group management for asynchronous CUDA operations
 - Array request/response system for structured memory allocation
 - Manual or automatic allocation of VRAM to different processes
@@ -19,12 +19,18 @@ The main components are:
 The default memory manager instance is available as `default_memmgr`.
 """
 
+from cubie.memory.cupy_emm import CuPyAsyncNumbaManager, install_async_emm
 from cubie.memory.mem_manager import MemoryManager, current_cupy_stream
+
+# Install the CuPy async pool as Numba's EMM before the first CUDA context is
+# created (below, when the manager queries device memory).
+install_async_emm()
 
 default_memmgr = MemoryManager()
 
 __all__ = [
     "current_cupy_stream",
+    "CuPyAsyncNumbaManager",
     "default_memmgr",
-    "MemoryManager"
+    "MemoryManager",
 ]

--- a/src/cubie/memory/cupy_emm.py
+++ b/src/cubie/memory/cupy_emm.py
@@ -6,9 +6,6 @@ memory pool via the EMM plugin interface, so ``cuda.device_array`` returns a
 the fast kernel-launch path (no per-launch ``__cuda_array_interface__``
 re-parse) and let transfers use Numba's pinned + streamed async copies.
 
-Recovered from history (pre-#561); only the async pool is provided — the sync
-pool and Numba-default paths are intentionally omitted.
-
 See Also
 --------
 :class:`~cubie.memory.mem_manager.MemoryManager`
@@ -17,10 +14,9 @@ See Also
 
 import ctypes
 import logging
-from contextlib import contextmanager
-from typing import Any, Callable, Iterator, Optional
+from typing import Any, Callable, Optional
 
-from cubie.cuda_simsafe import cuda, CUDA_SIMULATION
+from cubie.cuda_simsafe import cuda, cupy, CUDA_SIMULATION
 
 logger = logging.getLogger(__name__)
 
@@ -45,11 +41,12 @@ if not CUDA_SIMULATION:
             self.is_cupy = True
 
         def initialize(self) -> None:
-            import cupy as cp
-
             super().initialize()
+            # Context.prepare_for_use calls initialize() on every context
+            # activation; the pool must persist across calls because live
+            # allocations hold blocks from it.
             if self._mp is None:
-                self._mp = cp.cuda.MemoryAsyncPool()
+                self._mp = cupy.cuda.MemoryAsyncPool()
 
         def memalloc(self, nbytes: int) -> "cuda.MemoryPointer":
             cp_mp = self._mp.malloc(nbytes)
@@ -74,22 +71,13 @@ if not CUDA_SIMULATION:
             # Real device free/total (cuMemGetInfo), not pool bytes: the
             # manager uses this to size chunks against the device, and the
             # pool's free_bytes() is 0 until it has cached blocks.
-            import cupy as cp
-
-            free, total = cp.cuda.runtime.memGetInfo()
+            free, total = cupy.cuda.runtime.memGetInfo()
             return cuda.MemoryInfo(free=free, total=total)
 
         def reset(self, stream: Optional[Any] = None) -> None:
             super().reset()
             if self._mp:
                 self._mp.free_all_blocks(stream=stream)
-
-        @contextmanager
-        def defer_cleanup(self) -> Iterator[None]:
-            # Returning memory to the pool never interrupts async work the
-            # way a real device_free would, so nothing extra to defer.
-            with super().defer_cleanup():
-                yield
 
         @property
         def interface_version(self) -> int:

--- a/src/cubie/memory/cupy_emm.py
+++ b/src/cubie/memory/cupy_emm.py
@@ -1,0 +1,110 @@
+"""CuPy async External Memory Manager plugin for Numba CUDA contexts.
+
+Backs Numba's device allocations with CuPy's asynchronous (stream-ordered)
+memory pool via the EMM plugin interface, so ``cuda.device_array`` returns a
+**native** ``DeviceNDArray`` drawn from a pooled allocator. Native arrays keep
+the fast kernel-launch path (no per-launch ``__cuda_array_interface__``
+re-parse) and let transfers use Numba's pinned + streamed async copies.
+
+Recovered from history (pre-#561); only the async pool is provided — the sync
+pool and Numba-default paths are intentionally omitted.
+
+See Also
+--------
+:class:`~cubie.memory.mem_manager.MemoryManager`
+    Coordinates allocation through this plugin.
+"""
+
+import ctypes
+import logging
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Optional
+
+from cubie.cuda_simsafe import cuda, CUDA_SIMULATION
+
+logger = logging.getLogger(__name__)
+
+
+if not CUDA_SIMULATION:
+
+    class CuPyAsyncNumbaManager(
+        cuda.GetIpcHandleMixin, cuda.HostOnlyCUDAMemoryManager
+    ):
+        """EMM plugin allocating native Numba arrays from CuPy's async pool.
+
+        Adapted from the numba cupy-EMM tutorial, using
+        ``cupy.cuda.MemoryAsyncPool`` so allocations are stream-ordered
+        (cudaMallocAsync) against whichever stream is current at allocation.
+        """
+
+        def __init__(self, context) -> None:
+            super().__init__(context=context)
+            # Kept alive so CuPy returns the block to the pool on finalize.
+            self._allocations: dict[int, Any] = {}
+            self._mp = None
+            self.is_cupy = True
+
+        def initialize(self) -> None:
+            import cupy as cp
+
+            super().initialize()
+            if self._mp is None:
+                self._mp = cp.cuda.MemoryAsyncPool()
+
+        def memalloc(self, nbytes: int) -> "cuda.MemoryPointer":
+            cp_mp = self._mp.malloc(nbytes)
+            self._allocations[cp_mp.ptr] = cp_mp
+            return cuda.MemoryPointer(
+                cuda.current_context(),
+                ctypes.c_void_p(int(cp_mp.ptr)),
+                nbytes,
+                finalizer=self._make_finalizer(cp_mp.ptr),
+            )
+
+        def _make_finalizer(self, ptr: int) -> Callable[[], None]:
+            allocations = self._allocations
+
+            def finalizer() -> None:
+                # Dropping the last reference returns the block to the pool.
+                allocations.pop(ptr, None)
+
+            return finalizer
+
+        def get_memory_info(self) -> "cuda.MemoryInfo":
+            # Real device free/total (cuMemGetInfo), not pool bytes: the
+            # manager uses this to size chunks against the device, and the
+            # pool's free_bytes() is 0 until it has cached blocks.
+            import cupy as cp
+
+            free, total = cp.cuda.runtime.memGetInfo()
+            return cuda.MemoryInfo(free=free, total=total)
+
+        def reset(self, stream: Optional[Any] = None) -> None:
+            super().reset()
+            if self._mp:
+                self._mp.free_all_blocks(stream=stream)
+
+        @contextmanager
+        def defer_cleanup(self) -> Iterator[None]:
+            # Returning memory to the pool never interrupts async work the
+            # way a real device_free would, so nothing extra to defer.
+            with super().defer_cleanup():
+                yield
+
+        @property
+        def interface_version(self) -> int:
+            return 1
+
+    def install_async_emm() -> None:
+        """Install the CuPy async pool as Numba's device memory manager.
+
+        Must run before the CUDA context is created; the manager takes effect
+        on first context creation.
+        """
+        cuda.set_memory_manager(CuPyAsyncNumbaManager)
+
+else:  # pragma: no cover - simulated: no device, no EMM
+    CuPyAsyncNumbaManager = None
+
+    def install_async_emm() -> None:
+        return None

--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -75,7 +75,6 @@ from cubie.cuda_simsafe import (
     CUDA_SIMULATION,
     Stream,
     cupy,
-    cupyx,
     current_mem_info,
 )
 from cubie.memory.stream_groups import StreamGroups
@@ -300,7 +299,12 @@ class current_cupy_stream:
         """
         ptr = _numba_stream_ptr(self.nb_stream)
         if ptr:
-            self.cupy_ext_stream = cupy.cuda.ExternalStream(ptr)
+            # The Numba stream implements the __cuda_stream__ protocol, so
+            # from_external wraps it directly (ExternalStream(ptr) is
+            # deprecated).
+            self.cupy_ext_stream = cupy.cuda.Stream.from_external(
+                self.nb_stream
+            )
             self.cupy_ext_stream.__enter__()
         return self
 
@@ -355,13 +359,12 @@ def _pinned_host_array(shape: Tuple[int, ...], dtype: type) -> ndarray:
     Notes
     -----
     Pinned memory enables asynchronous host/device transfers. On a
-    real GPU this is provided by CuPy's pinned memory pool
-    (:func:`cupyx.empty_pinned`); the CUDA simulator has no device to
-    transfer to, so a plain NumPy array is used instead.
+    real GPU this uses Numba's ``cuda.pinned_array``; the CUDA simulator
+    has no device to transfer to, so a plain NumPy array is used instead.
     """
     if CUDA_SIMULATION:  # pragma: no cover - simulated
         return np_empty(shape, dtype=dtype)
-    return cupyx.empty_pinned(shape, dtype=dtype)
+    return cuda.pinned_array(shape, dtype=dtype)
 
 
 # These will be keys to a dict, so must be hashable: eq=False
@@ -1234,10 +1237,12 @@ class MemoryManager:
         """
         _ensure_cuda_context()
         if memory_type == "device":
+            # Native Numba array from the CuPy async pool (via the EMM).
+            # current_cupy_stream makes the pool allocation stream-ordered.
             if CUDA_SIMULATION:  # pragma: no cover - simulated
                 return cuda.device_array(shape, dtype)
             with current_cupy_stream(stream):
-                return cupy.empty(shape, dtype=dtype)
+                return cuda.device_array(shape, dtype)
         elif memory_type == "pinned":
             return _pinned_host_array(shape, dtype)
         else:
@@ -1291,13 +1296,20 @@ class MemoryManager:
         """
         _ensure_cuda_context()
         stream = self.get_stream(instance)
-        if CUDA_SIMULATION:  # pragma: no cover - simulated
-            for i, from_array in enumerate(from_arrays):
+        # Pinned host buffer -> device, streamed async H2D. The low-level
+        # driver copy skips copy_to_device's per-call np.array re-wrap and
+        # compatibility checks (~50us/call), which are unnecessary here: the
+        # source is an already-pinned, C-contiguous, size-matched buffer.
+        for i, from_array in enumerate(from_arrays):
+            if CUDA_SIMULATION:  # pragma: no cover - simulated
                 cuda.to_device(from_array, stream=stream, to=to_arrays[i])
-        else:
-            with current_cupy_stream(stream):
-                for i, from_array in enumerate(from_arrays):
-                    to_arrays[i].set(from_array)
+                continue
+            if from_array.size == 0:
+                continue
+            cuda.cudadrv.driver.host_to_device(
+                to_arrays[i], from_array, to_arrays[i].alloc_size,
+                stream=stream,
+            )
 
     def from_device(
         self,
@@ -1320,13 +1332,18 @@ class MemoryManager:
         """
         _ensure_cuda_context()
         stream = self.get_stream(instance)
-        if CUDA_SIMULATION:  # pragma: no cover - simulated
-            for i, from_array in enumerate(from_arrays):
+        # Device -> pinned host buffer, streamed async D2H via the low-level
+        # driver copy (to_arrays are pinned, C-contiguous, size-matched).
+        for i, from_array in enumerate(from_arrays):
+            if CUDA_SIMULATION:  # pragma: no cover - simulated
                 from_array.copy_to_host(to_arrays[i], stream=stream)
-        else:
-            with current_cupy_stream(stream):
-                for i, from_array in enumerate(from_arrays):
-                    from_array.get(out=to_arrays[i], blocking=False)
+                continue
+            if from_array.size == 0:
+                continue
+            cuda.cudadrv.driver.device_to_host(
+                to_arrays[i], from_array, from_array.alloc_size,
+                stream=stream,
+            )
 
     def sync_stream(self, instance: object) -> None:
         """

--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -299,9 +299,8 @@ class current_cupy_stream:
         """
         ptr = _numba_stream_ptr(self.nb_stream)
         if ptr:
-            # The Numba stream implements the __cuda_stream__ protocol, so
-            # from_external wraps it directly (ExternalStream(ptr) is
-            # deprecated).
+            # Numba streams implement the __cuda_stream__ protocol, so
+            # from_external wraps the stream object directly.
             self.cupy_ext_stream = cupy.cuda.Stream.from_external(
                 self.nb_stream
             )
@@ -1306,8 +1305,10 @@ class MemoryManager:
                 continue
             if from_array.size == 0:
                 continue
+            # Sized by the pinned host buffer so the copy can never run
+            # past it, whatever the device allocation rounded up to.
             cuda.cudadrv.driver.host_to_device(
-                to_arrays[i], from_array, to_arrays[i].alloc_size,
+                to_arrays[i], from_array, from_array.nbytes,
                 stream=stream,
             )
 
@@ -1340,8 +1341,10 @@ class MemoryManager:
                 continue
             if from_array.size == 0:
                 continue
+            # Sized by the pinned host buffer so the copy can never run
+            # past it, whatever the device allocation rounded up to.
             cuda.cudadrv.driver.device_to_host(
-                to_arrays[i], from_array, from_array.alloc_size,
+                to_arrays[i], from_array, to_arrays[i].nbytes,
                 stream=stream,
             )
 

--- a/src/cubie/time_logger.py
+++ b/src/cubie/time_logger.py
@@ -97,18 +97,17 @@ class CUDAEvent:
             timelogger = default_timelogger
         self._verbosity = timelogger.verbosity
 
-        if not is_cudasim_enabled():
-            # CUDA mode: create event objects for GPU timeline recording
+        # Skip driver-event allocation when verbosity is None: every record/
+        # elapsed method is a no-op then, so the batch kernel's 4 events/solve
+        # would be created and discarded for nothing.
+        if self._verbosity is not None and not is_cudasim_enabled():
             self._start_event = cuda.event()
             self._end_event = cuda.event()
-            self._start_time = None
-            self._end_time = None
-        else:  # pragma: no cover - simulated
-            # CUDASIM mode: use wall-clock timestamps as fallback
+        else:  # pragma: no cover - simulated / timing disabled
             self._start_event = None
             self._end_event = None
-            self._start_time = None
-            self._end_time = None
+        self._start_time = None
+        self._end_time = None
 
         # Register with TimeLogger
         timelogger._register_cuda_event(self)

--- a/tests/batchsolving/arrays/test_basearraymanager.py
+++ b/tests/batchsolving/arrays/test_basearraymanager.py
@@ -539,15 +539,16 @@ class TestBaseArrayManager:
         assert test_arrmgr._arrays_equal(arr1, arr2, shape_only=True) is False
 
     def test_update_host_array_no_change(self, test_arrmgr):
-        """Test update_host_array when arrays are equal"""
+        """Equal-valued resubmission still queues a device copy."""
         test_arrmgr._needs_reallocation = []
-        current = np.array([1, 2, 3])
-        new = np.array([1, 2, 3])
+        dtype = test_arrmgr.host.arr1.dtype
+        current = np.array([1, 2, 3], dtype=dtype)
+        new = np.array([1, 2, 3], dtype=dtype)
 
         test_arrmgr._update_host_array(new, current, "arr1")
         test_arrmgr.allocate()
         assert "arr1" not in test_arrmgr._needs_reallocation
-        assert "arr1" not in test_arrmgr._needs_overwrite
+        assert "arr1" in test_arrmgr._needs_overwrite
 
     def test_update_host_array_shape_change(self, test_arrmgr):
         """Test update_host_array when array shape changes"""
@@ -573,17 +574,18 @@ class TestBaseArrayManager:
         assert "arr1" in test_arrmgr._needs_reallocation
 
     def test_update_host_array_value_change(self, test_arrmgr):
-        """Test update_host_array when array values change but shape stays same"""
+        """New values land in the existing buffer and queue a copy."""
         test_arrmgr._needs_reallocation = []
-        current = np.array([1, 2, 3])
-        new = np.array([4, 5, 6])
+        dtype = test_arrmgr.host.arr1.dtype
+        current = np.array([1, 2, 3], dtype=dtype)
+        new = np.array([4, 5, 6], dtype=dtype)
         test_arrmgr.allocate()
         test_arrmgr._update_host_array(new, current, "arr1")
 
         assert "arr1" not in test_arrmgr._needs_reallocation
         assert "arr1" in test_arrmgr._needs_overwrite
-        # Check that the array was attached to the host container
-        assert test_arrmgr.host.arr1.array is new
+        # Values are copied into the existing host buffer in place
+        np.testing.assert_array_equal(current, new)
 
     def test_chunk_placeholders(self, test_arrmgr):
         """Test next_chunk method (placeholder implementation)"""

--- a/tests/batchsolving/arrays/test_batchoutputarrays.py
+++ b/tests/batchsolving/arrays/test_batchoutputarrays.py
@@ -330,20 +330,24 @@ class TestOutputArrays:
 
         # Simulate computation by modifying device arrays
         # (In reality, CUDA kernels would write to these device arrays)
-        original_device_state = output_arrays_manager.device_state.get()
+        original_device_state = output_arrays_manager.device_state.copy_to_host()
         original_device_observables = (
-            output_arrays_manager.device_observables.get()
+            output_arrays_manager.device_observables.copy_to_host()
         )
         original_status_codes = np.arange(
             output_arrays_manager.device_status_codes.size, dtype=np.int32
         )
 
         # Modify device arrays to simulate kernel output
-        output_arrays_manager.device_state.set(original_device_state * 2)
-        output_arrays_manager.device_observables.set(
+        output_arrays_manager.device_state.copy_to_device(
+            original_device_state * 2
+        )
+        output_arrays_manager.device_observables.copy_to_device(
             original_device_observables * 3
         )
-        output_arrays_manager.device_status_codes.set(original_status_codes)
+        output_arrays_manager.device_status_codes.copy_to_device(
+            original_status_codes
+        )
 
         # Set up chunking
         output_arrays_manager._chunks = 1
@@ -361,15 +365,15 @@ class TestOutputArrays:
         # Verify that host arrays now contain the modified device data
         np.testing.assert_array_equal(
             output_arrays_manager.state,
-            output_arrays_manager.device_state.get(),
+            output_arrays_manager.device_state.copy_to_host(),
         )
         np.testing.assert_array_equal(
             output_arrays_manager.observables,
-            output_arrays_manager.device_observables.get(),
+            output_arrays_manager.device_observables.copy_to_host(),
         )
         np.testing.assert_array_equal(
             output_arrays_manager.status_codes,
-            output_arrays_manager.device_status_codes.get(),
+            output_arrays_manager.device_status_codes.copy_to_host(),
         )
 
 

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -7,9 +7,11 @@ import pytest
 from numba import cuda
 
 from cubie.cuda_simsafe import (
+    DeviceNDArray,
     Stream,
 )
 
+from cubie.memory.cupy_emm import CuPyAsyncNumbaManager
 from cubie.memory.mem_manager import (
     MemoryManager,
     ArrayRequest,
@@ -514,9 +516,10 @@ class TestMemoryManager:
         arr = mgr.allocate(
             shape=(4, 4), dtype=np.float32, memory_type="device"
         )
+        assert isinstance(arr, DeviceNDArray)
         assert not isinstance(arr, cp.ndarray)
-        assert hasattr(arr, "__cuda_array_interface__")
-        assert hasattr(arr, "copy_to_host")
+        context_manager = cuda.current_context().memory_manager
+        assert isinstance(context_manager, CuPyAsyncNumbaManager)
 
     def test_free(self, registered_mgr, registered_instance):
         """Test free removes allocation by key from all instances."""
@@ -934,7 +937,7 @@ class TestMemoryManager:
         # Synchronize stream to ensure copy is complete
         stream.synchronize()
 
-        # Copy back to host and verify values (native device arrays)
+        # Copy back to host and verify values
         result_arr1 = device_arrays["arr1"].copy_to_host()
         result_arr2 = device_arrays["arr2"].copy_to_host()
 

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -502,19 +502,21 @@ class TestMemoryManager:
 
     @pytest.mark.nocudasim
     @pytest.mark.cupy
-    def test_allocate_device_returns_cupy_array(self, mgr):
-        """Test that a "device" allocation is a CuPy array on a real GPU.
+    def test_allocate_device_returns_native_array(self, mgr):
+        """A "device" allocation is a native Numba device array.
 
-        CuPy is CuBIE's single device allocation provider; device
-        arrays are allocated straight from CuPy's memory pool rather
-        than through a Numba External Memory Manager plugin.
+        Device memory is drawn from CuPy's async pool through the EMM
+        plugin, so the returned object is a Numba DeviceNDArray (fast
+        kernel-launch path), not a raw CuPy ndarray.
         """
         import cupy as cp
 
         arr = mgr.allocate(
             shape=(4, 4), dtype=np.float32, memory_type="device"
         )
-        assert isinstance(arr, cp.ndarray)
+        assert not isinstance(arr, cp.ndarray)
+        assert hasattr(arr, "__cuda_array_interface__")
+        assert hasattr(arr, "copy_to_host")
 
     def test_free(self, registered_mgr, registered_instance):
         """Test free removes allocation by key from all instances."""
@@ -932,9 +934,9 @@ class TestMemoryManager:
         # Synchronize stream to ensure copy is complete
         stream.synchronize()
 
-        # Copy back to host and verify values
-        result_arr1 = device_arrays["arr1"].get()
-        result_arr2 = device_arrays["arr2"].get()
+        # Copy back to host and verify values (native device arrays)
+        result_arr1 = device_arrays["arr1"].copy_to_host()
+        result_arr2 = device_arrays["arr2"].copy_to_host()
 
         np.testing.assert_array_equal(result_arr1, host_arr1)
         np.testing.assert_array_equal(result_arr2, host_arr2)
@@ -1418,19 +1420,19 @@ def test_numba_stream_ptr(stream1):
 def test_cupy_stream_wrapper(stream1, stream2):
     """Verify current_cupy_stream always forwards a Numba stream.
 
-    CuPy is CuBIE's single device allocation provider, so the
-    forwarding context manager wraps every non-default stream it is
-    given.
+    Pool allocations are ordered on the Numba integration stream, so the
+    forwarding context manager wraps every non-default stream it is given
+    (via ``Stream.from_external``).
     """
     import cupy as cp
 
     with current_cupy_stream(stream1) as cupy_stream:
-        assert isinstance(cupy_stream.cupy_ext_stream, cp.cuda.ExternalStream)
+        assert isinstance(cupy_stream.cupy_ext_stream, cp.cuda.Stream)
         assert cupy_stream.cupy_ext_stream.ptr == _numba_stream_ptr(stream1)
         assert cp.cuda.get_current_stream().ptr == _numba_stream_ptr(stream1)
 
     with current_cupy_stream(stream2) as cupy_stream:
-        assert isinstance(cupy_stream.cupy_ext_stream, cp.cuda.ExternalStream)
+        assert isinstance(cupy_stream.cupy_ext_stream, cp.cuda.Stream)
         assert cupy_stream.cupy_ext_stream.ptr == _numba_stream_ptr(stream2)
         assert cp.cuda.get_current_stream().ptr == _numba_stream_ptr(stream2)
 


### PR DESCRIPTION
## Summary

At small ensemble sizes cubie's `solve()` was dominated by host-side
bookkeeping — at N=64, actual GPU work was ~10 µs of a ~730 µs solve, so the
whole small-N gap to e.g. DiffEqGPU was fixed per-call overhead. This tackles
that on two fronts and restores native pooled arrays + async transfers.

**Min-of-100 per solve, N=64: fixed 0.73 → 0.45 ms, adaptive 0.69 → 0.37 ms.**
Large-N transfers no longer scale (async, size-independent).

## Overhead cuts

- **time_logger**: don't allocate CUDA driver events when timing is off. Each
  solve built 4 `CUDAEvent`s (8 driver events) that were immediately discarded
  when `time_logging_level=None`. 67 → 4 µs.
- **BatchOutputArrays**: skip d2h of inactive output arrays. Disabled outputs
  are `(1,1,1)` placeholders but were still copied device→host every solve;
  gated on the compile flags (`status_codes` always transferred).
- **BaseArrayManager / BatchInputArrays**: inputs re-upload on shape match
  instead of an O(n) value comparison. The comparison only paid off for
  *identical* re-submitted arrays (a benchmark contrivance); equally-sized
  arrays with new values is the common case and now goes straight to an async
  h2d.
- **Size-derivation caches**: `update_from_solver` rebuilt the size attrs
  objects every solve. Cache on cheap, complete determinants (num_runs,
  precision, time dims, per-variable heights), invalidated by
  `_invalidate_hook`. input+output `update()` 145 → 68 µs.

## Native pooled arrays + async transfers

Restores the pre-#561 architecture. The EMM plugin interface was **not**
deprecated — only the in-tree `numba.cuda` target moved to the standalone
package; `set_memory_manager` / `HostOnlyCUDAMemoryManager` are supported in
numba-cuda-mlir 0.4.1 (RMM uses the same mechanism).

- Recover `cupy_emm.py` (async-only `CuPyAsyncNumbaManager`): native Numba
  device arrays from CuPy's `MemoryAsyncPool` via the EMM. Native arrays keep
  the fast kernel-launch path (no per-launch `__cuda_array_interface__`
  re-parse that raw cupy arrays incur).
- Device alloc `cupy.empty` → `cuda.device_array`; host `cupyx.empty_pinned` →
  `cuda.pinned_array`.
- Inputs staged into persistent pinned buffers so the h2d is genuinely async (a
  pageable source forces Numba to stage per call).
- Transfers use the low-level `driver.host_to_device` / `device_to_host`
  (~7 µs/call) instead of synchronous cupy `.set()`/`.get()` that scaled to
  ~370 µs at large N. `copy_to_device`'s per-call `np.array` re-wrap (~50 µs)
  is skipped — the staged buffers are already pinned, C-contiguous and
  size-matched. Both directions are now async and size-independent.
- `current_cupy_stream` uses `Stream.from_external` (`ExternalStream` is
  deprecated); it now wraps only the pool allocation, off the transfer hot
  path.

### Note on the numba-cuda-mlir memory docs

The [numba-cuda-mlir memory reference](https://nvidia.github.io/numba-cuda-mlir/latest/reference/memory.html)
says the Memory API is "not recommended for new code … pass PyTorch Tensors or
CuPy arrays to kernels instead." We deliberately diverge: passing cupy arrays is
exactly the per-launch CAI-reparse path we measured as slow, and the EMM route
gives native arrays (fast launch) + the async transfers this PR requires. The
EMM is documented as supported/backwards-compatible; if it is ever removed we'll
revisit against `cuda.core`'s `DeviceMemoryResource`.

## Verification

685 tests pass across the touched subsystems (memory 141, arrays/solver/kernel
278, interpolator/solveresult/writeback/input 202, time_logger 64), including
under `-W error::DeprecationWarning`. Tests that asserted the old cupy
`.get()`/`.set()` device-array API were moved to native `copy_to_host` /
`copy_to_device`; device allocation is asserted native.

```
pytest tests/memory tests/batchsolving/arrays tests/batchsolving/test_solver.py \
       tests/batchsolving/test_SolverKernel.py -o addopts="" -p no:cacheprovider
```

Numerical equivalence was checked with a harness that includes reused-solver
stress cases (same shape / new values, changing num_runs, changing duration) —
the identical-array repeat would otherwise hide a wrongly-skipped h2d or a stale
size cache.

## Repro — stage-by-stage host-overhead benchmark

Run against this branch (defines the system inline; monkeypatches each stage of
`solve()` and reports per-stage host wall time across a sweep of N). Note the
`(cupy)` labels on the transfer rows are historical — those stages now use the
native driver copies.

```python
#!/usr/bin/env python
"""Stage-by-stage host-overhead profiler for cubie's solve() path."""
import time
import numpy as np

REPEATS = 80
NS = [64, 4096, 262144]

import cubie as qb
from cubie.time_logger import default_timelogger
default_timelogger.set_verbosity(None)

_acc = {}
_order = []

def _wrap(obj, attr, label):
    orig = getattr(obj, attr)
    if label not in _order:
        _order.append(label)
    def wrapper(*a, **k):
        t0 = time.perf_counter()
        try:
            return orig(*a, **k)
        finally:
            _acc[label] = _acc.get(label, 0.0) + (time.perf_counter() - t0)
    setattr(obj, attr, wrapper)
    return orig

from cubie.batchsolving.solver import Solver
from cubie.batchsolving.BatchInputHandler import BatchInputHandler
from cubie.batchsolving.BatchSolverKernel import BatchSolverKernel
from cubie.batchsolving.arrays.BatchInputArrays import InputArrays
from cubie.batchsolving.arrays.BatchOutputArrays import OutputArrays
from cubie.batchsolving.solveresult import SolveResult
from cubie.memory.mem_manager import MemoryManager
from cubie.CUDAFactory import CUDAFactory
from cubie.integrators.SingleIntegratorRun import SingleIntegratorRun

_wrap(BatchInputHandler, "__call__", "1_input_handler(grid)")
_wrap(CUDAFactory, "update_compile_settings", "2_update_compile_settings")
_wrap(InputArrays, "update", "3_input_arrays.update")
_wrap(OutputArrays, "update", "4_output_arrays.update")
_wrap(MemoryManager, "allocate_queue", "5_allocate_queue")
_wrap(BatchSolverKernel, "_setup_cuda_events", "6_setup_cuda_events")
_wrap(InputArrays, "initialise", "7_h2d_input.initialise")
_wrap(OutputArrays, "initialise", "7_h2d_output.initialise")
_wrap(InputArrays, "finalise", "8_d2h_input.finalise")
_wrap(OutputArrays, "finalise", "8_d2h_output.finalise")
_wrap(MemoryManager, "sync_stream", "9_sync_stream(GPU wait)")
_wrap(BatchSolverKernel, "wait_for_writeback", "10_wait_for_writeback")
_wrap(SolveResult, "from_solver", "11_result_construction")
_wrap(MemoryManager, "to_device", "7b_to_device")
_wrap(MemoryManager, "from_device", "8b_from_device")
_wrap(BatchSolverKernel, "_validate_timing_parameters", "V_validate_timing")
_wrap(SingleIntegratorRun, "set_summary_timing_from_duration", "S_set_summary")
_wrap(BatchSolverKernel, "run", "R_kernel.run(total)")

precision = np.float32
lorenz = qb.create_ODE_system(
    """
    dx = sigma * (y - x)
    dy = x * (rho - z) - y
    dz = x * y - beta * z
    """,
    states={'x': 1.0, 'y': 0.0, 'z': 0.0},
    parameters={'rho': 21.0},
    constants={'sigma': 10.0, 'beta': 8.0 / 3.0},
    name="Lorenz_mlir",
    precision=precision,
)
fixed_solver = qb.Solver(
    lorenz, algorithm='classical-rk4', dt=0.001, save_every=1.0,
    step_controller='fixed', output_types=['state'], time_logging_level=None)
adaptive_solver = qb.Solver(
    lorenz, algorithm='tsit5', atol=1e-08, rtol=1e-08, save_every=1.0,
    dt_min=1e-12, dt_max=1e3, step_controller='pid', kp=6 / 5, kd=0.0, ki=0.0,
    max_gain=5.0, min_gain=0.1, output_types=['state'], time_logging_level=None)


def make_grid(solver, n):
    return solver.build_grid(
        initial_values={'x': 1.0, 'y': 0.0, 'z': 0.0},
        parameters={'rho': np.linspace(0.0, 21.0, n)})


def bench(solver, label):
    print(f"\n{'=' * 78}\n{label}\n{'=' * 78}")
    header = f"{'stage':32s}" + "".join(f"{n:>11d}" for n in NS)
    print(header)
    rows, totals, launch = {}, {}, {}
    for n in NS:
        inits, params = make_grid(solver, n)
        solver.solve(initial_values=inits, parameters=params, blocksize=64,
                     results_type='raw', duration=1.0)
        _acc.clear()
        for _ in range(REPEATS):
            solver.solve(initial_values=inits, parameters=params,
                         blocksize=64, results_type='raw', duration=1.0)
        for k, v in _acc.items():
            rows.setdefault(k, {})[n] = v / REPEATS * 1e6
        t0 = time.perf_counter()
        for _ in range(REPEATS):
            solver.solve(initial_values=inits, parameters=params,
                         blocksize=64, results_type='raw', duration=1.0)
        totals[n] = (time.perf_counter() - t0) / REPEATS * 1e6
        run_total = rows.get("R_kernel.run(total)", {}).get(n, 0.0)
        inside = sum(rows.get(k, {}).get(n, 0.0) for k in [
            "2_update_compile_settings", "3_input_arrays.update",
            "4_output_arrays.update", "5_allocate_queue",
            "6_setup_cuda_events", "7_h2d_input.initialise",
            "7_h2d_output.initialise", "8_d2h_input.finalise",
            "8_d2h_output.finalise", "V_validate_timing", "S_set_summary"])
        launch[n] = max(0.0, run_total - inside)
    for k in _order:
        if k == "R_kernel.run(total)":
            continue
        print(f"{k:32s}" + "".join(
            f"{rows.get(k, {}).get(n, 0.0):11.1f}" for n in NS))
    print(f"{'K_kernel_launch(residual)':32s}" +
          "".join(f"{launch[n]:11.1f}" for n in NS))
    print("-" * len(header))
    print(f"{'TOTAL solve() wall (us)':32s}" +
          "".join(f"{totals[n]:11.1f}" for n in NS))


bench(fixed_solver, "FIXED  (classical-rk4, fixed step)")
bench(adaptive_solver, "ADAPTIVE (tsit5, PID controller)")
print(f"\n(units: microseconds per solve() call, mean of {REPEATS} reps)")
```

Quick stable end-to-end number (min-of-100, like the suite benchmark):

```python
import timeit, numpy as np, cubie as qb
from cubie.time_logger import default_timelogger; default_timelogger.set_verbosity(None)
l = qb.create_ODE_system("dx = sigma*(y-x)\ndy = x*(rho-z)-y\ndz = x*y - beta*z",
    states={'x':1.,'y':0.,'z':0.}, parameters={'rho':21.},
    constants={'sigma':10.,'beta':8/3}, name="Lorenz_mlir", precision=np.float32)
s = qb.Solver(l, algorithm='classical-rk4', dt=0.001, save_every=1.,
    step_controller='fixed', output_types=['state'], time_logging_level=None)
for N in (64, 262144):
    inits, params = s.build_grid(initial_values={'x':1.,'y':0.,'z':0.},
        parameters={'rho': np.linspace(0, 21, N)})
    run = lambda: s.solve(initial_values=inits, parameters=params, blocksize=64,
                          results_type='raw', duration=1.0)
    run()
    print(N, min(timeit.repeat(run, repeat=100, number=1)) * 1e3, "ms")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
