### PR TITLE
test: julia golden gate pins one difficult dt/tol per algorithm

### DIFF
--- a/tests/integrated_numerical_tests/julia_reference/conftest.py
+++ b/tests/integrated_numerical_tests/julia_reference/conftest.py
@@ -2,20 +2,17 @@
 
 Solvers and the Lorenz system flow through the shared
 ``solver_settings`` hierarchy: each algorithm under test is one
-``solver_settings_override`` parameter set (see
-``test_julia_reference.py``). The fixtures here pin the vendored
-DifferentialEquations.jl data and run the per-algorithm dt and
-tolerance sweeps the numerical-equivalence protocol requires.
+``solver_settings_override`` parameter set carrying its pinned dt or
+tolerance (see ``test_julia_reference.py``). The fixtures here pin the
+vendored DifferentialEquations.jl data and run the single per-algorithm
+solve the numerical-equivalence protocol requires.
 """
 
 import numpy as np
 import pytest
 
 from tests.integrated_numerical_tests.julia_reference.ne_gate import (
-    DT0_NE,
-    DTS_NE,
     N_NE,
-    TOLS_NE,
     load_reference,
 )
 from tests.system_fixtures import LORENZ_JULIA_STATES
@@ -37,8 +34,19 @@ def golden_ensemble(julia_reference):
     return rho, states, scale
 
 
-def _solve_finals(solver, solver_settings, initials_array, parameter_array):
-    """One solve; returns a copied (N_NE, 3) float32 finals array."""
+@pytest.fixture(scope="function")
+def gate_final(solver, solver_settings, golden_ensemble):
+    """One cubie solve at the pinned settings; (alias, finals).
+
+    The pinned dt or tolerance arrives through the solver settings
+    override, so the session solver compiles once and solves once.
+    Returns (alias, (N_NE, 3) float32 finals).
+    """
+    golden_rho, _, _ = golden_ensemble
+    initials_array, parameter_array = solver.build_grid(
+        initial_values=dict(LORENZ_JULIA_STATES),
+        parameters={'rho': golden_rho},
+    )
     solution = solver.solve(
         initial_values=initials_array,
         parameters=parameter_array,
@@ -58,49 +66,4 @@ def _solve_finals(solver, solver_settings, initials_array, parameter_array):
     if finals.shape != (N_NE, 3):
         raise ValueError(
             "expected ({0}, 3) finals, got {1}".format(N_NE, finals.shape))
-    return finals
-
-
-def _gate_grid(solver, golden_ensemble):
-    """Julia-ensemble input arrays: default initials over the rho grid."""
-    golden_rho, _, _ = golden_ensemble
-    return solver.build_grid(
-        initial_values=dict(LORENZ_JULIA_STATES),
-        parameters={'rho': golden_rho},
-    )
-
-
-@pytest.fixture(scope="function")
-def fixed_sweep(solver_mutable, solver_settings, golden_ensemble):
-    """Cubie fixed-step finals over DTS_NE for the configured algorithm.
-
-    Returns (alias, {dt: (N_NE, 3) float32 finals}).
-    """
-    alias = solver_settings["algorithm"]
-    initials_array, parameter_array = _gate_grid(
-        solver_mutable, golden_ensemble)
-    finals_by_dt = {}
-    for dt in DTS_NE:
-        solver_mutable.update(dt=dt)
-        finals_by_dt[dt] = _solve_finals(
-            solver_mutable, solver_settings, initials_array,
-            parameter_array)
-    return alias, finals_by_dt
-
-
-@pytest.fixture(scope="function")
-def adaptive_matched_sweep(solver_mutable, solver_settings, golden_ensemble):
-    """Cubie adaptive finals over TOLS_NE under Julia-matched control.
-
-    Returns (alias, {tol: (N_NE, 3) float32 finals}).
-    """
-    alias = solver_settings["algorithm"]
-    initials_array, parameter_array = _gate_grid(
-        solver_mutable, golden_ensemble)
-    finals_by_tol = {}
-    for tol in TOLS_NE:
-        solver_mutable.update(atol=tol, rtol=tol, dt=DT0_NE)
-        finals_by_tol[tol] = _solve_finals(
-            solver_mutable, solver_settings, initials_array,
-            parameter_array)
-    return alias, finals_by_tol
+    return solver_settings["algorithm"], finals

--- a/tests/integrated_numerical_tests/julia_reference/ne_gate.py
+++ b/tests/integrated_numerical_tests/julia_reference/ne_gate.py
@@ -62,19 +62,19 @@ FLOOR_REL = 4e-6
 ORDER_CAP_REL = 3e-2
 EQ_CAP_REL = 5e-1
 
-# Exact pairs (identical tableau): mutual rms distance must stay well
-# below the truncation error once above the roundoff floor allowance.
+# Explicit pairs (identical tableau, no inner solves): mutual rms
+# distance must stay well below the truncation error once above the
+# roundoff floor allowance.
 EQ_FRACTION = 0.25
 EQ_FLOOR_MULT = 3.0
 
-# Non-exact pairs (same method class, different tableau): errors of
-# comparable magnitude at the pinned dt.
+# Implicit families: one-sided bound on the golden-referenced error
+# ratio — cubie's error within this factor of the Julia run's.
 RATIO_LIM = 4.0
 
 # Fixed-tier pins require the Julia error to clear the roundoff floor
-# by this multiple, so the two-sided ratio check stays meaningful: a
-# cubie error pinned at the float32 floor still lands on the ratio
-# bound, never below it.
+# by this multiple, so the error ratio at the pin measures truncation
+# behaviour rather than floor noise.
 PIN_MARGIN_MULT = RATIO_LIM
 
 # Adaptive matched-controller tier: the mutual rms distance must not
@@ -87,16 +87,13 @@ def load_algorithms():
     """Return the mutual algorithm table as a list of dicts.
 
     Keys: ``cubie_alias``, ``julia_expr``, ``order`` (int), ``family``,
