### PR TITLE
perf: add dense FIRK stage prediction

### DIFF
--- a/src/cubie/integrators/AGENTS.md
+++ b/src/cubie/integrators/AGENTS.md
@@ -58,7 +58,8 @@ Order matters — each component seeds the next:
 4. `check_compatibility()` — if the algorithm is errorless but the controller is
    adaptive, the controller is **silently replaced with `FixedStepController`** and a
    `UserWarning` is issued (an errorless algorithm gives no error signal to adapt on).
-   Happens before the loop is created.
+   It also records the fixed/adaptive boundary on the algorithm and invalidates its
+   device cache when that boundary changes. Happens before the loop is created.
 5. `instantiate_loop()` — creates `IVPLoop` from the finalised sizes/flags/timing.
 6. `get_child_allocators(self._loop, self._algo_step, name='algorithm')` (and the
    controller equivalent) — registers algo/controller buffers as children of the loop's

--- a/src/cubie/integrators/SingleIntegratorRunCore.py
+++ b/src/cubie/integrators/SingleIntegratorRunCore.py
@@ -501,10 +501,15 @@ class SingleIntegratorRunCore(CUDAFactory):
                 warn_on_unused=False,
             )
             
-        # Set the is_controller_fixed attribute on the algorithm
-        self._algo_step.is_controller_fixed = (
-            not self._step_controller.is_adaptive
-        )
+        # Controller-dependent algorithm code must rebuild when a hot-swap
+        # crosses the fixed/adaptive boundary.
+        is_controller_fixed = not self._step_controller.is_adaptive
+        if (
+            getattr(self._algo_step, "is_controller_fixed", None)
+            != is_controller_fixed
+        ):
+            self._algo_step.is_controller_fixed = is_controller_fixed
+            self._algo_step._invalidate_cache()
 
     def instantiate_loop(
         self,

--- a/src/cubie/integrators/algorithms/AGENTS.md
+++ b/src/cubie/integrators/algorithms/AGENTS.md
@@ -33,7 +33,7 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
 | `generic_erk_tableaus.py` | `ERKTableau` + ERK sets (Heun, Ralston, Bogacki-Shampine, Dormand-Prince 5(4)/8(5,3), RK4, Cash-Karp, Fehlberg, Tsit5, Vern7); `ERK_TABLEAU_REGISTRY`, `DEFAULT_ERK_TABLEAU`. |
 | `generic_dirk.py` | `DIRKStep` + `DIRKStepConfig`: diagonally-implicit RK, one Newton solve per implicit stage, stage-skipping for explicit stages, FSAL caching. |
 | `generic_dirk_tableaus.py` | `DIRKTableau` (adds `diagonal()`) + tableaus (implicit midpoint, trapezoidal/ESDIRK, Lobatto IIIC-3 default, SDIRK_2_2, L-stable DIRK3/SDIRK4). |
-| `generic_firk.py` | `FIRKStep` + `FIRKStepConfig`: fully-implicit RK; all stages as one coupled `n*stages` Newton system; Kahan-summed output accumulation. |
+| `generic_firk.py` | `FIRKStep` + `FIRKStepConfig`: fully-implicit RK; all stages as one coupled `n*stages` Newton system; equal-size accepted steps use dense collocation extrapolation for the next Newton guess; Kahan-summed output accumulation. |
 | `generic_firk_tableaus.py` | `FIRKTableau` + Gauss-Legendre-2 (default) and Radau IIA-5; `compute_embedded_weights_radauIIA`. |
 | `generic_rosenbrock_w.py` | `GenericRosenbrockWStep` + `RosenbrockWStepConfig`: linearly-implicit Rosenbrock-W using a cached Jacobian and a **linear** (not Newton) solve per stage; needs `driver_del_t` and time-derivative helpers. |
 | `generic_rosenbrockw_tableaus.py` | `RosenbrockTableau` (adds `C`, `gamma`, `gamma_stages`) + ROS3P (default), RODAS3P, SciML Rosenbrock23. RODAS4P/5P and ode23s 2(3) are commented-out / non-working. |
@@ -108,6 +108,12 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
 - **Rosenbrock lazy sizing:** `cached_auxiliary_count` triggers `build_implicit_helpers()`
   on first access to learn the cached-auxiliaries buffer size; `register_buffers` first
   registers it at size 0 and resizes later via `update_buffer`.
+- **FIRK dense prediction:** under a fixed controller, the persistent stage vector is
+  transformed in place with the tableau-derived `A^-1 L A` map only when the preceding
+  proposal was accepted and its step size equals the current one. Two- and three-stage
+  tableaus use scalar-unrolled transforms; the generic path applies pivoted LU factors
+  in place. The only additional persistent storage is one step-size scalar, not an
+  `n`-sized vector.
 
 ### FSAL warp-coherence
 - FSAL stage-0 RHS reuse is guarded by `all_sync(activemask(), accepted_flag != 0)` so

--- a/src/cubie/integrators/algorithms/generic_firk.py
+++ b/src/cubie/integrators/algorithms/generic_firk.py
@@ -38,7 +38,12 @@ See Also
 from typing import Callable, Optional
 
 from attrs import define, field, validators
-from cubie.cuda_simsafe import cuda, int32
+from cubie.cuda_simsafe import cuda, int32, selp
+from numpy import (
+    asarray as np_asarray,
+    linalg as np_linalg,
+    ndarray as np_ndarray,
+)
 
 from cubie.result_codes import CUBIE_RESULT_CODES
 
@@ -102,6 +107,117 @@ Fixed-step controllers maintain a constant step size throughout the
 integration. This is the only valid choice for errorless tableaus since
 adaptive stepping requires an error estimate to adjust the step size.
 """
+
+
+def _dense_predictor_matrix(tableau: FIRKTableau) -> np_ndarray:
+    """Return the one-step dense extrapolation matrix for *tableau*.
+
+    The FIRK unknown contains derivative increments ``U`` while the
+    collocation polynomial is defined by state increments ``A U``.  The
+    returned matrix maps the previous step's ``U`` to the next equal-size
+    step's stage guess.
+
+    Parameters
+    ----------
+    tableau
+        Fully implicit Runge--Kutta tableau.
+
+    Returns
+    -------
+    numpy.ndarray
+        Dense predictor matrix in host coefficient precision.
+    """
+
+    stage_count = tableau.stage_count
+    nodes = np_asarray((0.0,) + tuple(tableau.c), dtype=float)
+    stage_nodes = np_asarray(tableau.c, dtype=float)
+
+    endpoint_weights = []
+    for basis_index in range(1, stage_count + 1):
+        weight = 1.0
+        basis_node = nodes[basis_index]
+        for other_index, other_node in enumerate(nodes):
+            if other_index != basis_index:
+                weight *= (1.0 - other_node) / (basis_node - other_node)
+        endpoint_weights.append(weight)
+
+    extrapolation = []
+    for target_node in 1.0 + stage_nodes:
+        target_weights = []
+        for basis_index in range(1, stage_count + 1):
+            weight = 1.0
+            basis_node = nodes[basis_index]
+            for other_index, other_node in enumerate(nodes):
+                if other_index != basis_index:
+                    weight *= (target_node - other_node) / (
+                        basis_node - other_node
+                    )
+            target_weights.append(weight)
+        extrapolation.append(
+            [
+                target_weights[index] - endpoint_weights[index]
+                for index in range(stage_count)
+            ]
+        )
+
+    stage_matrix = np_asarray(tableau.a, dtype=float)
+    return np_linalg.solve(
+        stage_matrix,
+        np_asarray(extrapolation) @ stage_matrix,
+    )
+
+
+def _lu_factor(
+    matrix: np_ndarray,
+) -> tuple[np_ndarray, np_ndarray, tuple[tuple[int, int], ...]]:
+    """Factor *matrix* for a buffer-free in-place device transform.
+
+    Parameters
+    ----------
+    matrix
+        Square dense matrix.
+
+    Returns
+    -------
+    tuple
+        Unit-lower and upper factors plus inverse-permutation swaps.
+    """
+
+    upper = np_asarray(matrix).copy()
+    stage_count = upper.shape[0]
+    lower = np_asarray(
+        [
+            [1.0 if row == column else 0.0 for column in range(stage_count)]
+            for row in range(stage_count)
+        ],
+        dtype=upper.dtype,
+    )
+    pivot_swaps = []
+
+    for column in range(stage_count):
+        pivot_row = column
+        pivot_magnitude = abs(upper[column, column])
+        for candidate_row in range(column + 1, stage_count):
+            candidate_magnitude = abs(upper[candidate_row, column])
+            if candidate_magnitude > pivot_magnitude:
+                pivot_row = candidate_row
+                pivot_magnitude = candidate_magnitude
+        if pivot_magnitude == 0.0:
+            raise ValueError("Dense FIRK predictor matrix is singular")
+        if pivot_row != column:
+            upper[[column, pivot_row], :] = upper[[pivot_row, column], :]
+            if column:
+                lower[[column, pivot_row], :column] = lower[
+                    [pivot_row, column], :column
+                ]
+            pivot_swaps.append((column, pivot_row))
+
+        for row in range(column + 1, stage_count):
+            multiplier = upper[row, column] / upper[column, column]
+            lower[row, column] = multiplier
+            upper[row, column:] -= multiplier * upper[column, column:]
+
+    return lower, upper, tuple(reversed(pivot_swaps))
 
 
 @define
@@ -359,6 +475,17 @@ class FIRKStep(ODEImplicitStep):
 
         config = self.compile_settings
         tableau = config.tableau
+        enable_dense_prediction = bool(
+            getattr(self, "is_controller_fixed", False)
+        )
+        buffer_registry.register(
+            "previous_step_size",
+            self,
+            int(enable_dense_prediction),
+            config.stage_increment_location,
+            persistent=True,
+            precision=config.precision,
+        )
 
         nonlinear_solver = solver_function
 
@@ -378,6 +505,32 @@ class FIRKStep(ODEImplicitStep):
             error_weights = tuple(typed_zero for _ in range(stage_count))
         stage_time_fractions = tableau.typed_vector(tableau.c, numba_precision)
 
+        dense_predictor = np_asarray(
+            _dense_predictor_matrix(tableau),
+            dtype=config.precision,
+        )
+        dense_lower, dense_upper, dense_swaps = _lu_factor(dense_predictor)
+        dense_coefficients_unpadded = tuple(
+            numba_precision(value) for value in dense_predictor.flat
+        )
+        dense_coefficients = dense_coefficients_unpadded + tuple(
+            typed_zero
+            for _ in range(max(0, 9 - len(dense_coefficients_unpadded)))
+        )
+        dense_lower_coefficients = tuple(
+            numba_precision(value) for value in dense_lower.flat
+        )
+        dense_upper_coefficients = tuple(
+            numba_precision(value) for value in dense_upper.flat
+        )
+        dense_swap_rows_unpadded = tuple(
+            int32(row) for swap in dense_swaps for row in swap
+        )
+        dense_swap_rows = dense_swap_rows_unpadded or (
+            int32(0),
+            int32(0),
+        )
+        dense_swap_count = int32(len(dense_swaps))
         # Replace streaming accumulation with direct assignment when
         # stage matches b or b_hat row in coupling matrix.
         accumulates_output = tableau.accumulates_output
@@ -396,6 +549,7 @@ class FIRKStep(ODEImplicitStep):
         alloc_stage_increment = getalloc("stage_increment", self)
         alloc_stage_driver_stack = getalloc("stage_driver_stack", self)
         alloc_stage_state = getalloc("stage_state", self)
+        alloc_previous_step_size = getalloc("previous_step_size", self)
 
         # Re-register the solver child under the same name as
         # register_buffers so the size snapshot reflects the solver's
@@ -458,6 +612,9 @@ class FIRKStep(ODEImplicitStep):
                 shared, persistent_local
             )
             stage_increment = alloc_stage_increment(shared, persistent_local)
+            previous_step_size = alloc_previous_step_size(
+                shared, persistent_local
+            )
             stage_driver_stack = alloc_stage_driver_stack(
                 shared, persistent_local
             )
@@ -467,6 +624,162 @@ class FIRKStep(ODEImplicitStep):
             current_time = time_scalar
             end_time = current_time + dt_scalar
             status_code = success
+
+            if enable_dense_prediction:
+                previous_dt = previous_step_size[0]
+                apply_dense_prediction = (
+                    not first_step_flag
+                    and accepted_flag != int32(0)
+                    and dt_scalar == previous_dt
+                )
+                previous_step_size[0] = dt_scalar
+
+                if stage_count == int32(2):
+                    for state_idx in range(n):
+                        old_stage_0 = stage_increment[state_idx]
+                        old_stage_1 = stage_increment[n + state_idx]
+                        predicted_stage_0 = (
+                            dense_coefficients[0] * old_stage_0
+                            + dense_coefficients[1] * old_stage_1
+                        )
+                        predicted_stage_1 = (
+                            dense_coefficients[2] * old_stage_0
+                            + dense_coefficients[3] * old_stage_1
+                        )
+                        stage_increment[state_idx] = selp(
+                            first_step_flag,
+                            typed_zero,
+                            selp(
+                                apply_dense_prediction,
+                                predicted_stage_0,
+                                old_stage_0,
+                            ),
+                        )
+                        stage_increment[n + state_idx] = selp(
+                            first_step_flag,
+                            typed_zero,
+                            selp(
+                                apply_dense_prediction,
+                                predicted_stage_1,
+                                old_stage_1,
+                            ),
+                        )
+                elif stage_count == int32(3):
+                    for state_idx in range(n):
+                        old_stage_0 = stage_increment[state_idx]
+                        old_stage_1 = stage_increment[n + state_idx]
+                        old_stage_2 = stage_increment[2 * n + state_idx]
+                        predicted_stage_0 = (
+                            dense_coefficients[0] * old_stage_0
+                            + dense_coefficients[1] * old_stage_1
+                            + dense_coefficients[2] * old_stage_2
+                        )
+                        predicted_stage_1 = (
+                            dense_coefficients[3] * old_stage_0
+                            + dense_coefficients[4] * old_stage_1
+                            + dense_coefficients[5] * old_stage_2
+                        )
+                        predicted_stage_2 = (
+                            dense_coefficients[6] * old_stage_0
+                            + dense_coefficients[7] * old_stage_1
+                            + dense_coefficients[8] * old_stage_2
+                        )
+                        stage_increment[state_idx] = selp(
+                            first_step_flag,
+                            typed_zero,
+                            selp(
+                                apply_dense_prediction,
+                                predicted_stage_0,
+                                old_stage_0,
+                            ),
+                        )
+                        stage_increment[n + state_idx] = selp(
+                            first_step_flag,
+                            typed_zero,
+                            selp(
+                                apply_dense_prediction,
+                                predicted_stage_1,
+                                old_stage_1,
+                            ),
+                        )
+                        stage_increment[2 * n + state_idx] = selp(
+                            first_step_flag,
+                            typed_zero,
+                            selp(
+                                apply_dense_prediction,
+                                predicted_stage_2,
+                                old_stage_2,
+                            ),
+                        )
+                else:
+                    for state_idx in range(n):
+                        for stage_idx in range(stage_count):
+                            predicted = typed_zero
+                            coefficient_base = stage_idx * stage_count
+                            for source_idx in range(stage_idx, stage_count):
+                                predicted += (
+                                    dense_upper_coefficients[
+                                        coefficient_base + source_idx
+                                    ]
+                                    * stage_increment[
+                                        source_idx * n + state_idx
+                                    ]
+                                )
+                            target_index = stage_idx * n + state_idx
+                            stage_increment[target_index] = selp(
+                                apply_dense_prediction,
+                                predicted,
+                                stage_increment[target_index],
+                            )
+
+                        for reverse_idx in range(stage_count):
+                            stage_idx = stage_count - int32(1) - reverse_idx
+                            target_index = stage_idx * n + state_idx
+                            predicted = stage_increment[target_index]
+                            coefficient_base = stage_idx * stage_count
+                            for source_idx in range(stage_idx):
+                                predicted += (
+                                    dense_lower_coefficients[
+                                        coefficient_base + source_idx
+                                    ]
+                                    * stage_increment[
+                                        source_idx * n + state_idx
+                                    ]
+                                )
+                            stage_increment[target_index] = selp(
+                                apply_dense_prediction,
+                                predicted,
+                                stage_increment[target_index],
+                            )
+
+                        for swap_idx in range(dense_swap_count):
+                            swap_base = int32(2) * swap_idx
+                            left_stage = dense_swap_rows[swap_base]
+                            right_stage = dense_swap_rows[
+                                swap_base + int32(1)
+                            ]
+                            left_index = left_stage * n + state_idx
+                            right_index = right_stage * n + state_idx
+                            left_value = stage_increment[left_index]
+                            right_value = stage_increment[right_index]
+                            stage_increment[left_index] = selp(
+                                apply_dense_prediction,
+                                right_value,
+                                left_value,
+                            )
+                            stage_increment[right_index] = selp(
+                                apply_dense_prediction,
+                                left_value,
+                                right_value,
+                            )
+
+                        for stage_idx in range(stage_count):
+                            target_index = stage_idx * n + state_idx
+                            stage_increment[target_index] = selp(
+                                first_step_flag,
+                                typed_zero,
+                                stage_increment[target_index],
+                            )
 
             for idx in range(n):
                 if accumulates_output:

--- a/tests/integrated_numerical_tests/test_ode_loop.py
+++ b/tests/integrated_numerical_tests/test_ode_loop.py
@@ -9,11 +9,26 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from cubie.integrators.algorithms.generic_firk_tableaus import FIRKTableau
+
 from tests._utils import (
     assert_integration_outputs,
     MID_RUN_PARAMS,
     merge_dicts,
     ALGORITHM_PARAM_SETS,
+)
+
+
+FOUR_STAGE_FIRK_TABLEAU = FIRKTableau(
+    a=(
+        (0.1, 0.0, 0.0, 0.0),
+        (0.0, 0.2, 0.0, 0.0),
+        (0.0, 0.0, 0.3, 0.0),
+        (0.0, 0.0, 0.0, 0.4),
+    ),
+    b=(0.25, 0.25, 0.25, 0.25),
+    c=(0.1, 0.3, 0.6, 1.0),
+    order=1,
 )
 
 
@@ -521,6 +536,39 @@ def test_firk_with_shared_solver_buffer_matches_reference(
     produces a correctly sized pool and that the integration result
     matches the CPU reference within loose tolerances (issue #520).
     """
+    assert_integration_outputs(
+        cpu_loop_outputs,
+        device_loop_outputs,
+        output_functions,
+        rtol=tolerance.rel_loose,
+        atol=tolerance.abs_loose,
+    )
+    assert device_loop_outputs.status == 0
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [
+        merge_dicts(
+            MID_RUN_PARAMS,
+            {
+                "algorithm": "firk",
+                "tableau": FOUR_STAGE_FIRK_TABLEAU,
+                "step_controller": "fixed",
+            },
+        )
+    ],
+    ids=["firk-four-stage-dense-predictor"],
+    indirect=True,
+)
+def test_four_stage_firk_dense_predictor_matches_reference(
+    device_loop_outputs,
+    cpu_loop_outputs,
+    output_functions,
+    tolerance,
+):
+    """Generic in-place predictor updates every state component."""
+
     assert_integration_outputs(
         cpu_loop_outputs,
         device_loop_outputs,

--- a/tests/integrators/algorithms/test_step_algorithms.py
+++ b/tests/integrators/algorithms/test_step_algorithms.py
@@ -22,10 +22,15 @@ from cubie.integrators.algorithms.generic_erk_tableaus import (
     DEFAULT_ERK_TABLEAU,
     ERK_TABLEAU_REGISTRY,
 )
-from cubie.integrators.algorithms.generic_firk import FIRKStep
+from cubie.integrators.algorithms.generic_firk import (
+    FIRKStep,
+    _dense_predictor_matrix,
+    _lu_factor,
+)
 from cubie.integrators.algorithms.generic_firk_tableaus import (
     DEFAULT_FIRK_TABLEAU,
     FIRK_TABLEAU_REGISTRY,
+    RADAU_IIA_5_TABLEAU,
 )
 from cubie.integrators.norms import DIRKCorrectionNorm, FIRKCorrectionNorm
 from cubie.integrators.algorithms.generic_rosenbrock_w import (
@@ -114,6 +119,68 @@ def _expected_memory_requirements(
         "Memory expectation missing for "
         f"{type(step_object).__name__}."
     )
+
+
+@pytest.mark.parametrize(
+    "tableau",
+    [DEFAULT_FIRK_TABLEAU, RADAU_IIA_5_TABLEAU],
+)
+def test_firk_dense_predictor_extrapolates_collocation_polynomial(tableau):
+    stage_matrix = np.asarray(tableau.a)
+    stage_nodes = np.asarray(tableau.c)
+    increments = np.arange(1, tableau.stage_count + 1, dtype=float)
+    old_stage_values = stage_matrix @ increments
+
+    polynomial = np.polynomial.polynomial.polyfit(
+        np.concatenate(([0.0], stage_nodes)),
+        np.concatenate(([0.0], old_stage_values)),
+        tableau.stage_count,
+    )
+    shifted_stage_values = (
+        np.polynomial.polynomial.polyval(1.0 + stage_nodes, polynomial)
+        - np.polynomial.polynomial.polyval(1.0, polynomial)
+    )
+    expected = np.linalg.solve(stage_matrix, shifted_stage_values)
+
+    predictor = _dense_predictor_matrix(tableau)
+    np.testing.assert_allclose(predictor @ increments, expected)
+
+
+@pytest.mark.parametrize(
+    "tableau",
+    [DEFAULT_FIRK_TABLEAU, RADAU_IIA_5_TABLEAU],
+)
+def test_firk_dense_predictor_lu_reconstructs_matrix(tableau):
+    predictor = np.asarray(
+        _dense_predictor_matrix(tableau),
+        dtype=np.float32,
+    )
+    lower, upper, inverse_swaps = _lu_factor(predictor)
+
+    reconstructed = lower @ upper
+    for left_row, right_row in inverse_swaps:
+        reconstructed[[left_row, right_row], :] = reconstructed[
+            [right_row, left_row], :
+        ]
+
+    np.testing.assert_allclose(reconstructed, predictor, rtol=2e-6)
+
+
+def test_radau_dense_predictor_coefficients_are_pinned():
+    expected = np.asarray(
+        [
+            [0.19107136, -0.89141154, 1.7003402],
+            [1.5580782, -5.5244045, 4.9663267],
+            [3.2735543, -10.606888, 8.333333],
+        ],
+        dtype=np.float32,
+    )
+
+    actual = np.asarray(
+        _dense_predictor_matrix(RADAU_IIA_5_TABLEAU),
+        dtype=np.float32,
+    )
+    np.testing.assert_array_equal(actual, expected)
 
 
 ALIAS_CASES = [

--- a/tests/integrators/cpu_reference/algorithms.py
+++ b/tests/integrators/cpu_reference/algorithms.py
@@ -25,6 +25,9 @@ from cubie.integrators.algorithms.generic_firk_tableaus import (
     FIRKTableau,
     DEFAULT_FIRK_TABLEAU,
 )
+from cubie.integrators.algorithms.generic_firk import (
+    _dense_predictor_matrix,
+)
 from cubie.integrators.algorithms.generic_erk_tableaus import (
     DEFAULT_ERK_TABLEAU,
     ERKTableau,
@@ -1204,6 +1207,7 @@ class CPUFIRKStep(CPUStep):
         residual_reduction: Optional[float] = None,
         residual_floor: Optional[float] = None,
         tableau: Optional[FIRKTableau] = None,
+        dense_prediction: bool = False,
     ) -> None:
         resolved = DEFAULT_FIRK_TABLEAU if tableau is None else tableau
         super().__init__(
@@ -1227,10 +1231,16 @@ class CPUFIRKStep(CPUStep):
         self._firk_time = self.precision(0.0)
         self._firk_dt = self.precision(0.0)
         self._firk_stage_increments = None
+        self._firk_previous_dt = None
+        self._firk_dense_prediction = dense_prediction
+        self._firk_dense_predictor = np.asarray(
+            _dense_predictor_matrix(resolved),
+            dtype=self.precision,
+        )
 
     def residual(self, candidate: Array) -> Array:
         """Compute the residual for the fully implicit stage equations.
-        
+
         For FIRK, all stages are coupled: candidate is a flattened vector
         of all stage increments k_i for i=1..s where s is the stage count.
         The residual for each stage i is:
@@ -1240,15 +1250,15 @@ class CPUFIRKStep(CPUStep):
         state_dim = self._state_size
         a_matrix = self.a_matrix
         c_nodes = self.c_nodes
-        
+
         residual = np.zeros_like(candidate)
-        
+
         for stage_idx in range(stage_count):
             # Extract this stage's increment from the flattened candidate
             k_start = stage_idx * state_dim
             k_end = (stage_idx + 1) * state_dim
             k_i = candidate[k_start:k_end]
-            
+
             # Compute the stage state: x_0 + sum_j(a_ij * k_j)
             stage_state = self._firk_state.copy()
             for j in range(stage_count):
@@ -1256,7 +1266,7 @@ class CPUFIRKStep(CPUStep):
                 j_end = (j + 1) * state_dim
                 k_j = candidate[j_start:j_end]
                 stage_state += a_matrix[stage_idx, j] * k_j
-            
+
             # Evaluate the RHS at this stage
             stage_time = self._firk_time + c_nodes[stage_idx] * self._firk_dt
             drivers_stage = self._firk_drivers[stage_idx]
@@ -1273,16 +1283,16 @@ class CPUFIRKStep(CPUStep):
                 observables_stage,
                 stage_time,
             )
-            
+
             # Residual: M * k_i - dt * f(...)
             mass_term = self.mass_matrix_apply(k_i)
             residual[k_start:k_end] = mass_term - self._firk_dt * derivative
-        
+
         return residual
 
     def jacobian(self, candidate: Array) -> Array:
         """Compute the Jacobian of the residual for the fully implicit system.
-        
+
         The Jacobian is block-structured:
             J[i,j] = delta_ij * M - dt * a_ij * df/dx
         where delta_ij is the Kronecker delta.
@@ -1291,10 +1301,10 @@ class CPUFIRKStep(CPUStep):
         state_dim = self._state_size
         a_matrix = self.a_matrix
         c_nodes = self.c_nodes
-        
+
         all_dim = stage_count * state_dim
         jac = np.zeros((all_dim, all_dim), dtype=self.precision)
-        
+
         for stage_idx in range(stage_count):
             # Compute the stage state to evaluate the Jacobian
             stage_state = self._firk_state.copy()
@@ -1303,7 +1313,7 @@ class CPUFIRKStep(CPUStep):
                 j_end = (j + 1) * state_dim
                 k_j = candidate[j_start:j_end]
                 stage_state += a_matrix[stage_idx, j] * k_j
-            
+
             stage_time = self._firk_time + c_nodes[stage_idx] * self._firk_dt
             drivers_stage = self._firk_drivers[stage_idx]
             _, df_dx = self.observables_and_jac(
@@ -1312,15 +1322,15 @@ class CPUFIRKStep(CPUStep):
                 drivers_stage,
                 stage_time,
             )
-            
+
             # Fill in the block row for this stage
             i_start = stage_idx * state_dim
             i_end = (stage_idx + 1) * state_dim
-            
+
             for dep_idx in range(stage_count):
                 j_start = dep_idx * state_dim
                 j_end = (dep_idx + 1) * state_dim
-                
+
                 if stage_idx == dep_idx:
                     # Diagonal block: M - dt * a_ii * df/dx
                     jac[i_start:i_end, j_start:j_end] = (
@@ -1331,7 +1341,7 @@ class CPUFIRKStep(CPUStep):
                     jac[i_start:i_end, j_start:j_end] = (
                         -self._firk_dt * a_matrix[stage_idx, dep_idx] * df_dx
                     )
-        
+
         return jac
 
     def step(
@@ -1355,14 +1365,14 @@ class CPUFIRKStep(CPUStep):
 
         state_dim = state_vector.shape[0]
         all_dim = stage_count * state_dim
-        
+
         # Pre-compute driver values for all stages
         stage_drivers = []
         for stage_idx in range(stage_count):
             stage_time = current_time + c_nodes[stage_idx] * dt_value
             drivers_stage = self.drivers(stage_time)
             stage_drivers.append(drivers_stage)
-        
+
         # Set up the fully implicit solve
         self._firk_state = state_vector.copy()
         self._firk_params = params_array
@@ -1373,10 +1383,24 @@ class CPUFIRKStep(CPUStep):
         # state weights every stage block of the coupled residual.
         self._linear_norm_reference = np.tile(state_vector, stage_count)
 
-        # Initial guess: zero increments (or could use previous step's increments)
+        # Equal-size steps extrapolate the prior collocation polynomial.
+        # A changed step size retains the existing carried-vector behavior.
         guess = np.zeros(all_dim, dtype=self.precision)
         if self._firk_stage_increments is not None:
-            guess = self._firk_stage_increments.copy()
+            previous = self._firk_stage_increments.reshape(
+                stage_count,
+                state_dim,
+            )
+            if (
+                self._firk_dense_prediction
+                and dt_value == self._firk_previous_dt
+            ):
+                guess = (self._firk_dense_predictor @ previous).reshape(
+                    all_dim
+                )
+            else:
+                guess = self._firk_stage_increments.copy()
+        self._firk_previous_dt = dt_value
 
         def correction_norm(update, iterate):
             stage_values = np.zeros(all_dim, dtype=self.precision)
@@ -1875,7 +1899,11 @@ def get_ref_step_factory(
         preconditioner_order: int = 2,
         residual_reduction: Optional[float] = None,
         residual_floor: Optional[float] = None,
+        dense_prediction: bool = False,
     ) -> Callable:
+        extra_kwargs = {}
+        if step_class is CPUFIRKStep:
+            extra_kwargs["dense_prediction"] = dense_prediction
         if tableau_value is None:
             return step_class(
                 evaluator,
@@ -1890,6 +1918,7 @@ def get_ref_step_factory(
                 preconditioner_order=preconditioner_order,
                 residual_reduction=residual_reduction,
                 residual_floor=residual_floor,
+                **extra_kwargs,
             )
         return step_class(
             evaluator,
@@ -1905,6 +1934,7 @@ def get_ref_step_factory(
             residual_reduction=residual_reduction,
             residual_floor=residual_floor,
             tableau=tableau_value,
+            **extra_kwargs,
         )
 
     return factory
@@ -1926,6 +1956,7 @@ def get_ref_stepper(
     residual_reduction: Optional[float] = None,
     residual_floor: Optional[float] = None,
     tableau: Optional[Union[str, ButcherTableau]] = None,
+    dense_prediction: bool = False,
 ) -> CPUStep:
     """Return a configured CPU reference stepper for ``algorithm``."""
 
@@ -1943,4 +1974,5 @@ def get_ref_stepper(
         preconditioner_order=preconditioner_order,
         residual_reduction=residual_reduction,
         residual_floor=residual_floor,
+        dense_prediction=dense_prediction,
     )

--- a/tests/integrators/cpu_reference/loops.py
+++ b/tests/integrators/cpu_reference/loops.py
@@ -121,6 +121,7 @@ def run_reference_loop(
         residual_reduction=residual_reduction,
         residual_floor=solver_settings.get("krylov_residual_floor"),
         tableau=tableau,
+        dense_prediction=(solver_settings["step_controller"] == "fixed"),
     )
 
     saved_state_indices = _ensure_array(


### PR DESCRIPTION
## Summary

- add a fixed-step FIRK dense stage predictor using the collocation
  extrapolation transform `A^-1 L A`
- transform the persistent stage vector in place, adding no per-state vector
  buffers and only one configured-precision scalar per solver
- use scalar-unrolled, predicated two- and three-stage paths plus a generic
  pivoted-LU path for larger tableaus
- invalidate the cached algorithm when crossing the fixed/adaptive controller
  boundary, and mirror the predictor in the CPU reference
- keep adaptive solves compiled free of the predictor and omit the rejected
  zero-retry experiment entirely

This PR is stacked on #654, which fixes the FIRK operator/preconditioner
constant captures and the Neumann diagnostic wording.

## A/B evidence

Corrected fixed-step Radau, Float32 throughout:

| Workload | Carry predictor | Dense predictor | Result |
|---|---:|---:|---:|
| Lorenz, 860,160 runs, 24 waves, median Newton iterations | 47 | 31 | -34.0% |
| Lorenz, 860,160 runs, 24 waves, median Krylov iterations | 96 | 64 | -33.3% |
| Lorenz, 860,160 runs, 24 waves, kernel | 26.92 ms | 19.30 ms | -28.36% |
| n=24, 216-variable RHS, 344,064 runs, 24 waves, kernel | baseline | dense | -33.491% |
| n=24, 216-variable RHS, 344,064 runs, 24 waves, wall | baseline | dense | -5.028% |

The Lorenz case retained 96 registers, zero spills, and 10 blocks/SM. The
n=24 case retained the same 255 registers, spill count, occupancy, and wave
count on both sides. The predictor therefore consumes 0n extra vector storage;
its only new persistent state is one scalar holding the previous step size.

The zero-retry A/B was rejected and is not present: after the operator fix it
never activated and cost approximately 3.6% runtime.

## Performance gate

`python benchmarks/ab_gate.py --main origin/codex/radau-operator-capture-fix`
plus the required 16-pair numba-cuda rerun for a noisy adaptive sample:

| Backend/config | Kernel delta | Wall delta |
|---|---:|---:|
| numba-cuda fixed | -0.02% | -0.14% |
| numba-cuda adaptive | -0.33% | -2.43% |
| numba-cuda chunked | +0.01% | -0.23% |
| numba-cuda wave | -0.00% | -0.11% |
| MLIR fixed | -0.03% | +0.15% |
| MLIR adaptive | +0.16% | +3.74% |
| MLIR chunked | -0.06% | -0.46% |
| MLIR wave | +0.04% | -0.53% |

All rows preserve register count, zero spills, and blocks/SM. The final gate
verdict is PASS on both installed CUDA backends.

## Verification

- 129 FIRK algorithm tests passed
- 61 `SingleIntegratorRunCore` tests passed
- real-GPU four-stage generic FIRK predictor test passed
- real-GPU fixed Radau Julia gates passed on MLIR and numba-cuda
- real-GPU Gauss shared-buffer CPU-reference comparison passed
- 3 dt-min hang tests passed
- changed-file Ruff, blocking Flake8, and `git diff --check` passed
- independent verifier: PASS against the approved specification
