### PR TITLE
fix(ci): precompiled kernel cache survives the CPU-to-GPU machine hop

### DIFF
--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -74,13 +74,7 @@ jobs:
       matrix:
         include:
           - {os: linux, python-version: "3.10", cuda: "12", extra: dev12}
-          - {os: linux, python-version: "3.10", cuda: "13", extra: dev13}
           - {os: linux, python-version: "3.14", cuda: "12", extra: dev12}
-          - {os: linux, python-version: "3.14", cuda: "13", extra: dev13}
-          - {os: windows, python-version: "3.10", cuda: "12", extra: dev12}
-          - {os: windows, python-version: "3.10", cuda: "13", extra: dev13}
-          - {os: windows, python-version: "3.14", cuda: "12", extra: dev12}
-          - {os: windows, python-version: "3.14", cuda: "13", extra: dev13}
     runs-on: ${{ matrix.os == 'linux' && 'ubuntu-latest' || 'windows-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -183,13 +177,7 @@ jobs:
       matrix:
         include:
           - {os: linux, python-version: "3.10", cuda: "12", extra: dev12, fleet: gpu-linux}
-          - {os: linux, python-version: "3.10", cuda: "13", extra: dev13, fleet: gpu-linux}
           - {os: linux, python-version: "3.14", cuda: "12", extra: dev12, fleet: gpu-linux}
-          - {os: linux, python-version: "3.14", cuda: "13", extra: dev13, fleet: gpu-linux}
-          - {os: windows, python-version: "3.10", cuda: "12", extra: dev12, fleet: gpu-windows}
-          - {os: windows, python-version: "3.10", cuda: "13", extra: dev13, fleet: gpu-windows}
-          - {os: windows, python-version: "3.14", cuda: "12", extra: dev12, fleet: gpu-windows}
-          - {os: windows, python-version: "3.14", cuda: "13", extra: dev13, fleet: gpu-windows}
     runs-on: runs-on/fleet=${{ matrix.fleet }}/env=production
 
     steps:

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -74,7 +74,13 @@ jobs:
       matrix:
         include:
           - {os: linux, python-version: "3.10", cuda: "12", extra: dev12}
+          - {os: linux, python-version: "3.10", cuda: "13", extra: dev13}
           - {os: linux, python-version: "3.14", cuda: "12", extra: dev12}
+          - {os: linux, python-version: "3.14", cuda: "13", extra: dev13}
+          - {os: windows, python-version: "3.10", cuda: "12", extra: dev12}
+          - {os: windows, python-version: "3.10", cuda: "13", extra: dev13}
+          - {os: windows, python-version: "3.14", cuda: "12", extra: dev12}
+          - {os: windows, python-version: "3.14", cuda: "13", extra: dev13}
     runs-on: ${{ matrix.os == 'linux' && 'ubuntu-latest' || 'windows-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -177,7 +183,13 @@ jobs:
       matrix:
         include:
           - {os: linux, python-version: "3.10", cuda: "12", extra: dev12, fleet: gpu-linux}
+          - {os: linux, python-version: "3.10", cuda: "13", extra: dev13, fleet: gpu-linux}
           - {os: linux, python-version: "3.14", cuda: "12", extra: dev12, fleet: gpu-linux}
+          - {os: linux, python-version: "3.14", cuda: "13", extra: dev13, fleet: gpu-linux}
+          - {os: windows, python-version: "3.10", cuda: "12", extra: dev12, fleet: gpu-windows}
+          - {os: windows, python-version: "3.10", cuda: "13", extra: dev13, fleet: gpu-windows}
+          - {os: windows, python-version: "3.14", cuda: "12", extra: dev12, fleet: gpu-windows}
+          - {os: windows, python-version: "3.14", cuda: "13", extra: dev13, fleet: gpu-windows}
     runs-on: runs-on/fleet=${{ matrix.fleet }}/env=production
 
     steps:

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -122,6 +122,11 @@ jobs:
         env:
           CUBIE_KERNEL_CACHE_DIR: ${{ github.workspace }}/kernel-cache/kernels
           CUBIE_MAX_CACHE_ENTRIES: "0"
+          # -p plugins are imported before pytest's pythonpath/conftest
+          # machinery runs, and the pytest console script does not put
+          # the cwd on sys.path, so the tests package must be exported
+          # explicitly for `-p tests.precompile_plugin` to resolve.
+          PYTHONPATH: ${{ github.workspace }}
           # Strip plain asserts (with rewriting off) so tests that
           # would fail on headless placeholder results keep running
           # and reach every kernel launch; test verdicts are
@@ -277,6 +282,10 @@ jobs:
         env:
           CUBIE_KERNEL_CACHE_DIR: ${{ github.workspace }}/kernel-cache/kernels
           CUBIE_MAX_CACHE_ENTRIES: "0"
+          # Same as the precompile leg: -p plugin imports happen before
+          # any pytest sys.path setup, so the repo root must be on
+          # PYTHONPATH for `tests.precompile_plugin` to import.
+          PYTHONPATH: ${{ github.workspace }}
         run: pytest -m "not specific_algos and not sim_only" -p tests.precompile_plugin -n logical --junitxml=pytest-results.xml
 
       # The artifact service occasionally answers CreateArtifact with a

--- a/tests/_precompile_hashing.py
+++ b/tests/_precompile_hashing.py
@@ -13,7 +13,7 @@ system and compile-settings hashes and never need function identity.
 """
 import marshal
 from hashlib import sha256
-from types import CodeType
+from types import CodeType, FunctionType
 from typing import Optional
 
 # Whichever backend serializer is installed; population and consumer
@@ -26,11 +26,34 @@ except ImportError:
     )
 
 
+def _portable_const(value):
+    """Return a deterministically ordered stand-in for a constant.
+
+    The compiler folds ``in {...}`` and ``in (...)`` membership tests
+    into frozenset constants, and before Python 3.12 ``marshal``
+    serialized their members in hash-iteration order, which varies
+    with each process's hash seed. Replace every frozenset with a
+    marker tuple of its members sorted by their own marshal bytes so
+    the code hash is identical across processes and machines. The
+    result is only marshaled for hashing, never executed.
+    """
+    if isinstance(value, CodeType):
+        return _portable_code(value)
+    if isinstance(value, frozenset):
+        members = sorted(
+            (_portable_const(member) for member in value),
+            key=marshal.dumps,
+        )
+        return ("__frozenset__",) + tuple(members)
+    if isinstance(value, tuple):
+        return tuple(_portable_const(member) for member in value)
+    return value
+
+
 def _portable_code(code: CodeType) -> CodeType:
-    """Remove source locations from a code object and its children."""
+    """Remove source locations and hash-order detail from a code object."""
     constants = tuple(
-        _portable_code(value) if isinstance(value, CodeType) else value
-        for value in code.co_consts
+        _portable_const(value) for value in code.co_consts
     )
     return code.replace(
         co_filename="", co_firstlineno=1, co_consts=constants
@@ -46,6 +69,11 @@ def _stable_value_key(value, active: set[int]):
             _function_key(py_func, active),
             _stable_value_key(value.targetoptions, active),
         )
+    if isinstance(value, FunctionType):
+        # The serialized fallback pickles plain functions by value,
+        # embedding co_filename, which differs between the CPU
+        # population checkout and the GPU consumer checkout.
+        return ("function", _function_key(value, active))
     if isinstance(value, CodeType):
         code_hash = sha256(marshal.dumps(_portable_code(value))).hexdigest()
         return ("code", code_hash)

--- a/tests/_precompile_hashing.py
+++ b/tests/_precompile_hashing.py
@@ -11,7 +11,6 @@ same key when the GPU runner looks it up.
 Kept out of :mod:`cubie.cubie_cache`: production caches are keyed by
 system and compile-settings hashes and never need function identity.
 """
-import marshal
 from hashlib import sha256
 from types import CodeType, FunctionType
 from typing import Optional
@@ -26,38 +25,55 @@ except ImportError:
     )
 
 
-def _portable_const(value):
-    """Return a deterministically ordered stand-in for a constant.
+def _canonical_const(value):
+    """Return a value-only stand-in for a code constant.
 
     The compiler folds ``in {...}`` and ``in (...)`` membership tests
-    into frozenset constants, and before Python 3.12 ``marshal``
-    serialized their members in hash-iteration order, which varies
-    with each process's hash seed. Replace every frozenset with a
-    marker tuple of its members sorted by their own marshal bytes so
-    the code hash is identical across processes and machines. The
-    result is only marshaled for hashing, never executed.
+    into frozenset constants whose iteration order varies with each
+    process's hash seed, so frozensets become marker tuples sorted by
+    member repr. Nested code objects become their fingerprints.
     """
     if isinstance(value, CodeType):
-        return _portable_code(value)
+        return ("__code__", _code_fingerprint(value))
     if isinstance(value, frozenset):
         members = sorted(
-            (_portable_const(member) for member in value),
-            key=marshal.dumps,
+            (_canonical_const(member) for member in value), key=repr
         )
         return ("__frozenset__",) + tuple(members)
     if isinstance(value, tuple):
-        return tuple(_portable_const(member) for member in value)
+        return tuple(_canonical_const(member) for member in value)
     return value
 
 
-def _portable_code(code: CodeType) -> CodeType:
-    """Remove source locations and hash-order detail from a code object."""
-    constants = tuple(
-        _portable_const(value) for value in code.co_consts
+def _code_fingerprint(code: CodeType) -> str:
+    """Hash a code object by value without marshal or pickle.
+
+    ``marshal.dumps`` writes a ``FLAG_REF`` bit per object based on
+    its runtime refcount at dump time, so two dumps of the same code
+    object can differ depending on what else references its interned
+    name strings (deterministic only on Python >= 3.12, where
+    identifier strings are immortal). Hashing the repr of a tuple of
+    the code object's value components has no such context
+    sensitivity. Source locations (filename, line numbers) are
+    excluded so checkouts at different paths agree.
+    """
+    structure = (
+        code.co_argcount,
+        code.co_posonlyargcount,
+        code.co_kwonlyargcount,
+        code.co_nlocals,
+        code.co_stacksize,
+        code.co_flags,
+        code.co_code,
+        tuple(_canonical_const(value) for value in code.co_consts),
+        code.co_names,
+        code.co_varnames,
+        code.co_freevars,
+        code.co_cellvars,
+        code.co_name,
+        getattr(code, "co_exceptiontable", b""),
     )
-    return code.replace(
-        co_filename="", co_firstlineno=1, co_consts=constants
-    )
+    return sha256(repr(structure).encode("utf-8")).hexdigest()
 
 
 def _stable_value_key(value, active: set[int]):
@@ -75,8 +91,7 @@ def _stable_value_key(value, active: set[int]):
         # population checkout and the GPU consumer checkout.
         return ("function", _function_key(value, active))
     if isinstance(value, CodeType):
-        code_hash = sha256(marshal.dumps(_portable_code(value))).hexdigest()
-        return ("code", code_hash)
+        return ("code", _code_fingerprint(value))
     if value.__class__.__name__ == "FastMathOptions":
         return ("fastmath", tuple(sorted(value.flags)))
     if isinstance(value, tuple):
@@ -119,14 +134,11 @@ def _function_key(py_func, active: Optional[set[int]] = None):
         defaults_key = _stable_value_key(
             (py_func.__defaults__, py_func.__kwdefaults__), active
         )
-        code_hash = sha256(
-            marshal.dumps(_portable_code(py_func.__code__))
-        ).hexdigest()
         return (
             py_func.__module__,
             py_func.__qualname__,
             sha256(cache_dumps(closure_key)).hexdigest(),
-            code_hash,
+            _code_fingerprint(py_func.__code__),
             sha256(cache_dumps(defaults_key)).hexdigest(),
         )
     finally:

--- a/tests/precompile_plugin.py
+++ b/tests/precompile_plugin.py
@@ -1,4 +1,5 @@
 """Populate and enforce the shared CUDA test-kernel cache."""
+import contextlib
 import importlib
 import os
 from pathlib import Path
@@ -95,6 +96,12 @@ class _FakeDeviceArray(np.ndarray):
 
     def copy_to_device(self, ary, stream=0):
         np.copyto(self, np.asarray(ary).reshape(self.shape))
+
+    def get(self, stream=None, order="C", out=None):
+        if out is not None:
+            np.copyto(out, np.array(self))
+            return out
+        return np.array(self)
 
 
 def _fake_device_array(array):
@@ -475,6 +482,23 @@ if POPULATION:
     _MemoryManager.from_device = _host_copy
     _MemoryManager.get_available_memory = lambda self, group: 8 << 30
     _MemoryManager.get_memory_info = lambda self: (8 << 30, 24 << 30)
+
+    # ArrayInterpolator.get_interpolated stages its kernel arguments
+    # through cupy directly; without a CUDA driver those calls raise
+    # before the launch, so the kernel would never reach the cache.
+    import cubie.array_interpolator as _array_interpolator  # noqa: E402
+
+    @contextlib.contextmanager
+    def _fake_cupy_stream(stream):
+        yield stream
+
+    _array_interpolator.cupy = SimpleNamespace(
+        asarray=lambda a: _fake_device_array(np.array(a, copy=True)),
+        empty=lambda shape, dtype=np.float64: _fake_device_array(
+            np.empty(shape, dtype=dtype)
+        ),
+    )
+    _array_interpolator.current_cupy_stream = _fake_cupy_stream
 
 
 # CuBIE creates a few dispatchers while importing its cache module. Finish

--- a/tests/precompile_plugin.py
+++ b/tests/precompile_plugin.py
@@ -172,7 +172,9 @@ def _host_copy(self, instance, from_arrays, to_arrays, stream=None):
 
 
 STATS = {"cache_hits": 0, "compilations_completed": 0}
+MISSED_KERNELS = []
 _WORKER_STATS = []
+_WORKER_MISSES = []
 _PENDING_DISPATCHERS = []
 _CACHE_STATS_INSTALLED = False
 
@@ -183,6 +185,28 @@ def _combined_stats():
         for key in combined:
             combined[key] += worker_stats.get(key, 0)
     return combined
+
+
+def _combined_misses():
+    combined = list(MISSED_KERNELS)
+    for worker_misses in _WORKER_MISSES:
+        combined.extend(worker_misses)
+    return combined
+
+
+def _describe_compilation(cache, sig):
+    """Name a compiled kernel so cache misses are diagnosable."""
+    function_key = getattr(cache, "_function_key", None)
+    if function_key is not None and len(function_key) >= 5:
+        identity = (
+            f"{function_key[0]}.{function_key[1]} "
+            f"closure={function_key[2][:10]} "
+            f"code={function_key[3][:10]} "
+            f"defaults={function_key[4][:10]}"
+        )
+    else:
+        identity = getattr(cache, "_name", repr(cache))
+    return f"{identity} sig={sig}"
 
 
 def _install_cache_stats():
@@ -203,6 +227,7 @@ def _install_cache_stats():
     def save_overload(self, sig, data):
         result = original_save(self, sig, data)
         STATS["compilations_completed"] += 1
+        MISSED_KERNELS.append(_describe_compilation(self, sig))
         return result
 
     CUBIECache.load_overload = load_overload
@@ -466,11 +491,13 @@ def pytest_configure(config):
 def pytest_testnodedown(node, error):
     if POPULATION:
         return
-    worker_stats = getattr(node, "workeroutput", {}).get(
-        "cubie_kernel_cache_stats"
-    )
+    workeroutput = getattr(node, "workeroutput", {})
+    worker_stats = workeroutput.get("cubie_kernel_cache_stats")
     if worker_stats:
         _WORKER_STATS.append(worker_stats)
+    worker_misses = workeroutput.get("cubie_kernel_cache_misses")
+    if worker_misses:
+        _WORKER_MISSES.append(worker_misses)
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -478,6 +505,9 @@ def pytest_sessionfinish(session, exitstatus):
         return
     if hasattr(session.config, "workeroutput"):
         session.config.workeroutput["cubie_kernel_cache_stats"] = STATS.copy()
+        session.config.workeroutput["cubie_kernel_cache_misses"] = list(
+            MISSED_KERNELS
+        )
         return
     if _combined_stats()["compilations_completed"]:
         session.exitstatus = 1
@@ -492,3 +522,5 @@ def pytest_terminal_summary(terminalreporter):
         "compilations_completed="
         f"{stats['compilations_completed']}"
     )
+    for description in sorted(_combined_misses()):
+        terminalreporter.write_line(f"KERNEL_CACHE MISS {description}")


### PR DESCRIPTION
## Problem

The first full CUDA runs of the refactored precompile → GPU cache pipeline (runs #862/#864) had every GPU leg fail the zero-recompile gate: ~50 cache misses per Python 3.10 leg, 3 per 3.14 leg, despite all tests passing.

## Root causes and fixes (four, layered)

**1. Plugin import path (original scope).** `-p tests.precompile_plugin` is imported during option preparse, before `pythonpath`/conftest machinery touches `sys.path`, and the `pytest` console script does not add the cwd. Both pytest steps export `PYTHONPATH: ${{ github.workspace }}`.

**2. Frozenset marshal ordering (~part of the 3.10 misses).** On CPython < 3.12, `marshal.dumps` writes frozenset code-constants (compiler-folded `in {...}` membership tests) in hash-iteration order, which varies with each process's hash seed. Every pytest process (3 population cc-passes, then the GPU leg) computed different code hashes for any kernel whose reachable code carried one.

**3. marshal `FLAG_REF` refcount sensitivity (the rest of the 3.10 misses).** marshal sets a `FLAG_REF` bit per object based on its *runtime refcount* at dump time, so two dumps of the *same code object* differ depending on what else references its interned name strings — process-context dependent. Python ≥ 3.12 immortalizes identifier strings, which is why 3.14 legs were clean. Proven by byte-diffing two in-run marshal blobs of one code object: they differ only in `0xda` vs `0x5a` type bytes on the freevar names. Fix for 2+3: code objects are no longer marshaled at all — `_code_fingerprint` hashes the repr of a value-only tuple of code attributes (no memoization, no refcounts, no source locations), with frozenset constants normalized to repr-sorted markers.

**4. cupy staging coverage gap (the 3 misses on every leg).** `ArrayInterpolator.get_interpolated` stages kernel arguments through cupy directly; on the driver-less population runners those calls raise before the launch, so its kernel never entered the cache (this worked on dev machines only because a real GPU is present). The population plugin now substitutes a numpy-backed cupy shim and a no-op stream context in `cubie.array_interpolator`.

The consumer leg also now prints a `KERNEL_CACHE MISS <module.qualname> closure=… code=… sig=…` line per compilation, so any future miss is named in the CI log rather than only counted.

## Verification

Local (Python 3.10, RTX 4070 Super):
- Three full-suite populations under different hash seeds and xdist worker counts produce byte-identical key sets (315/315, all pairs).
- A population running entirely on the fakes produces key sets byte-identical to one that staged through real cupy on the GPU (315/315).
- A real-GPU consumer run with coverage enabled: `cache_hits=635 compilations_completed=0` across 2949 tests — the fully cached GPU suite completes in **~42 s** (compiling: ~8 min).

CI ([2-leg trial, run #874](https://github.com/cubiepy/cubie/actions/runs/29786727420)): both GPU legs report `compilations_completed=0`. The 3.10 leg is fully green. The 3.14 leg's single red was `test_custom_stream_close_does_not_wait_for_unrelated_stream` — the warm-process driver-coefficient bug of issue #628, fixed on main by #631 (`72b6b069`), which this branch predated. `origin/main` is now merged in; on code containing the fix the full GPU suite passed 12/12 consecutive local runs (vs ~1-in-4 flaking before the fix).

## Performance gate

Not applicable — the diff touches only workflow YAML and `tests/`; no host or device code changes, so A and B would be byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
