### PR TITLE
fix(ci): precompile population covers the pinned staging path and mlir integer launch-arg widths

### DIFF
--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -182,6 +182,32 @@ jobs:
             echo "precompile produced no cached kernels in kernel-cache/kernels" >&2
             exit 1
           fi
+          # A lane can fill the cache with peripheral kernels while
+          # every solver-run fixture dies before its launch (a broken
+          # population fake produces exactly that), so require the
+          # batch-solver integration kernel by name.
+          python - <<'EOF'
+          import pickle
+          import sys
+          from pathlib import Path
+
+          needle = (
+              "BatchSolverKernel.build_kernel.<locals>"
+              ".integration_kernel"
+          )
+          for nbi in Path("kernel-cache/kernels").rglob("*.nbi"):
+              with open(nbi, "rb") as stream:
+                  pickle.load(stream)
+                  _, index = pickle.load(stream)
+              if any(needle in key[5][1] for key in index):
+                  sys.exit(0)
+          print(
+              "precompile cache holds no batch-solver integration "
+              "kernel: solver-run fixtures never reached a launch",
+              file=sys.stderr,
+          )
+          sys.exit(1)
+          EOF
 
       - name: Upload kernel cache
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/tests/precompile_plugin.py
+++ b/tests/precompile_plugin.py
@@ -150,6 +150,7 @@ if POPULATION:
     backend_cuda.synchronize = lambda: None
     backend_cuda.stream = lambda: _fake_stream
     backend_cuda.default_stream = lambda: _fake_stream
+    backend_cuda.external_stream = lambda ptr: _fake_stream
 
 if POPULATION and BACKEND == "numba-cuda":
     from cuda.core._device import ComputeCapability  # noqa: E402
@@ -391,11 +392,12 @@ else:
         """Normalize a launch argument the way the real launch does.
 
         Mirrors ``_ArgMarshaller._maybe_copy_to_device_item``'s scalar
-        rules: the launch path converts numpy integer scalars to
-        Python ints (typed int64), float64 scalars to Python floats,
-        and numpy bools to Python bools before typing, so population
-        signatures must do the same or GPU consumers recompile with
-        promoted-scalar signatures.
+        rules in the installed cubie-numba-cuda-mlir wheel: numpy
+        integer scalars stay at their exact width (typing an
+        ``np.int32`` argument as ``int32``), float64 scalars become
+        Python floats, and numpy bools become Python bools before
+        typing. Population signatures must match, or GPU consumers
+        recompile with differently-typed scalar signatures.
         """
         if isinstance(value, (tuple, list)):
             processed = [_marshal_launch_arg(item) for item in value]
@@ -405,7 +407,7 @@ else:
         if isinstance(value, (np.datetime64, np.timedelta64)):
             return value
         if isinstance(value, np.integer):
-            return int(value)
+            return value
         if isinstance(value, (np.float16, np.float32)):
             return value
         if isinstance(value, np.floating):
@@ -499,6 +501,33 @@ if POPULATION:
         ),
     )
     _array_interpolator.current_cupy_stream = _fake_cupy_stream
+
+    # Input/output chunk staging draws pinned buffers from the
+    # ChunkBufferPool, which allocates through ``cupyx.empty_pinned``;
+    # without a CUDA driver that raises inside every solver run's
+    # fixture setup, so no batch-solver kernel would reach the cache.
+    import cubie.memory.chunk_buffer_pool as _chunk_buffer_pool  # noqa: E402
+
+    _chunk_buffer_pool.cupyx = SimpleNamespace(
+        empty_pinned=lambda shape, dtype=np.float64: np.zeros(
+            shape, dtype=dtype
+        ),
+    )
+
+    # The busy-kernel canary fixture (tests.conftest.start_cuda_busy_work)
+    # builds its non-blocking stream through ``cupy.cuda.Stream``,
+    # imported from cuda_simsafe at fixture call time. Stub the stream
+    # constructor while keeping the real pinned-pointer class so
+    # ``is_pinned_array`` still answers correctly.
+    import cubie.cuda_simsafe as _cuda_simsafe  # noqa: E402
+
+    _real_pinned_pointer = _cuda_simsafe.cupy.cuda.PinnedMemoryPointer
+    _cuda_simsafe.cupy = SimpleNamespace(
+        cuda=SimpleNamespace(
+            Stream=lambda non_blocking=False: SimpleNamespace(ptr=0),
+            PinnedMemoryPointer=_real_pinned_pointer,
+        ),
+    )
 
 
 # CuBIE creates a few dispatchers while importing its cache module. Finish