-    ``exact`` (bool — identical tableau on both sides, so per-trajectory
-    equivalence is expected rather than just matching order/error
-    magnitude), ``notes``.
+    ``notes``.
     """
     path = os.path.join(DATA_DIR, "algorithms.csv")
     with open(path, newline="", encoding="utf-8") as f:
         rows = list(csv.DictReader(f))
     for row in rows:
         row["order"] = int(row["order"])
-        row["exact"] = row["exact"].strip().lower() == "true"
     return rows
 
 

--- a/tests/integrated_numerical_tests/julia_reference/ne_gate.py
+++ b/tests/integrated_numerical_tests/julia_reference/ne_gate.py
@@ -191,8 +191,7 @@ def ensemble_error(final_states, golden_states):
 
 def rms_difference(cubie_final, julia_final):
     """Mutual rms distance between the two final-state ensembles."""
-    with np.errstate(invalid="ignore", over="ignore"):
-        diff = np.asarray(cubie_final, dtype=np.float64) - julia_final
+    diff = np.asarray(cubie_final, dtype=np.float64) - julia_final
     return float(np.sqrt(np.mean(diff ** 2)))
 
 
@@ -249,7 +248,7 @@ def adaptive_pin(reference, alias, golden_states, scale):
 
 
 def fixed_point_verdict(cubie_final, julia_final, golden_states, scale,
-                        exact, implicit):
+                        implicit):
     """Single-point verdict for the fixed tier at the pinned dt.
 
     Returns (ok, report). Implicit-family algorithms (implicit, dirk,
@@ -259,12 +258,9 @@ def fixed_point_verdict(cubie_final, julia_final, golden_states, scale,
     tolerances, which leaves an inner-solve floor in their error
     (issue #641); cubie's derived inner tolerances are tighter, so
     beating the Julia error is expected and per-trajectory
-    equivalence is unattainable. Explicit exact pairs (identical
-    tableau, no inner solves) must agree per-trajectory: mutual rms
-    distance within EQ_FRACTION of the truncation error. Explicit
-    non-exact pairs (same method class, different tableau) must land
-    errors of comparable magnitude: the error ratio inside RATIO_LIM
-    both ways.
+    equivalence is unattainable. Explicit pairs carry identical
+    tableaus and no inner solves, so they must agree per-trajectory:
+    mutual rms distance within EQ_FRACTION of the truncation error.
     """
     floor = FLOOR_REL * scale
     err_c = ensemble_error(cubie_final, golden_states)
@@ -275,19 +271,15 @@ def fixed_point_verdict(cubie_final, julia_final, golden_states, scale,
         "(floor={3:.3e})".format(err_c, err_j, rms_diff, floor))
     if not np.isfinite(err_c):
         return False, report
-    ratio = err_c / err_j
     if implicit:
+        ratio = err_c / err_j
         return ratio < RATIO_LIM, (
             "{0}; error ratio {1:.3g}, limit {2:g} one-sided".format(
                 report, ratio, RATIO_LIM))
-    if exact:
-        bound = max(EQ_FRACTION * max(err_c, err_j),
-                    EQ_FLOOR_MULT * floor)
-        return rms_diff <= bound, "{0}; equivalence bound {1:.3e}".format(
-            report, bound)
-    return (1.0 / RATIO_LIM < ratio < RATIO_LIM), (
-        "{0}; error ratio {1:.3g}, limit {2:g} both ways".format(
-            report, ratio, RATIO_LIM))
+    bound = max(EQ_FRACTION * max(err_c, err_j),
+                EQ_FLOOR_MULT * floor)
+    return rms_diff <= bound, "{0}; equivalence bound {1:.3e}".format(
+        report, bound)
 
 
 def adaptive_point_verdict(cubie_final, julia_final, golden_states, scale):

--- a/tests/integrated_numerical_tests/julia_reference/ne_gate.py
+++ b/tests/integrated_numerical_tests/julia_reference/ne_gate.py
@@ -70,12 +70,12 @@ EQ_FLOOR_MULT = 3.0
 
 # Implicit families: one-sided bound on the golden-referenced error
 # ratio — cubie's error within this factor of the Julia run's.
-RATIO_LIM = 4.0
+RATIO_LIM = 2.0
 
 # Fixed-tier pins require the Julia error to clear the roundoff floor
 # by this multiple, so the error ratio at the pin measures truncation
 # behaviour rather than floor noise.
-PIN_MARGIN_MULT = RATIO_LIM
+PIN_MARGIN_MULT = 4.0
 
 # Adaptive matched-controller tier: the mutual rms distance must not
 # exceed this multiple of the Julia run's own error at any in-range

--- a/tests/integrated_numerical_tests/julia_reference/ne_gate.py
+++ b/tests/integrated_numerical_tests/julia_reference/ne_gate.py
@@ -8,6 +8,15 @@ and their final states are judged against a Float64 golden reference
 (Vern9 at tol 1e-13) and against each other. The Julia and golden data
 are vendored under ``data/`` by ``benchmarks/vendor_julia_reference.py``.
 
+The vendored data covers full dt and tolerance sweeps; the gate solves
+each algorithm once, at a single pinned dt (fixed tier) or tolerance
+(adaptive tier) selected from the Julia data at the difficult end of
+the convergence region. At that pin the truncation error is a steep
+function of the method's order — a dropped order inflates it by
+``(1/dt)`` per lost power, orders of magnitude beyond the ratio bound —
+so one solve detects any drift from the textbook scheme that a full
+sweep would.
+
 Keep the constants in sync with the GPUODEBenchmarks protocol; the gate
 is only meaningful while both sides integrate bit-identical inputs on
 the same grids.
@@ -58,10 +67,15 @@ EQ_CAP_REL = 5e-1
 EQ_FRACTION = 0.25
 EQ_FLOOR_MULT = 3.0
 
-# Non-exact pairs (same method class, different tableau): same observed
-# order and errors of comparable magnitude.
-ORDER_TOL = 0.6
+# Non-exact pairs (same method class, different tableau): errors of
+# comparable magnitude at the pinned dt.
 RATIO_LIM = 4.0
+
+# Fixed-tier pins require the Julia error to clear the roundoff floor
+# by this multiple, so the two-sided ratio check stays meaningful: a
+# cubie error pinned at the float32 floor still lands on the ratio
+# bound, never below it.
+PIN_MARGIN_MULT = RATIO_LIM
 
 # Adaptive matched-controller tier: the mutual rms distance must not
 # exceed this multiple of the Julia run's own error at any in-range
@@ -175,152 +189,120 @@ def ensemble_error(final_states, golden_states):
     return float(np.sqrt(np.mean(diff ** 2)))
 
 
-def observed_orders(errs_by_dt, floor, cap):
-    """Median log2 error ratio between successive dt halvings in-region."""
-    orders = []
-    for k in range(len(DTS_NE) - 1):
-        d1, d2 = DTS_NE[k], DTS_NE[k + 1]
-        if d1 in errs_by_dt and d2 in errs_by_dt:
-            e1, e2 = errs_by_dt[d1], errs_by_dt[d2]
-            if (np.isfinite(e1) and np.isfinite(e2)
-                    and floor < e1 < cap and floor < e2 < cap and e2 > 0):
-                orders.append(np.log2(e1 / e2))
-    return float(np.median(orders)) if orders else float("nan")
+def rms_difference(cubie_final, julia_final):
+    """Mutual rms distance between the two final-state ensembles."""
+    with np.errstate(invalid="ignore", over="ignore"):
+        diff = np.asarray(cubie_final, dtype=np.float64) - julia_final
+    return float(np.sqrt(np.mean(diff ** 2)))
 
 
-def fixed_points(cubie_finals, julia_finals, golden_states):
-    """Per-dt error table: (dt, err_cubie, err_julia, rms_diff)."""
-    points = []
+def fixed_pin(reference, alias, golden_states, scale):
+    """Pinned dt for one algorithm's fixed-tier check.
+
+    Walks the dt grid coarse to fine and returns the finest dt of the
+    contiguous run where the Julia error sits inside the convergence
+    region: at least PIN_MARGIN_MULT times the roundoff floor and
+    below the order cap. Later dts that dip back into range past a
+    break belong to the flat roundoff-dominated tail, not to the
+    asymptotic regime the pin must sample. Raises when no dt
+    qualifies (the vendored data no longer covers the region).
+    """
+    floor = FLOOR_REL * scale
+    cap = ORDER_CAP_REL * scale
+    errs = {dt: ensemble_error(final, golden_states)
+            for dt, final in julia_fixed_finals(reference, alias).items()}
+    pin = None
     for dt in DTS_NE:
-        fc = cubie_finals.get(dt)
-        fj = julia_finals.get(dt)
-        err_c = ensemble_error(fc, golden_states) if fc is not None else None
-        err_j = ensemble_error(fj, golden_states) if fj is not None else None
-        rms_diff = None
-        if fc is not None and fj is not None:
-            with np.errstate(invalid="ignore", over="ignore"):
-                d = np.asarray(fc, dtype=np.float64) - fj
-            rms_diff = float(np.sqrt(np.mean(d ** 2)))
-        points.append((dt, err_c, err_j, rms_diff))
-    return points
+        err = errs.get(dt)
+        if (err is not None and np.isfinite(err)
+                and PIN_MARGIN_MULT * floor <= err < cap):
+            pin = dt
+        elif pin is not None:
+            break
+    if pin is None:
+        raise ValueError(
+            "no in-region dt for '{0}'; regenerate data/ with "
+            "benchmarks/vendor_julia_reference.py".format(alias))
+    return pin
 
 
-def fixed_verdict(points, exact, scale):
-    """Verdict for one algorithm's fixed sweep.
+def adaptive_pin(reference, alias, golden_states, scale):
+    """Pinned tolerance for one algorithm's adaptive-tier check.
 
-    Returns (verdict, order_cubie, order_julia). EQUIVALENT: identical
-    tableau and mutual rms difference below EQ_FRACTION of the truncation
-    error at every in-region dt. CONSISTENT: different tableau of the
-    same order; observed orders and error magnitudes agree. MISMATCH:
-    neither holds. INSUFFICIENT OVERLAP: fewer than two dts where both
-    sides landed in the comparable-error region.
-    """
-    floor = FLOOR_REL * scale
-    order_cap = ORDER_CAP_REL * scale
-    eq_cap = EQ_CAP_REL * scale
-
-    order_c = observed_orders(
-        {dt: e for dt, e, _, _ in points if e is not None},
-        floor, order_cap)
-    order_j = observed_orders(
-        {dt: e for dt, _, e, _ in points if e is not None},
-        floor, order_cap)
-
-    checked = 0
-    julia_valid = 0
-    ok = True
-    for dt, err_c, err_j, rms_diff in points:
-        if err_c is None or err_j is None:
-            continue
-        if np.isfinite(err_j) and floor < err_j < eq_cap:
-            julia_valid += 1
-        if not np.isfinite(err_c) or not np.isfinite(err_j):
-            continue
-        emax = max(err_c, err_j)
-        if not (floor < emax < eq_cap):
-            continue
-        checked += 1
-        if exact:
-            if rms_diff > max(EQ_FRACTION * emax, EQ_FLOOR_MULT * floor):
-                ok = False
-        else:
-            ratio = err_c / err_j if err_j > 0 else float("inf")
-            if not (1.0 / RATIO_LIM < ratio < RATIO_LIM):
-                ok = False
-    if not exact and np.isfinite(order_c) and np.isfinite(order_j):
-        if abs(order_c - order_j) > ORDER_TOL:
-            ok = False
-
-    if checked < 2:
-        # Julia produced sane in-region errors that cubie never matched
-        # anywhere (out-of-region / non-finite): that is divergence, not
-        # missing data.
-        verdict = ("MISMATCH" if julia_valid >= 2
-                   else "INSUFFICIENT OVERLAP")
-    elif ok:
-        verdict = "EQUIVALENT" if exact else "CONSISTENT"
-    else:
-        verdict = "MISMATCH"
-    return verdict, order_c, order_j
-
-
-def matched_verdict(cubie_by_tol, julia_by_tol, golden_states, scale):
-    """Verdict for the adaptive matched-controller tier.
-
-    Returns (verdict, worst_ratio). TRACKING when the mutual rms distance
-    stays within ADAPTIVE_EQ_FRACTION of the Julia run's own error at
-    every tolerance where the Julia solve is in a sane range.
+    Returns the tightest tolerance where the Julia solve's own error
+    is in the sane range the tracking check divides by. Raises when
+    no tolerance qualifies.
     """
     floor = FLOOR_REL * scale
     eq_cap = EQ_CAP_REL * scale
-    checked = 0
-    worst = 0.0
-    for tol in TOLS_NE:
-        fj = julia_by_tol.get(tol)
-        fc = cubie_by_tol.get(tol)
-        if fj is None or fc is None:
-            continue
-        err_j = ensemble_error(fj, golden_states)
-        if not np.isfinite(err_j) or not (floor < err_j < eq_cap):
-            continue
-        with np.errstate(invalid="ignore", over="ignore"):
-            d = np.asarray(fc, dtype=np.float64) - fj
-        rms_diff = float(np.sqrt(np.mean(d ** 2)))
-        checked += 1
-        worst = max(worst, rms_diff / max(err_j, EQ_FLOOR_MULT * floor))
-    if checked == 0:
-        return "INSUFFICIENT OVERLAP", worst
-    if worst <= ADAPTIVE_EQ_FRACTION:
-        return "TRACKING", worst
-    return "DIVERGENT", worst
+    errs = {tol: ensemble_error(final, golden_states)
+            for tol, final
+            in julia_adaptive_finals(reference, alias).items()}
+    in_range = [tol for tol in TOLS_NE
+                if tol in errs and np.isfinite(errs[tol])
+                and floor < errs[tol] < eq_cap]
+    if not in_range:
+        raise ValueError(
+            "no in-range tolerance for '{0}'; regenerate data/ with "
+            "benchmarks/vendor_julia_reference.py".format(alias))
+    return min(in_range)
 
 
-def _fmt(value, spec="{0:.3e}"):
-    return spec.format(value) if value is not None else "-"
+def fixed_point_verdict(cubie_final, julia_final, golden_states, scale,
+                        exact, implicit):
+    """Single-point verdict for the fixed tier at the pinned dt.
+
+    Returns (ok, report). Implicit-family algorithms (implicit, dirk,
+    firk, rosenbrock) are held to a one-sided accuracy bound: cubie's
+    golden-referenced error within RATIO_LIM of Julia's. The Julia
+    fixed-step runs solve their stages at OrdinaryDiffEq's default
+    tolerances, which leaves an inner-solve floor in their error
+    (issue #641); cubie's derived inner tolerances are tighter, so
+    beating the Julia error is expected and per-trajectory
+    equivalence is unattainable. Explicit exact pairs (identical
+    tableau, no inner solves) must agree per-trajectory: mutual rms
+    distance within EQ_FRACTION of the truncation error. Explicit
+    non-exact pairs (same method class, different tableau) must land
+    errors of comparable magnitude: the error ratio inside RATIO_LIM
+    both ways.
+    """
+    floor = FLOOR_REL * scale
+    err_c = ensemble_error(cubie_final, golden_states)
+    err_j = ensemble_error(julia_final, golden_states)
+    rms_diff = rms_difference(cubie_final, julia_final)
+    report = (
+        "err_cubie={0:.3e} err_julia={1:.3e} rms_diff={2:.3e} "
+        "(floor={3:.3e})".format(err_c, err_j, rms_diff, floor))
+    if not np.isfinite(err_c):
+        return False, report
+    ratio = err_c / err_j
+    if implicit:
+        return ratio < RATIO_LIM, (
+            "{0}; error ratio {1:.3g}, limit {2:g} one-sided".format(
+                report, ratio, RATIO_LIM))
+    if exact:
+        bound = max(EQ_FRACTION * max(err_c, err_j),
+                    EQ_FLOOR_MULT * floor)
+        return rms_diff <= bound, "{0}; equivalence bound {1:.3e}".format(
+            report, bound)
+    return (1.0 / RATIO_LIM < ratio < RATIO_LIM), (
+        "{0}; error ratio {1:.3g}, limit {2:g} both ways".format(
+            report, ratio, RATIO_LIM))
 
 
-def fixed_table(points):
-    """Human-readable per-dt error table for assertion messages."""
-    lines = ["dt           err_cubie   err_julia   rms_diff"]
-    for dt, err_c, err_j, rms_diff in points:
-        lines.append("{0:<12.10g} {1:<11s} {2:<11s} {3}".format(
-            dt, _fmt(err_c), _fmt(err_j), _fmt(rms_diff)))
-    return "\n".join(lines)
+def adaptive_point_verdict(cubie_final, julia_final, golden_states, scale):
+    """Single-point verdict for the adaptive tier at the pinned tol.
 
-
-def adaptive_table(cubie_by_tol, julia_by_tol, golden_states):
-    """Human-readable per-tolerance error table for assertion messages."""
-    lines = ["tol      err_cubie   err_julia   rms_diff"]
-    for tol in TOLS_NE:
-        fc = cubie_by_tol.get(tol)
-        fj = julia_by_tol.get(tol)
-        err_c = ensemble_error(fc, golden_states) if fc is not None else None
-        err_j = ensemble_error(fj, golden_states) if fj is not None else None
-        rms_diff = None
-        if fc is not None and fj is not None:
-            with np.errstate(invalid="ignore", over="ignore"):
-                d = np.asarray(fc, dtype=np.float64) - fj
-            rms_diff = float(np.sqrt(np.mean(d ** 2)))
-        lines.append("{0:<8.0e} {1:<11s} {2:<11s} {3}".format(
-            tol, _fmt(err_c), _fmt(err_j), _fmt(rms_diff)))
-    return "\n".join(lines)
+    Returns (ok, report). The mutual rms distance must stay within
+    ADAPTIVE_EQ_FRACTION of the Julia run's own error.
+    """
+    floor = FLOOR_REL * scale
+    err_j = ensemble_error(julia_final, golden_states)
+    err_c = ensemble_error(cubie_final, golden_states)
+    rms_diff = rms_difference(cubie_final, julia_final)
+    worst = rms_diff / max(err_j, EQ_FLOOR_MULT * floor)
+    report = (
+        "err_cubie={0:.3e} err_julia={1:.3e} rms_diff={2:.3e}; "
+        "rms/err ratio {3:.3g}, limit {4:g}".format(
+            err_c, err_j, rms_diff, worst, ADAPTIVE_EQ_FRACTION))
+    return worst <= ADAPTIVE_EQ_FRACTION, report

--- a/tests/integrated_numerical_tests/julia_reference/test_julia_reference.py
+++ b/tests/integrated_numerical_tests/julia_reference/test_julia_reference.py
@@ -52,11 +52,6 @@ def _collect_pins():
         scale = float(np.sqrt(np.mean(golden ** 2)))
         keys = set(archive.files)
         for alias, row in ALGORITHMS.items():
-            if row["family"] == "erk" and not row["exact"]:
-                raise ValueError(
-                    "'{0}' is explicit with a non-identical tableau; "
-                    "the protocol defines no check for that "
-                    "combination".format(alias))
             fixed_pins[alias] = fixed_pin(archive, alias, golden, scale)
             if not algorithm_is_adaptive(alias):
                 continue
@@ -156,11 +151,9 @@ def test_fixed_step_matches_julia(gate_final, julia_reference,
         row["family"] != "erk")
 
     assert ok, (
-        "{0} (order {1}, {2}, {3}) deviates from Julia at dt={4:g}: "
-        "{5}".format(
-            alias, row["order"], row["julia_expr"],
-            "exact tableau" if row["exact"] else "same class", pin,
-            report))
+        "{0} (order {1}, {2}) deviates from Julia at dt={3:g}: "
+        "{4}".format(
+            alias, row["order"], row["julia_expr"], pin, report))
 
 
 @pytest.mark.parametrize(

--- a/tests/integrated_numerical_tests/julia_reference/test_julia_reference.py
+++ b/tests/integrated_numerical_tests/julia_reference/test_julia_reference.py
@@ -1,14 +1,19 @@
 """Golden-reference gate: cubie vs DifferentialEquations.jl.
 
-Fixed-step Float32 convergence study and adaptive matched-controller
-study on the Lorenz ensemble (N=1024, rho in [0, 21], t in [0, 1]).
-Cubie integrates the same bit-identical Float32 inputs as the vendored
-DifferentialEquations.jl sweeps; final states are judged against the
-Float64 golden reference (Vern9, tol 1e-13) and against the Julia
-implementation per algorithm. Protocol, thresholds, and provenance:
-``ne_gate.py`` and ``data/README.md``.
+Single-solve Float32 checks on the Lorenz ensemble (N=1024, rho in
+[0, 21], t in [0, 1]): per algorithm, one fixed-step solve at a pinned
+difficult dt and one adaptive solve under Julia-matched control at a
+pinned tight tolerance. Cubie integrates the same bit-identical
+Float32 inputs as the vendored DifferentialEquations.jl sweeps; final
+states are judged against the Float64 golden reference (Vern9, tol
+1e-13) and against the Julia implementation at the pin. At the pinned
+dt a dropped order inflates the truncation error by ``1/dt`` per lost
+power, so the single solve catches drift from the textbook scheme.
+Protocol, pin selection, thresholds, and provenance: ``ne_gate.py``
+and ``data/README.md``.
 """
 
+import numpy as np
 import pytest
 
 from cubie.integrators.algorithms import algorithm_is_adaptive
@@ -18,25 +23,49 @@ from tests.integrated_numerical_tests.julia_reference.ne_gate import (
     DT0_NE,
     DT_MIN_NE,
     DT_MAX_NE,
-    DTS_NE,
     RTOL_FIXED_NE,
-    TOLS_NE,
-    adaptive_table,
-    fixed_points,
-    fixed_table,
-    fixed_verdict,
+    adaptive_pin,
+    adaptive_point_verdict,
+    fixed_pin,
+    fixed_point_verdict,
     julia_adaptive_finals,
     julia_fixed_finals,
     load_algorithms,
     load_controller_constants,
     load_reference,
     matched_controller_settings,
-    matched_verdict,
 )
 
 pytestmark = pytest.mark.nocudasim
 
 ALGORITHMS = {row["cubie_alias"]: row for row in load_algorithms()}
+
+_ADAPTIVE_CONSTANTS = load_controller_constants()
+
+
+def _collect_pins():
+    """Per-alias pinned dt and tolerance from the vendored data."""
+    fixed_pins = {}
+    adaptive_pins = {}
+    with load_reference() as archive:
+        golden = archive["golden_states"].astype(np.float64)
+        scale = float(np.sqrt(np.mean(golden ** 2)))
+        keys = set(archive.files)
+        for alias, row in ALGORITHMS.items():
+            fixed_pins[alias] = fixed_pin(archive, alias, golden, scale)
+            if not algorithm_is_adaptive(alias):
+                continue
+            if "adaptive_{0}_tols".format(alias) not in keys:
+                continue
+            if matched_controller_settings(
+                    _ADAPTIVE_CONSTANTS, alias, row["order"]) is None:
+                continue
+            adaptive_pins[alias] = adaptive_pin(
+                archive, alias, golden, scale)
+    return fixed_pins, adaptive_pins
+
+
+FIXED_PINS, ADAPTIVE_PINS = _collect_pins()
 
 # Shared solve pins for every gate run: the protocol saves only the
 # final state of all three Lorenz states at t = 1.0, and leaves the
@@ -62,12 +91,12 @@ _GATE_BASE_OVERRIDE = {
 
 
 def _fixed_override(alias):
-    """Solver settings for one algorithm's fixed-step sweep."""
+    """Solver settings for one algorithm's pinned fixed-step solve."""
     override = dict(_GATE_BASE_OVERRIDE)
     override.update(
         algorithm=alias,
         step_controller="fixed",
-        dt=DTS_NE[0],
+        dt=FIXED_PINS[alias],
         atol=ATOL_FIXED_NE,
         rtol=RTOL_FIXED_NE,
     )
@@ -75,43 +104,42 @@ def _fixed_override(alias):
 
 
 def _adaptive_override(alias, matched):
-    """Solver settings for one algorithm's matched-controller sweep."""
+    """Solver settings for one algorithm's pinned adaptive solve."""
     override = dict(_GATE_BASE_OVERRIDE)
     override.update(
         algorithm=alias,
         dt=DT0_NE,
         dt_min=DT_MIN_NE,
         dt_max=DT_MAX_NE,
-        atol=TOLS_NE[0],
-        rtol=TOLS_NE[0],
+        atol=ADAPTIVE_PINS[alias],
+        rtol=ADAPTIVE_PINS[alias],
     )
     override.update(matched)
     return override
 
 
-def _adaptive_aliases():
-    """Aliases in the mutual adaptive set with a mappable controller."""
-    constants = load_controller_constants()
-    with load_reference() as archive:
-        keys = set(archive.files)
-    aliases = []
-    for alias, row in ALGORITHMS.items():
-        if not algorithm_is_adaptive(alias):
-            continue
-        if "adaptive_{0}_tols".format(alias) not in keys:
-            continue
-        if matched_controller_settings(
-                constants, alias, row["order"]) is None:
-            continue
-        aliases.append(alias)
-    return aliases
+# radau_iia_5 deviates on both tiers (NaN-stained fixed solve at the
+# pin, adaptive error frozen at ~1.49 under matched control) — a
+# FIRK-solve-path deviation tracked on #648. Non-strict so the fix
+# surfaces as XPASS without breaking the gate.
+_KNOWN_DEVIATIONS = {
+    "radau_iia_5": pytest.mark.xfail(
+        reason="FIRK solve path deviates from the Julia reference "
+        "on both tiers (#648)",
+        strict=False,
+    ),
+}
+
+
+def _marks(alias):
+    return [_KNOWN_DEVIATIONS[alias]] if alias in _KNOWN_DEVIATIONS else []
 
 
 FIXED_PARAMS = [
-    pytest.param(_fixed_override(alias), id=alias) for alias in ALGORITHMS
+    pytest.param(_fixed_override(alias), id=alias, marks=_marks(alias))
+    for alias in ALGORITHMS
 ]
 
-_ADAPTIVE_CONSTANTS = load_controller_constants()
 ADAPTIVE_PARAMS = [
     pytest.param(
         _adaptive_override(
@@ -120,46 +148,48 @@ ADAPTIVE_PARAMS = [
                 _ADAPTIVE_CONSTANTS, alias, ALGORITHMS[alias]["order"]),
         ),
         id=alias,
+        marks=_marks(alias),
     )
-    for alias in _adaptive_aliases()
+    for alias in ADAPTIVE_PINS
 ]
 
 
 @pytest.mark.parametrize(
     "solver_settings_override", FIXED_PARAMS, indirect=True)
-def test_fixed_step_matches_julia(fixed_sweep, julia_reference,
+def test_fixed_step_matches_julia(gate_final, julia_reference,
                                   golden_ensemble):
-    """Fixed-step sweep converges like, and agrees with, the Julia side."""
-    alias, cubie_finals = fixed_sweep
+    """Pinned fixed-step solve agrees with the Julia side."""
+    alias, cubie_final = gate_final
     row = ALGORITHMS[alias]
     _, golden_states, scale = golden_ensemble
-    julia_finals = julia_fixed_finals(julia_reference, alias)
+    pin = FIXED_PINS[alias]
+    julia_final = julia_fixed_finals(julia_reference, alias)[pin]
 
-    points = fixed_points(cubie_finals, julia_finals, golden_states)
-    verdict, order_c, order_j = fixed_verdict(points, row["exact"], scale)
+    ok, report = fixed_point_verdict(
+        cubie_final, julia_final, golden_states, scale, row["exact"],
+        row["family"] != "erk")
 
-    expected = "EQUIVALENT" if row["exact"] else "CONSISTENT"
-    assert verdict == expected, (
-        "{0} (order {1}, {2}): verdict {3}, expected {4}.\n"
-        "Observed order cubie={5:.2f} julia={6:.2f}.\n{7}".format(
-            alias, row["order"], row["julia_expr"], verdict, expected,
-            order_c, order_j, fixed_table(points)))
+    assert ok, (
+        "{0} (order {1}, {2}, {3}) deviates from Julia at dt={4:g}: "
+        "{5}".format(
+            alias, row["order"], row["julia_expr"],
+            "exact tableau" if row["exact"] else "same class", pin,
+            report))
 
 
 @pytest.mark.parametrize(
     "solver_settings_override", ADAPTIVE_PARAMS, indirect=True)
 def test_adaptive_matched_controller_tracks_julia(
-        adaptive_matched_sweep, julia_reference, golden_ensemble):
-    """Adaptive solve under Julia-matched control tracks the Julia side."""
-    alias, cubie_by_tol = adaptive_matched_sweep
+        gate_final, julia_reference, golden_ensemble):
+    """Pinned adaptive solve under Julia-matched control tracks Julia."""
+    alias, cubie_final = gate_final
     _, golden_states, scale = golden_ensemble
-    julia_by_tol = julia_adaptive_finals(julia_reference, alias)
+    pin = ADAPTIVE_PINS[alias]
+    julia_final = julia_adaptive_finals(julia_reference, alias)[pin]
 
-    verdict, worst = matched_verdict(
-        cubie_by_tol, julia_by_tol, golden_states, scale)
+    ok, report = adaptive_point_verdict(
+        cubie_final, julia_final, golden_states, scale)
 
-    assert verdict == "TRACKING", (
-        "{0}: matched-controller verdict {1} (worst rms/err ratio "
-        "{2:.3g}).\n{3}".format(
-            alias, verdict, worst,
-            adaptive_table(cubie_by_tol, julia_by_tol, golden_states)))
+    assert ok, (
+        "{0} diverges from Julia under matched control at tol={1:g}: "
+        "{2}".format(alias, pin, report))

--- a/tests/integrated_numerical_tests/julia_reference/test_julia_reference.py
+++ b/tests/integrated_numerical_tests/julia_reference/test_julia_reference.py
@@ -52,6 +52,11 @@ def _collect_pins():
         scale = float(np.sqrt(np.mean(golden ** 2)))
         keys = set(archive.files)
         for alias, row in ALGORITHMS.items():
+            if row["family"] == "erk" and not row["exact"]:
+                raise ValueError(
+                    "'{0}' is explicit with a non-identical tableau; "
+                    "the protocol defines no check for that "
+                    "combination".format(alias))
             fixed_pins[alias] = fixed_pin(archive, alias, golden, scale)
             if not algorithm_is_adaptive(alias):
                 continue
@@ -118,26 +123,8 @@ def _adaptive_override(alias, matched):
     return override
 
 
-# radau_iia_5 deviates on both tiers (NaN-stained fixed solve at the
-# pin, adaptive error frozen at ~1.49 under matched control) — a
-# FIRK-solve-path deviation tracked on #648. Non-strict so the fix
-# surfaces as XPASS without breaking the gate.
-_KNOWN_DEVIATIONS = {
-    "radau_iia_5": pytest.mark.xfail(
-        reason="FIRK solve path deviates from the Julia reference "
-        "on both tiers (#648)",
-        strict=False,
-    ),
-}
-
-
-def _marks(alias):
-    return [_KNOWN_DEVIATIONS[alias]] if alias in _KNOWN_DEVIATIONS else []
-
-
 FIXED_PARAMS = [
-    pytest.param(_fixed_override(alias), id=alias, marks=_marks(alias))
-    for alias in ALGORITHMS
+    pytest.param(_fixed_override(alias), id=alias) for alias in ALGORITHMS
 ]
 
 ADAPTIVE_PARAMS = [
@@ -148,7 +135,6 @@ ADAPTIVE_PARAMS = [
                 _ADAPTIVE_CONSTANTS, alias, ALGORITHMS[alias]["order"]),
         ),
         id=alias,
-        marks=_marks(alias),
     )
     for alias in ADAPTIVE_PINS
 ]
@@ -166,7 +152,7 @@ def test_fixed_step_matches_julia(gate_final, julia_reference,
     julia_final = julia_fixed_finals(julia_reference, alias)[pin]
 
     ok, report = fixed_point_verdict(
-        cubie_final, julia_final, golden_states, scale, row["exact"],
+        cubie_final, julia_final, golden_states, scale,
         row["family"] != "erk")
 
     assert ok, (


### PR DESCRIPTION
## Summary

The Julia golden-reference gate solves each algorithm **once** instead of sweeping the full dt and tolerance grids, making it a practical per-PR CI gate: **~40 s wall on a desktop GPU** (was ~5 min), 34 passed / 3 failed.

- **Fixed tier** pins the finest dt of the contiguous convergence region in the vendored Julia data (Julia error at least `PIN_MARGIN_MULT x` the roundoff floor, below the order cap, walked coarse to fine without crossing a break). At that pin a dropped order inflates the error by `1/dt` per lost power — 2^3 to 2^13 depending on the method — far beyond the verdict bound, so one solve catches drift from the textbook scheme that the sweep-and-order-fit previously required 13 solves to see.
- **Adaptive tier** pins the tightest tolerance where the Julia solve's own error is in the sane range of the tracking check.
- Pins are derived deterministically from the vendored data at collection, so regenerating `data/` re-derives them; no hand-maintained table.

## Verdicts

- **Explicit (erk)** algorithms keep the per-trajectory rms equivalence check — identical tableaus and no inner solves on either side.
- **Implicit families** (implicit/dirk/firk/rosenbrock) are held to a one-sided accuracy bound: `err_cubie < 2 x err_julia` against the golden. The Julia fixed-step reference solves its stages at OrdinaryDiffEq default tolerances and carries an inner-solve error floor (#641), so cubie's tighter derived inner tolerances legitimately beat it (e.g. kvaerno5: cubie 7.7e-6 vs Julia 4.1e-4) and per-trajectory equivalence is unattainable there; being worse than twice the reference error fails.
- **Failures are loud** — no xfails, no warning suppression.

## Test results (RTX desktop, real GPU)

```
34 passed, 3 failed in ~40 s
FAILED test_fixed_step_matches_julia[radau_iia_5]                  NaN at pin (#648)
FAILED test_adaptive_matched_controller_tracks_julia[radau_iia_5]  err frozen at 1.489 (#648)
FAILED test_fixed_step_matches_julia[rodas3p]                      2.31x reference error (#641)
```

## Notes

- Stacked on #642 (`test/julia-golden-gate`); retargets to main automatically when #642 merges. The tests import `algorithm_is_adaptive`, which #642 adds.
- The vendored sweep data is unchanged — pins are selected from it, and the full grids remain available for offline investigation.
- Tests-only diff; no src changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)