### PR TITLE
ci: precompile lanes fail on pytest crashes and empty kernel caches

### DIFF
--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -152,6 +152,12 @@ jobs:
           PYTHONOPTIMIZE: "1"
         run: |
           set -u
+          # Exit 1 is tolerated: test verdicts are meaningless on
+          # headless placeholder results, only compile coverage
+          # matters. But a crash before the test session (e.g. an
+          # import error in cubie or the plugin) also exits 1, so
+          # each pass must prove a session ran by writing its junit
+          # report, and the lane must end with kernels in the cache.
           for cc in 7.5 8.6 8.9; do
             echo "::group::precompile cc=$cc"
             set +e
@@ -159,14 +165,23 @@ jobs:
               -m "not specific_algos and not sim_only" \
               -p tests.precompile_plugin -n logical \
               --assert=plain \
+              --junitxml="precompile-junit-$cc.xml" \
               --no-cov -q -p no:cacheprovider
             status=$?
             set -e
             if [ "$status" -gt 1 ]; then
               exit "$status"
             fi
+            if [ ! -s "precompile-junit-$cc.xml" ]; then
+              echo "pytest exited $status without running a test session for cc=$cc" >&2
+              exit 1
+            fi
             echo "::endgroup::"
           done
+          if [ -z "$(find kernel-cache/kernels -type f -print -quit 2>/dev/null)" ]; then
+            echo "precompile produced no cached kernels in kernel-cache/kernels" >&2
+            exit 1
+          fi
 
       - name: Upload kernel cache
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Problem

The mlir precompile lanes in the CUDA matrix went green while compiling zero kernels. `tests/precompile_plugin.py` imports the backend at plugin load, and `cubie-numba-cuda-mlir==0.4.1.1`'s `_cext` raises `RuntimeError: Failed to load the CUDA dynamic library` on driverless CPU runners (the wheel predates fork PR ccam80/numba-cuda-mlir#226, which makes a missing driver non-fatal at import; a fixed wheel is being published separately). The crash exits pytest with code 1 — the same code as the tolerated headless test failures — so the `status -gt 1` guard passed, every cc group crashed identically, and the job uploaded an empty kernel cache as a success.

## Change

Two guards in the precompile step, so broken lanes show as errors:

- Each compute-capability pass writes `--junitxml=precompile-junit-$cc.xml` and the lane fails if the report is missing after the run. pytest only writes the report when a test session actually ran, so a crash before the session (import error in cubie, the backend, or the plugin) now fails the lane while genuine exit-1 test failures remain tolerated.
- After the loop, the lane fails if `kernel-cache/kernels` contains no files, so a lane that ran sessions but compiled nothing cannot upload an empty cache as green.

## Verification

Verified locally that a failing-test run (exit 1) writes a non-empty junit report while a plugin-import crash (also exit 1) writes none, and that the workflow YAML parses. Workflow-only diff — no A/B gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)