--- a/tests/precompile_plugin.py
+++ b/tests/precompile_plugin.py
@@ -169,6 +169,29 @@ if POPULATION and BACKEND == "numba-cuda":
     nb_devices.get_context = lambda *args, **kwargs: _fake_context
     backend_cuda.get_current_device = lambda: _fake_device
 
+if POPULATION and BACKEND == "mlir":
+    from numba_cuda_mlir.numba_cuda.cudadrv import (  # noqa: E402
+        devices as mlir_devices,
+    )
+
+    # cubie queries the live device outside any launch: the
+    # memory-placement heuristics call
+    # ``cuda.get_current_device().compute_capability`` during Solver
+    # construction (``resolve_thresholds``), which initialises the
+    # real CUDA driver and raises on the driverless population
+    # runner, erroring every affected fixture before its kernels
+    # reach the cache. Mirror the numba-cuda fakes above.
+    _fake_device = SimpleNamespace(
+        compute_capability=ComputeCapability(*TARGET_CC),
+        id=0,
+        name=b"cubie-precompile",
+        MAX_SHARED_MEMORY_PER_BLOCK=49152,
+        WARP_SIZE=32,
+    )
+    _fake_context = SimpleNamespace(device=_fake_device)
+    mlir_devices.get_context = lambda *args, **kwargs: _fake_context
+    backend_cuda.get_current_device = lambda: _fake_device
+
 
 def _host_copy(self, instance, from_arrays, to_arrays, stream=None):
     for source, destination in zip(from_arrays, to_arrays):


### PR DESCRIPTION
## Root cause

Run #890 (first full 16-leg matrix on main) missed 50–96 kernels per GPU leg with green precompile lanes. The two-leg demonstration (run #874) ran on the PR 645 branch, which lacked PR 621 — and an artifact diff between two populations proves key stability, not GPU-side coverage. Unpickling run #890's kernel-cache `.nbi` indexes showed the real problem: **zero `integration_kernel` entries** (run #874's artifact had 144) among 804 cached kernels — the population never reached a batch-solver kernel launch.

Two distinct causes:

