### PR TITLE
fix(ci): GPU coverage records import-time code

### DIFF
--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -273,11 +273,32 @@ jobs:
       - name: Test with pytest
         # -n logical (CLI) overrides pyproject's desktop-safe -n8 so the
         # runner uses all its vCPUs; change the runner instance size freely
-        # and this scales automatically. Coverage/XML report come from addopts.
+        # and this scales automatically.
+        #
+        # Coverage runs under `coverage run` rather than pytest-cov here:
+        # `-p tests.precompile_plugin` imports cubie at plugin-registration
+        # time, before pytest-cov could start, so pytest-cov would miss
+        # every import-time line (package __init__s, cuda_backend
+        # resolution, algorithm tableau tables). `coverage run` traces the
+        # main process from startup; COVERAGE_PROCESS_START traces the
+        # xdist worker subprocesses. --no-cov disables pytest-cov so the
+        # two do not double-count. coverage auto-reads [tool.coverage.*]
+        # from pyproject.toml, so omit/exclude/relative_files still apply.
+        shell: bash
         env:
           CUBIE_KERNEL_CACHE_DIR: ${{ github.workspace }}/kernel-cache/kernels
           CUBIE_MAX_CACHE_ENTRIES: "0"
-        run: pytest -m "not specific_algos and not sim_only" -p tests.precompile_plugin -n logical --junitxml=pytest-results.xml
+          COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml
+        run: |
+          set +e
+          python -m coverage run -m pytest \
+            -m "not specific_algos and not sim_only" \
+            -p tests.precompile_plugin -n logical --no-cov \
+            --junitxml=pytest-results.xml
+          status=$?
+          python -m coverage combine
+          python -m coverage xml -o coverage.xml
+          exit $status
 
       # The artifact service occasionally answers CreateArtifact with a
       # non-JSON error page and the action's five internal retries all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,14 @@ filterwarnings = [
 ]
 
 [tool.coverage.run]
-#source = ["cubie"]
+# Scope measurement to cubie for every entry point: pytest-cov's
+# --cov=cubie locally, and `coverage run` / worker process-startup in
+# GPU CI (which read this instead of the CLI flag).
+source = ["cubie"]
+# Each pytest-xdist worker (and, under `coverage run`, the main
+# process) writes its own data file to combine; required for the GPU
+# CI coverage path that starts coverage before pytest loads.
+parallel = true
 omit = [
     "*/tests/*",
     "*/__pycache__/*",


### PR DESCRIPTION
## Problem

Codecov for `cubiepy/cubie` reads ~70% where it was ~99%. The uploaded
`coverage.xml` from the GPU run genuinely **is** 70.72% (12060/17052
lines) — Codecov is faithful. The org move is a coincidence; the cause
is the precompile-cache CI rework (#638).

## Root cause

The GPU test step loads `-p tests.precompile_plugin`, whose module
scope runs `import cubie` (`tests/precompile_plugin.py:457`, required so
`tests` can import from it). A `-p` plugin is imported during pytest
plugin **registration**, before pytest-cov starts tracing in the xdist
workers. So cubie's entire eager import tree executes **untraced**.

The proof is in the report itself: `src/cubie/__init__.py` is **0/20
covered**. A package `__init__` runs on import, and the tests use cubie
and pass — so it can read 0% only if coverage was not yet tracing when
cubie was imported. The rest of the missing ~30% is the same import-time
code: `cuda_backend.py` 0/30 (resolves the backend at import), the
algorithm tableau constant tables (2–8%), and every subpackage
`__init__.py` at 0%. Runtime logic is unaffected (`odesystems` 80.6%).

The old ~99% runs predate this plugin: cubie was first imported during
test *collection*, after coverage was live, so import-time lines counted.

## Fix

Run the GPU step under `coverage run -m pytest --no-cov` instead of
pytest-cov:

- `coverage run` traces the **main process from interpreter startup**,
  so the plugin's registration-time `import cubie` is captured.
- `COVERAGE_PROCESS_START` (+ coverage's installed `.pth`) traces the
  **xdist worker subprocesses** for runtime coverage.
- `--no-cov` disables pytest-cov so the two do not double-count.
- `[tool.coverage.run]` gains `source = ["cubie"]` and `parallel = true`
  so both entry points (pytest-cov locally, `coverage run` in CI) scope
  to cubie and combine their per-process data files. coverage
  auto-reads `[tool.coverage.*]` from `pyproject.toml`, so the existing
  omit/exclude/`relative_files` still apply.

Setting `COVERAGE_PROCESS_START` alone with pytest-cov does **not** work
— pytest-cov starts its own coverage in `pytest_configure` and discards
the earlier `process_startup` data (verified).

## Verification (reproduced on CPU/CUDASIM — the bug is import-ordering,
not GPU-specific)

| Check | Result |
|---|---|
| status quo (`-p plugin` + pytest-cov) | `cubie/__init__.py` **0%** — reproduces the bug |
| pytest-cov + `COVERAGE_PROCESS_START` | still 0% — rejected |
| **this fix** (`coverage run --no-cov` + combine) | `__init__.py` **85%**, worker runtime traced (2 data files combined) |
| report scoped to cubie | 152 files, **0 non-cubie** (no numpy/numba pollution) |
| `--no-cov` vs `addopts` `--cov` | pytest-cov fully off, no double-count |
| local/nocuda `pytest --cov` with edited config | unchanged — report still produced, cubie-scoped |
| workflow YAML / `pyproject.toml` | parse clean |

Final confirmation belongs to the next real GPU run on this branch: the
uploaded `coverage.xml` should return to ~99%.

## Performance gate

N/A — this changes only `.github/workflows/ci_cuda_tests.yml` and the
`[tool.coverage.run]` config. No device code, compilation, or runtime
path is touched, so kernel timings are unaffected and `ab_gate.py` has
nothing to compare.

## Out of scope (separate, optional)

The two `codecov/codecov-action` steps upload **tokenless** (no `token:`,
never configured). That is not the cause here, but a freshly
org-transferred repo can hit dropped/rate-limited tokenless uploads;
adding a `CODECOV_TOKEN` org secret + `token:` input would make uploads
robust. Independent of this fix.
