### PR TITLE
fix: driver coefficients track every interpolator settings change

### DIFF
--- a/src/cubie/array_interpolator.py
+++ b/src/cubie/array_interpolator.py
@@ -193,7 +193,8 @@ class ArrayInterpolator(CUDAFactory):
         Returns
         -------
         bool
-            ``True`` when the coefficients or configuration changed.
+            ``True`` when the compiled evaluator configuration changed
+            and consumers must refresh their device-function handles.
 
         Notes
         -----
@@ -253,19 +254,38 @@ class ArrayInterpolator(CUDAFactory):
         time = {k: v for k, v in input_dict.items() if k in self.time_info}
 
         # Update order first, for checks  in _normalise_input_array
-        fn_changed = any(self.update_compile_settings(config))
+        initial_hash = self.compile_settings.values_hash
+        self.update_compile_settings(config)
 
         input_array = self._normalise_input_array(inputs)
-        if array_equal(input_array, self.input_array):
-            return False
-        else:
+        arrays_changed = not array_equal(input_array, self.input_array)
+        if arrays_changed:
             self._input_array = input_array
 
         dt, t0 = self._validate_time_inputs(time)
-        base_segments = self.num_samples - 1
         config.update({"t0": t0, "dt": dt, "num_inputs": self.num_inputs})
 
         # Final update; invalidates cache if settings have changed.
+        self._derive_segment_settings(config)
+        self.update_compile_settings(config)
+        fn_changed = self.compile_settings.values_hash != initial_hash
+        if fn_changed or arrays_changed:
+            self._coefficients = self._compute_coefficients()
+
+        return fn_changed
+
+    def _derive_segment_settings(self, config: Dict[str, Any]) -> None:
+        """Fill derived boundary-condition and segment-count settings.
+
+        Parameters
+        ----------
+        config
+            Pending driver configuration updates, modified in place.
+            ``boundary_condition`` defaults from the wrap setting when
+            absent, and ``num_segments`` is set from the sample count
+            and boundary condition.
+        """
+        base_segments = self.num_samples - 1
         wrap_setting = config.get("wrap", self.wrap)
         if wrap_setting:
             if "boundary_condition" not in config:
@@ -281,10 +301,6 @@ class ArrayInterpolator(CUDAFactory):
             else:
                 num_segments = base_segments
         config["num_segments"] = num_segments