1. **PR 621 staging crash (all 16 legs).** The staging path (`BatchInputArrays._stage_array` → `ChunkBufferPool._allocate_buffer`, `src/cubie/memory/chunk_buffer_pool.py:223`) allocates through `cupyx.empty_pinned`, which raises `cudaErrorInsufficientDriver` on the driverless CPU runners. Every `solver.kernel.run` fixture errored at setup (402 identical errors per lane, silently tolerated because population lanes ignore test verdicts), so `integration_kernel`, one `evaluate_rhs` variant, `_spin_until_released`, and the `start_cuda_busy_work` canary never populated.
2. **mlir integer-width marshalling (mlir legs).** cubie-numba-cuda-mlir 0.4.1.2 (pinned by the lanes' constraints) keeps `np.integer` launch args at their exact width, where 0.4.1.1 converted them to Python int. The population shim mirrored the old wheel, caching `int64` signatures for kernels the GPU looks up with `int32` (`run_controller_device_step`, `test_rejected_step_never_grows_dt` — identical closure/code/defaults hashes in the miss log, differing sig).

## Fix (population plugin only; no src changes)

- `chunk_buffer_pool.cupyx` patched with an `empty_pinned` → `np.zeros` shim.
- `cuda_simsafe.cupy` patched with a `cuda.Stream` stub (keeps the real `PinnedMemoryPointer` class so `is_pinned_array` still answers correctly) and `backend_cuda.external_stream` faked, covering the busy-kernel canary fixture.
- `_marshal_launch_arg` keeps `np.integer` values as-is, matching the installed wheel's marshalling.
- **Workflow guard:** the precompile step now unpickles the finished cache's `.nbi` indexes and fails the lane when no key qualname contains the batch-solver `integration_kernel` — a population that silently loses solver coverage can no longer ship a green artifact. Verified against run #890's artifact (fails) and run #874's (passes).

## Verification (local, RTX cc 8.9, wheel upgraded to 0.4.1.2 to match CI)

Populations run with `CUDA_VISIBLE_DEVICES=""` to emulate the driverless runner (a plain local run silently succeeds through unpatched cupy calls):

- Driverless population keys == with-driver population keys, 322/322 identical, 51 `integration_kernel` entries (run #890: 0).
- numba-cuda real-GPU consumer vs driverless cache: **3005 passed, cache_hits=679, compilations_completed=0** (55 s).
- mlir real-GPU consumer vs driverless cache: **3005 passed, cache_hits=674, compilations_completed=0** (39 s); `run_controller_device_step` now cached with `int32` scalar sigs matching the GPU miss log.
- Full CUDASIM suite: **2966 passed** (`-m "not nocudasim and not cupy and not specific_algos"`).

## Performance gate

No `src/cubie` changes; gate run as required:

```
numba-cuda fixed     kernel  A    61.949  B    61.876   -0.16%  ok
numba-cuda fixed     wall    A    76.122  B    76.719   +0.64%  ok
numba-cuda adaptive  kernel  A    94.885  B    94.706   -0.19%  ok
numba-cuda adaptive  wall    A    97.767  B    97.508   -0.29%  ok
numba-cuda chunked   kernel  A    62.343  B    62.413   +0.11%  ok
numba-cuda chunked   wall    A    78.907  B    79.383   +0.65%  ok
numba-cuda wave      kernel  A    25.666  B    25.689   +0.12%  ok
numba-cuda wave      wall    A    28.538  B    28.853   +0.73%  ok
mlir       fixed     kernel  A    61.917  B    61.907   -0.06%  ok
mlir       fixed     wall    A    75.368  B    75.460   +0.27%  ok
mlir       adaptive  kernel  A    90.797  B    91.045   +0.25%  ok
mlir       adaptive  wall    A    93.454  B    93.747   +0.29%  ok
mlir       chunked   kernel  A    62.310  B    62.376   +0.12%  ok
mlir       chunked   wall    A    78.405  B    78.417   -0.13%  ok
mlir       wave      kernel  A    25.672  B    25.654   -0.16%  ok
mlir       wave      wall    A    28.625  B    28.234   -1.58%  ok

GATE: PASS (kernel threshold 0.50%, wall threshold 10.00%)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Run #892 residual mlir misses: driver init in the population fixtures

The trial run (#892) cleared every numba-cuda leg but left all 8 mlir legs recompiling 20 kernels (13 `integration_kernel` + 7 `NeumannRHSEvaluator.build.<locals>.evaluate_rhs`, differing closure hashes, matching code/defaults hashes). The artifact held 114 `integration_kernel` entries with the same code hash, so this was a population coverage gap, not key instability: the mlir precompile lanes error with `CudaSupportError: Error at driver init` at fixture setup for `test_solve_firk_with_driver_arrays`, `test_algorithm_hot_swap_after_solve`, `test_shared_loop_buffers_leave_results_unchanged`, and the `test_memory_heuristics` suite. The path is `Solver.__init__` → `auto_memory_locations` → `resolve_thresholds()` (`src/cubie/integrators/memory_heuristics.py:139`) → `cuda_simsafe.compute_capability_code()` → `cuda.get_current_device()`, which initialises the real CUDA driver. The numba-cuda population branch already fakes `get_current_device`/`get_context`; the mlir branch only patched `mlir_tools._cached_cc`, so those fixtures died before their kernels reached the cache — the affected tests happen to be exactly the FIRK/hot-swap/shared-buffer ones whose kernels then missed on the GPU legs.

Fix: the mlir population branch mirrors the numba-cuda fakes (`backend_cuda.get_current_device` and `cudadrv.devices.get_context` answer with a fake device at the lane's target CC).

### Verification

- Local full-marker-set population (driverless) → real-GPU consumer, both backends: mlir **3005 passed, cache_hits=667, compilations_completed=0**; numba-cuda **3005 passed, cache_hits=670, compilations_completed=0**.
- Two-leg mlir trial on driverless CI runners ([run #896](https://github.com/cubiepy/cubie/actions/runs/29868748649), matrix temporarily trimmed on a throwaway branch): `cuda (linux, 3.14, 12, mlir)` **3005 passed, cache_hits=658, compilations_completed=0** (67 s); `cuda (windows, 3.11, 13, mlir)` **3005 passed, cache_hits=657, compilations_completed=0** (102 s).
