### PR TITLE
fix: time-logger tests bracket durations with the measuring clock

### DIFF
--- a/tests/test_time_logger.py
+++ b/tests/test_time_logger.py
@@ -405,8 +405,8 @@ class TestTimeLogger:
         logger.stop_event("runtime1")
 
         # Test filtering by compile category. The duration is bracketed
-        # with the logger's own clock (time.perf_counter) rather than
-        # the sleep's nominal length, which Windows can undershoot.
+        # with the logger's own clock (time.perf_counter), so the bound
+        # holds regardless of sleep precision on any platform.
         compile_durations = logger.get_aggregate_durations(category="compile")
         assert "compile1" in compile_durations
         assert "runtime1" not in compile_durations

--- a/tests/test_time_logger.py
+++ b/tests/test_time_logger.py
@@ -145,16 +145,28 @@ class TestTimeLogger:
         assert logger.events[0].metadata["message"] == "50% complete"
 
     def test_get_event_duration(self):
-        """Test calculating duration between start and stop events."""
+        """Test calculating duration between start and stop events.
+
+        The duration is bracketed with the logger's own clock
+        (time.perf_counter) instead of the sleep's nominal length:
+        Windows sleeps can return early, but the reported duration
+        must always contain the interval measured strictly inside
+        the event and fit inside the interval measured around it.
+        """
         logger = TimeLogger(verbosity='default')
         logger.register_event("test_operation", "runtime", "Test operation")
+        outer_start = time.perf_counter()
         logger.start_event("test_operation")
+        inner_start = time.perf_counter()
         time.sleep(0.02)
+        inner_end = time.perf_counter()
         logger.stop_event("test_operation")
-        
+        outer_end = time.perf_counter()
+
         duration = logger.get_event_duration("test_operation")
         assert duration is not None
-        assert duration >= 0.02
+        assert duration >= inner_end - inner_start
+        assert duration <= outer_end - outer_start
 
     def test_get_event_duration_no_stop(self):
         """Test get_event_duration returns None when stop event missing."""
@@ -262,19 +274,30 @@ class TestTimeLogger:
         assert "Summary" in captured.out
 
     def test_get_aggregate_durations(self):
-        """Test aggregating event durations."""
+        """Test aggregating event durations.
+
+        Each start/stop pair is bracketed with the logger's own clock
+        (time.perf_counter); the aggregate must lie between the sum of
+        the inner intervals and the sum of the outer intervals, which
+        holds regardless of how long the sleeps actually last.
+        """
         logger = TimeLogger(verbosity='default')
         logger.register_event("operation1", "runtime", "Operation 1")
-        logger.start_event("operation1")
-        time.sleep(0.01)
-        logger.stop_event("operation1")
-        logger.start_event("operation1")
-        time.sleep(0.01)
-        logger.stop_event("operation1")
-        
+        inner_total = 0.0
+        outer_total = 0.0
+        for _ in range(2):
+            outer_start = time.perf_counter()
+            logger.start_event("operation1")
+            inner_start = time.perf_counter()
+            time.sleep(0.01)
+            inner_total += time.perf_counter() - inner_start
+            logger.stop_event("operation1")
+            outer_total += time.perf_counter() - outer_start
+
         durations = logger.get_aggregate_durations()
         assert "operation1" in durations
-        assert durations["operation1"] >= 0.02
+        assert durations["operation1"] >= inner_total
+        assert durations["operation1"] <= outer_total
 
     def test_empty_event_name_raises(self):
         """Test that empty event names raise ValueError."""
@@ -369,19 +392,26 @@ class TestTimeLogger:
         logger.register_event("compile1", "compile", "Compile 1")
         logger.register_event("runtime1", "runtime", "Runtime 1")
         
+        outer_start = time.perf_counter()
         logger.start_event("compile1")
+        inner_start = time.perf_counter()
         time.sleep(0.01)
+        inner_end = time.perf_counter()
         logger.stop_event("compile1")
-        
+        outer_end = time.perf_counter()
+
         logger.start_event("runtime1")
         time.sleep(0.01)
         logger.stop_event("runtime1")
-        
-        # Test filtering by compile category
+
+        # Test filtering by compile category. The duration is bracketed
+        # with the logger's own clock (time.perf_counter) rather than
+        # the sleep's nominal length, which Windows can undershoot.
         compile_durations = logger.get_aggregate_durations(category="compile")
         assert "compile1" in compile_durations
         assert "runtime1" not in compile_durations
-        assert compile_durations["compile1"] >= 0.01
+        assert compile_durations["compile1"] >= inner_end - inner_start
+        assert compile_durations["compile1"] <= outer_end - outer_start
 
     def test_print_summary_by_category(self, capsys):
         """Test printing summary for specific categories.

--- a/tests/test_time_logger.py
+++ b/tests/test_time_logger.py
@@ -147,11 +147,12 @@ class TestTimeLogger:
     def test_get_event_duration(self):
         """Test calculating duration between start and stop events.
 
-        The duration is bracketed with the logger's own clock
-        (time.perf_counter) instead of the sleep's nominal length:
-        Windows sleeps can return early, but the reported duration
-        must always contain the interval measured strictly inside
-        the event and fit inside the interval measured around it.
+        Durations are bounded using ``time.perf_counter`` readings taken
+        immediately outside and inside the ``start_event``/``stop_event``
+        calls. The reported duration must lie between the inner interval
+        (measured strictly inside the event) and the outer interval
+        (measured around the entire call pair), guaranteeing correctness
+        on any platform regardless of sleep precision.
         """
         logger = TimeLogger(verbosity='default')
         logger.register_event("test_operation", "runtime", "Test operation")


### PR DESCRIPTION
# Summary

Fixes #636. Three duration tests in `tests/test_time_logger.py` asserted sleep-based wall-clock floors (`duration >= <slept seconds>`). Windows sleeps return up to ~1 ms early relative to `time.perf_counter` (the clock `TimeLogger` measures with), so Windows GPU CI legs failed with e.g. `assert 0.00973 >= 0.01` — a different subset of the three tripping per run (see #636 for both CI datasets).

## Change

Each logged region is bracketed with `perf_counter` readings taken immediately outside and inside the `start_event`/`stop_event` calls. The assertions become:

```
inner interval <= reported duration <= outer interval
```

Event ordering guarantees both bounds on any platform — the logger's internal timestamps are taken between the outer and inner readings by construction — so the tests no longer depend on how long `time.sleep` actually lasts, and the contract asserted (the logger measures the elapsed `perf_counter` interval) is stricter than the fixed floors it replaces. No tolerances were loosened; the sleeps remain only to make the measured intervals non-trivial.

## Verification

`pytest tests/test_time_logger.py` — 64 passed locally (real GPU venv). `flake8 --select=E9,F63,F7,F82` clean.

## Performance gate

Not applicable: test-only change, no `src/` modification, so an A/B of `benchmarks/ab_gate.py` would compare identical source trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)