-        fn_changed |= any(self.update_compile_settings(config))
-        self._coefficients = self._compute_coefficients()
-
-        return fn_changed
 
     def _normalise_input_array(
         self, input_dict: Dict[str, FloatArray]
@@ -545,6 +561,15 @@ class ArrayInterpolator(CUDAFactory):
         ------
         KeyError
             Raised when an unknown key is provided while ``silent`` is False.
+
+        Notes
+        -----
+        Updates naming a key in ``config_keys`` rederive
+        ``num_segments`` from the resulting wrap and boundary
+        condition; keys absent from the update keep their current
+        values. Changed settings recompute the host coefficients so
+        they always match the configuration captured by the compiled
+        device evaluators.
         """
         if updates_dict is None:
             updates_dict = {}
@@ -554,6 +579,7 @@ class ArrayInterpolator(CUDAFactory):
         if updates_dict == {}:
             return set()
 
+        initial_hash = self.compile_settings.values_hash
         recognised = self.update_compile_settings(updates_dict, silent=True)
         unrecognised = set(updates_dict.keys()) - recognised
 
@@ -562,6 +588,20 @@ class ArrayInterpolator(CUDAFactory):
                 f"Unrecognized parameters in update: {unrecognised}. "
                 "These parameters were not updated.",
             )
+
+        driver_config = {
+            key: updates_dict[key]
+            for key in recognised
+            if key in self.config_keys
+        }
+        if driver_config:
+            driver_config.setdefault(
+                "boundary_condition", self.boundary_condition
+            )
+            self._derive_segment_settings(driver_config)
+            self.update_compile_settings(driver_config, silent=True)
+        if self.compile_settings.values_hash != initial_hash:
+            self._coefficients = self._compute_coefficients()
 
         return recognised
 
@@ -580,6 +620,11 @@ class ArrayInterpolator(CUDAFactory):
     def coefficients(self) -> FloatArray:
         """Return the host-side coefficients array."""
         return self._coefficients
+
+    @property
+    def coefficients_shape(self) -> Tuple[int, int, int]:
+        """Exact coefficient layout captured by the device evaluators."""
+        return (self.num_segments, self.num_inputs, self.order + 1)
 
     # ---------------------------------------------------------------------- #
     # Inspection interface

--- a/src/cubie/batchsolving/solver.py
+++ b/src/cubie/batchsolving/solver.py
@@ -605,6 +605,29 @@ class Solver:
         """
         self.system_interface.merge_variable_labels_and_idxs(output_settings)
 
+    def _configure_drivers(self, drivers: Dict[str, Any]) -> None:
+        """Update owned driver data and evaluators as one unit.
+
+        Parameters
+        ----------
+        drivers
+            Driver samples plus interpolation settings, as accepted by
+            :meth:`ArrayInterpolator.update_from_dict`.
+        """
+        drivers = ArrayInterpolator.check_against_system_drivers(
+            drivers, self.system
+        )
+        fn_changed = self.driver_interpolator.update_from_dict(drivers)
+        if fn_changed:
+            self.kernel.update(
+                {
+                    "evaluate_driver_at_t": (
+                        self.driver_interpolator.evaluation_function
+                    ),
+                    "driver_del_t": self.driver_interpolator.driver_del_t,
+                }
+            )
+
     def solve(
         self,
         initial_values: Union[ndarray, Dict[str, Union[float, ndarray]]],
@@ -693,19 +716,8 @@ class Solver:
             states=initial_values, params=parameters, kind=grid_type
         )
 
-        fn_changed = False
         if drivers is not None:
-            drivers = ArrayInterpolator.check_against_system_drivers(
-                drivers, self.system
-            )
-            fn_changed = self.driver_interpolator.update_from_dict(drivers)
-        if fn_changed:
-            self.update(
-                {
-                    "evaluate_driver_at_t": self.driver_interpolator.evaluation_function,
-                    "driver_del_t": self.driver_interpolator.driver_del_t,
-                }
-            )
+            self._configure_drivers(drivers)
 
         self.kernel.run(
             inits=inits,

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1270,7 +1270,7 @@ NON_SOLVER_SETTINGS = {
 def _build_solver_instance(
     system: SymbolicODE,
     solver_settings: Dict[str, Any],
-    driver_array: Optional[ArrayInterpolator],
+    driver_settings: Optional[Dict[str, Any]],
     memory_manager: Optional[Any] = None,
 ) -> Solver:
     """Instantiate :class:`Solver` configured with ``solver_settings``."""
@@ -1282,8 +1282,8 @@ def _build_solver_instance(
     if memory_manager:
         settings.update(memory_manager=memory_manager)
     solver = Solver(system, **settings)
-    evaluate_driver_at_t = _get_evaluate_driver_at_t(driver_array)
-    solver.update({"evaluate_driver_at_t": evaluate_driver_at_t})
+    if driver_settings is not None:
+        solver._configure_drivers(driver_settings)
     return solver
 
 

--- a/tests/batchsolving/arrays/test_chunking.py
+++ b/tests/batchsolving/arrays/test_chunking.py
@@ -113,7 +113,6 @@ def test_chunked_results_match_unchunked(
     system,
     precision,
     solver_settings,
-    driver_array,
     driver_settings,
 ):
     """Chunked solves reproduce unchunked results exactly.
@@ -145,7 +144,7 @@ def test_chunked_results_match_unchunked(
     reference_solver = _build_solver_instance(
         system=system,
         solver_settings=reference_settings,
-        driver_array=driver_array,
+        driver_settings=driver_settings,
         memory_manager=MemoryManager(),
     )
     try:

--- a/tests/batchsolving/test_memory_pressure.py
+++ b/tests/batchsolving/test_memory_pressure.py
@@ -50,7 +50,6 @@ def test_host_arrays_spill_to_disk_and_results_match(
     solver_mutable,
     system,
     solver_settings,
-    driver_array,
     driver_settings,
     batch_input_arrays,
 ):
@@ -68,7 +67,7 @@ def test_host_arrays_spill_to_disk_and_results_match(
     reference_solver = _build_solver_instance(
         system=system,
         solver_settings=reference_settings,
-        driver_array=driver_array,
+        driver_settings=driver_settings,
         memory_manager=MemoryManager(),
     )
     try:
@@ -85,7 +84,6 @@ def test_host_arrays_spill_to_disk_and_results_match(
 def test_solver_spill_policies_are_independent(
     system,
     solver_settings,
-    driver_array,
     driver_settings,
     batch_input_arrays,
     tmp_path,
@@ -106,13 +104,13 @@ def test_solver_spill_policies_are_independent(
     spill_solver = _build_solver_instance(
         system=system,
         solver_settings=spill_settings,
-        driver_array=driver_array,
+        driver_settings=driver_settings,
         memory_manager=manager,
     )
     ram_solver = _build_solver_instance(
         system=system,
         solver_settings=ram_settings,
-        driver_array=driver_array,
+        driver_settings=driver_settings,
         memory_manager=manager,
     )
     try:
@@ -270,7 +268,7 @@ def test_repeat_solve_with_held_result_and_collapsed_vram(
 
 
 def test_outputs_above_pinned_ceiling_stay_pageable(
-    system, solver_settings, driver_array, driver_settings,
+    system, solver_settings, driver_settings,
     batch_input_arrays,
 ):
     """With a tiny pinned ceiling every buffer is pageable, not pinned.
@@ -284,7 +282,7 @@ def test_outputs_above_pinned_ceiling_stay_pageable(
     solver = _build_solver_instance(
         system=system,
         solver_settings=settings,
-        driver_array=driver_array,
+        driver_settings=driver_settings,
         memory_manager=manager,
     )
     try:

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -1627,7 +1627,6 @@ def test_shared_loop_buffers_leave_results_unchanged(
     solver,
     solver_settings,
     system,
-    driver_array,
     driver_settings,
     thread_mem_manager,
     simple_initial_values,
@@ -1668,10 +1667,54 @@ def test_shared_loop_buffers_leave_results_unchanged(
     shared_solver = _build_solver_instance(
         system=system,
         solver_settings=shared_settings,
-        driver_array=driver_array,
+        driver_settings=driver_settings,
         memory_manager=thread_mem_manager,
     )
     shared_output = run_solve(shared_solver)
 
     assert np.all(np.isfinite(local_output))
     np.testing.assert_array_equal(shared_output, local_output)
+
+
+def test_driver_setting_update_syncs_evaluator_and_coefficients(
+    solver_mutable,
+    system,
+    solver_settings,
+    driver_settings,
+    thread_mem_manager,
+    simple_initial_values,
+    simple_parameters,
+):
+    """Settings-only driver updates flow through ``Solver.update``.
+
+    Switching ``boundary_condition`` from "clamped" to "natural"
+    changes the coefficient tensor's segment count, so the updated
+    solver only reproduces a natural-from-scratch solver when the
+    evaluator and coefficients are refreshed together.
+    """
+
+    def run_solve(active_solver, drivers):
+        result = active_solver.solve(
+            initial_values=simple_initial_values,
+            parameters=simple_parameters,
+            drivers=drivers,
+            duration=solver_settings["duration"],
+        )
+        return np.asarray(result.time_domain_array)
+
+    run_solve(solver_mutable, driver_settings)
+    solver_mutable.update({"boundary_condition": "natural"})
+    updated_output = run_solve(solver_mutable, None)
+
+    natural_settings = dict(driver_settings)
+    natural_settings["boundary_condition"] = "natural"
+    reference_solver = _build_solver_instance(
+        system=system,
+        solver_settings=solver_settings,
+        driver_settings=natural_settings,
+        memory_manager=thread_mem_manager,
+    )
+    reference_output = run_solve(reference_solver, None)
+
+    assert np.all(np.isfinite(updated_output))
+    np.testing.assert_array_equal(updated_output, reference_output)

--- a/tests/batchsolving/test_solver_teardown.py
+++ b/tests/batchsolving/test_solver_teardown.py
@@ -259,7 +259,7 @@ def test_solve_ivp_spill_survives_solver_close(
 def test_custom_stream_close_does_not_wait_for_unrelated_stream(
     solver_mutable,
     batch_input_arrays,
-    driver_array,
+    driver_settings,
     solver_settings,
     system,
     thread_mem_manager,
@@ -301,7 +301,7 @@ def test_custom_stream_close_does_not_wait_for_unrelated_stream(
     reference_solver = _build_solver_instance(
         system=system,
         solver_settings=reference_settings,
-        driver_array=driver_array,
+        driver_settings=driver_settings,
         memory_manager=MemoryManager(),
     )
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -367,13 +367,13 @@ def low_memory(forced_free_mem):
 def low_mem_solver(
     system,
     solver_settings,
-    driver_array,
+    driver_settings,
     low_memory,
 ):
     return _build_solver_instance(
         system=system,
         solver_settings=solver_settings,
-        driver_array=driver_array,
+        driver_settings=driver_settings,
         memory_manager=low_memory,
     )
 
@@ -382,14 +382,14 @@ def low_mem_solver(
 def second_low_mem_solver(
     system,
     solver_settings,
-    driver_array,
+    driver_settings,
     low_memory,
 ):
     """Second solver sharing ``low_memory`` for cross-solver tests."""
     return _build_solver_instance(
         system=system,
         solver_settings=solver_settings,
-        driver_array=driver_array,
+        driver_settings=driver_settings,
         memory_manager=low_memory,
     )
 
@@ -443,12 +443,12 @@ def start_cuda_busy_work():
 def unchunking_solver(
     system,
     solver_settings,
-    driver_array,
+    driver_settings,
 ):
     return _build_solver_instance(
         system=system,
         solver_settings=solver_settings,
-        driver_array=driver_array,
+        driver_settings=driver_settings,
     )
 
 
@@ -897,11 +897,11 @@ def solverkernel_mutable(
 
 
 @pytest.fixture(scope="session")
-def solver(system, solver_settings, driver_array, thread_mem_manager):
+def solver(system, solver_settings, driver_settings, thread_mem_manager):
     return _build_solver_instance(
         system=system,
         solver_settings=solver_settings,
-        driver_array=driver_array,
+        driver_settings=driver_settings,
         memory_manager=thread_mem_manager,
     )
 
@@ -910,13 +910,13 @@ def solver(system, solver_settings, driver_array, thread_mem_manager):
 def solver_mutable(
     system,
     solver_settings,
-    driver_array,
+    driver_settings,
     thread_mem_manager,
 ):
     return _build_solver_instance(
         system=system,
         solver_settings=solver_settings,
-        driver_array=driver_array,
+        driver_settings=driver_settings,
         memory_manager=thread_mem_manager,
     )
 

--- a/tests/test_array_interpolator.py
+++ b/tests/test_array_interpolator.py
@@ -1318,3 +1318,62 @@ def test_not_a_knot_order_two_uses_single_start_constraint(precision):
     )
     assert interp.coefficients is not None
 
+
+# ── update: coefficients track the compiled configuration ───────────── #
+
+
+def test_settings_only_update_recomputes_coefficients(precision):
+    """``update`` keeps coefficients matched to the compiled layout."""
+    times = np.arange(0.0, 6.0, 1.0, dtype=precision)
+    interp = ArrayInterpolator(
+        precision=precision,
+        input_dict={
+            "values": times**2,
+            "time": times,
+            "order": 2,
+            "wrap": False,
+            "boundary_condition": "clamped",
+        },
+    )
+    base_segments = interp.num_samples - 1
+    assert interp.num_segments == base_segments + 2
+    assert interp.coefficients.shape == interp.coefficients_shape
+
+    interp.update({"boundary_condition": "natural"})
+    assert interp.num_segments == base_segments
+    assert interp.coefficients.shape == interp.coefficients_shape
+
+    interp.update({"order": 4})
+    assert interp.boundary_condition == "natural"
+    assert interp.coefficients_shape == (base_segments, 1, 5)
+    assert interp.coefficients.shape == interp.coefficients_shape
+
+    evaluated = interp.get_interpolated(
+        np.linspace(0.5, 4.5, 9, dtype=precision)
+    )
+    assert evaluated.shape == (9, 1)
+    assert np.all(np.isfinite(evaluated))
+
+
+def test_update_from_dict_applies_config_change_with_equal_arrays(
+    precision,
+):
+    """Equal arrays with new settings still refresh the evaluator."""
+    times = np.arange(0.0, 6.0, 1.0, dtype=precision)
+    input_dict = {
+        "values": times**2,
+        "time": times,
+        "order": 2,
+        "wrap": False,
+        "boundary_condition": "clamped",
+    }
+    interp = ArrayInterpolator(precision=precision, input_dict=input_dict)
+    assert interp.update_from_dict(dict(input_dict)) is False
+
+    changed_dict = dict(input_dict)
+    changed_dict["order"] = 3
+    assert interp.update_from_dict(changed_dict) is True
+    assert interp.order == 3
+    assert interp.coefficients_shape[2] == 4
+    assert interp.coefficients.shape == interp.coefficients_shape
+


### PR DESCRIPTION
Closes #628.

## Root cause

Two distinct bugs, one in the harness and one in the product:

- **Harness (the #628 report):** `_build_solver_instance` installed a session-scoped fixture evaluator into a fresh solver's kernel while the solver-owned interpolator kept its 6-sample placeholder coefficients, so device code compiled for 22 segments read a 5-segment tensor out of bounds. Garbage collection only changed the adjacent device-memory contents, and therefore the symptom.
- **Product:** `ArrayInterpolator` could desynchronize its own evaluator from its own coefficients through the public interface. `update()` changed compile settings (`order`/`wrap`/`boundary_condition`) without rederiving `num_segments` or recomputing coefficients, and `update_from_dict()` discarded configuration changes whenever the sample arrays compared equal. After `solver.update({"boundary_condition": ...})` the kernel received a freshly compiled evaluator while `solve()` passed the stale tensor — the same out-of-bounds class, reachable from a documented user flow.

## Result

The previous revision of this PR guarded the kernel instead (a coefficient-shape field in `BatchSolverConfig`, an update-together trio contract, and per-run prevalidation). Review found every one of those guards unreachable from the Solver interface once the interpolator keeps its own artifacts coherent, so that machinery does not exist in this revision; ownership does the work:

- `ArrayInterpolator.update` rederives `num_segments` and the boundary condition from the resulting settings and recomputes the host coefficients when driver settings change; keys absent from an update keep their current values.
- `ArrayInterpolator.update_from_dict` applies configuration changes even when the sample arrays are unchanged. Actual change is detected through the compile-settings `values_hash`, so repeated identical solves remain no-ops.
- `coefficients` therefore always matches `coefficients_shape` (`(num_segments, num_inputs, order + 1)`), the layout captured by the compiled evaluators.
- `Solver._configure_drivers` updates driver data and evaluator handles as one unit; `solve()` and the test harness both use it.
- Solver fixtures configure drivers from `driver_settings` through the solver instead of borrowing a session-scoped fixture evaluator.
- The kernel carries no driver-layout state and performs no per-run driver validation.

Regression tests cover the interpolator invariant directly (settings-only updates, equal-array config changes) and end-to-end through `Solver.update` (boundary-condition switch reproduces a from-scratch solver exactly).

## Verification

Real GPU, `tests/test_array_interpolator.py` + `tests/batchsolving/` (`-m "not specific_algos and not sim_only"`):

| Backend | Result |
| --- | --- |
| numba-cuda | 572 passed |
| numba-cuda-mlir | 572 passed |

Additional checks:

- CUDASIM pass over the same scope: passed
- `flake8 --select=E9,F63,F7,F82 --show-source` on touched files: passed

## Performance gate

Kernel closures are unchanged (identical regs/spills/occupancy in the gate's @META table on both sides). The default 4-pair run flagged `mlir adaptive`/`mlir wave` REGRESSION with DISTRUST; per the gate protocol both were rerun rather than accepted — at 8 and 16 pairs every row settles to ok/improvement.

numba-cuda (`--pairs 8`):

| Config | Kernel delta | Verdict |
| --- | ---: | --- |
| fixed | -1.63% | improvement |
| adaptive | -1.37% | improvement |
| chunked | -0.10% | ok |
| wave | -1.26% | improvement |

numba-cuda-mlir (`--pairs 16`):

| Config | Kernel delta | Verdict |
| --- | ---: | --- |
| fixed | -0.00% | ok |
| adaptive | -0.42% | ok |
| chunked | +0.08% | ok |
| wave | -0.22% | ok |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
