### PR TITLE
perf: dense FIRK stage prediction lives in a reusable predictor factory

### DIFF
--- a/src/cubie/integrators/AGENTS.md
+++ b/src/cubie/integrators/AGENTS.md
@@ -24,6 +24,7 @@ each have their own `AGENTS.md`.
 | `SingleIntegratorRunCore.py` | `SingleIntegratorRunCore(CUDAFactory)`: owns `_output_functions`, `_algo_step`, `_step_controller`, `_loop`; wires them and delegates compilation to `IVPLoop` in `build()`. Defines `SingleIntegratorRunCache` (holds `single_integrator_function`). |
 | `IntegratorRunSettings.py` | `IntegratorRunSettings(CUDAFactoryConfig)`: thin compile-settings holding only `algorithm` and `step_controller` names (plus inherited `precision`) — the core's own cache key. |
 | `norms.py` | CUDA factories for scaled vector norms and DIRK/FIRK Newton correction terms. |
+| `stage_predictors.py` | `DenseStagePredictor(CUDAFactory)`: in-place dense collocation extrapolation of a persistent stage-increment vector for equal-size accepted steps; tableau-derived, no codegen. Algorithms opt in as a buffer-registry child (FIRK today). |
 | `__init__.py` | Package API re-exports (`SingleIntegratorRun`, `IVPLoop`, algorithm/solver/controller classes, `get_algorithm_step`, `get_controller`); re-exports `CUBIE_RESULT_CODES` from `cubie.result_codes`. |
 
 ## Subdirectories

--- a/src/cubie/integrators/AGENTS.md
+++ b/src/cubie/integrators/AGENTS.md
@@ -24,7 +24,7 @@ each have their own `AGENTS.md`.
 | `SingleIntegratorRunCore.py` | `SingleIntegratorRunCore(CUDAFactory)`: owns `_output_functions`, `_algo_step`, `_step_controller`, `_loop`; wires them and delegates compilation to `IVPLoop` in `build()`. Defines `SingleIntegratorRunCache` (holds `single_integrator_function`). |
 | `IntegratorRunSettings.py` | `IntegratorRunSettings(CUDAFactoryConfig)`: thin compile-settings holding only `algorithm` and `step_controller` names (plus inherited `precision`) — the core's own cache key. |
 | `norms.py` | CUDA factories for scaled vector norms and DIRK/FIRK Newton correction terms. |
-| `stage_predictors.py` | `DenseStagePredictor(CUDAFactory)`: in-place dense collocation extrapolation of a persistent stage-increment vector for equal-size accepted steps; tableau-derived, no codegen. Algorithms opt in as a buffer-registry child (FIRK today). |
+| `stage_predictors.py` | `DenseStagePredictor(CUDAFactory)`: in-place read-ahead of a persistent stage-increment vector that warm-starts the next step's Newton solves; step-size-ratio polynomials precomputed from the tableau. FIRK and DIRK own one as a buffer-registry child. |
 | `__init__.py` | Package API re-exports (`SingleIntegratorRun`, `IVPLoop`, algorithm/solver/controller classes, `get_algorithm_step`, `get_controller`); re-exports `CUBIE_RESULT_CODES` from `cubie.result_codes`. |
 
 ## Subdirectories

--- a/src/cubie/integrators/SingleIntegratorRunCore.py
+++ b/src/cubie/integrators/SingleIntegratorRunCore.py
@@ -500,11 +500,6 @@ class SingleIntegratorRunCore(CUDAFactory):
                 },
                 warn_on_unused=False,
             )
-            
-        # Set the is_controller_fixed attribute on the algorithm
-        self._algo_step.is_controller_fixed = (
-            not self._step_controller.is_adaptive
-        )
 
     def instantiate_loop(
         self,

--- a/src/cubie/integrators/algorithms/AGENTS.md
+++ b/src/cubie/integrators/algorithms/AGENTS.md
@@ -31,9 +31,9 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
 | `explicit_euler.py` | `ExplicitEulerStep`: forward Euler, order 1, fixed-step. |
 | `generic_erk.py` | `ERKStep` + `ERKStepConfig`: streamed-accumulator explicit RK; FSAL caching; controller auto-selected from `tableau.has_error_estimate`. |
 | `generic_erk_tableaus.py` | `ERKTableau` + ERK sets (Heun, Ralston, Bogacki-Shampine, Dormand-Prince 5(4)/8(5,3), RK4, Cash-Karp, Fehlberg, Tsit5, Vern7); `ERK_TABLEAU_REGISTRY`, `DEFAULT_ERK_TABLEAU`. |
-| `generic_dirk.py` | `DIRKStep` + `DIRKStepConfig`: diagonally-implicit RK, one Newton solve per implicit stage, stage-skipping for explicit stages, FSAL caching. |
+| `generic_dirk.py` | `DIRKStep` + `DIRKStepConfig`: diagonally-implicit RK, one Newton solve per implicit stage, stage-skipping for explicit stages, FSAL caching, dense-predictor warm starts. |
 | `generic_dirk_tableaus.py` | `DIRKTableau` (adds `diagonal()`) + tableaus (implicit midpoint, trapezoidal/ESDIRK, Lobatto IIIC-3 default, SDIRK_2_2, L-stable DIRK3/SDIRK4). |
-| `generic_firk.py` | `FIRKStep` + `FIRKStepConfig`: fully-implicit RK; all stages as one coupled `n*stages` Newton system; owns a `DenseStagePredictor` for fixed-controller warm starts; Kahan-summed output accumulation. |
+| `generic_firk.py` | `FIRKStep` + `FIRKStepConfig`: fully-implicit RK; all stages as one coupled `n*stages` Newton system; dense-predictor warm starts; Kahan-summed output accumulation. |
 | `generic_firk_tableaus.py` | `FIRKTableau` + Gauss-Legendre-2 (default) and Radau IIA-5; `compute_embedded_weights_radauIIA`. |
 | `generic_rosenbrock_w.py` | `GenericRosenbrockWStep` + `RosenbrockWStepConfig`: linearly-implicit Rosenbrock-W using a cached Jacobian and a **linear** (not Newton) solve per stage; needs `driver_del_t` and time-derivative helpers. |
 | `generic_rosenbrockw_tableaus.py` | `RosenbrockTableau` (adds `C`, `gamma`, `gamma_stages`) + ROS3P (default), RODAS3P, SciML Rosenbrock23. RODAS4P/5P and ode23s 2(3) are commented-out / non-working. |
@@ -110,24 +110,15 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
   registers it at size 0 and resizes later via `update_buffer`.
 
 ### Dense stage prediction (FIRK and DIRK)
-`FIRKStep` and `DIRKStep` each own a `DenseStagePredictor`
-(`../stage_predictors.py`), registered as a buffer-registry child only when
-`ODEImplicitStep.dense_prediction` is true (`attempt_dense_prediction`
-requested and the tableau's stage nodes are pairwise distinct). The compiled
-step reads the previous step's stage-derivative curve ahead over the next
-step as the Newton warm start (for collocation tableaus this equals
-extrapolating the collocation polynomial, RADAU5-style); the transform
-matrix's entries are polynomials in the runtime step-size ratio, so fixed and
-adaptive controllers both benefit. The step judges applicability (not the
-predictor): no prediction on the first step or after a rejected proposal.
-FIRK transforms its persistent coupled stage vector in place; DIRK keeps a
-persistent `stage_increment_history` (`stage_count * n`) that the transform
-updates and each stage solve reads from and writes back to. The predictor's
-only own storage is one persistent step-size scalar, and steps with
-prediction inactive compile without the predictor or its buffers.
-`ODEImplicitStep.update` delegates predictor parameters and pipes
-`predictor_function` through compile settings so predictor rebuilds
-invalidate the step cache, mirroring `solver_function`.
+Both steps own a `DenseStagePredictor` (`../stage_predictors.py`) child that
+reads the previous step's stage-derivative curve ahead over the next step as
+the Newton warm start, with the step-size ratio handled at runtime.
+`ODEImplicitStep.dense_prediction` gates compilation (`attempt_dense_prediction`
+requested + tableau nodes pairwise distinct and well spread); the step judges
+first-step/rejection and passes a flag, the predictor bounds the ratio. DIRK
+keeps a persistent `stage_increment_history` (`stage_count * n`, registered
+size 0 when inactive); FIRK transforms its coupled stage vector in place.
+`predictor_function` pipes through compile settings like `solver_function`.
 
 ### FSAL warp-coherence
 - FSAL stage-0 RHS reuse is guarded by `all_sync(activemask(), accepted_flag != 0)` so

--- a/src/cubie/integrators/algorithms/AGENTS.md
+++ b/src/cubie/integrators/algorithms/AGENTS.md
@@ -33,7 +33,7 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
 | `generic_erk_tableaus.py` | `ERKTableau` + ERK sets (Heun, Ralston, Bogacki-Shampine, Dormand-Prince 5(4)/8(5,3), RK4, Cash-Karp, Fehlberg, Tsit5, Vern7); `ERK_TABLEAU_REGISTRY`, `DEFAULT_ERK_TABLEAU`. |
 | `generic_dirk.py` | `DIRKStep` + `DIRKStepConfig`: diagonally-implicit RK, one Newton solve per implicit stage, stage-skipping for explicit stages, FSAL caching. |
 | `generic_dirk_tableaus.py` | `DIRKTableau` (adds `diagonal()`) + tableaus (implicit midpoint, trapezoidal/ESDIRK, Lobatto IIIC-3 default, SDIRK_2_2, L-stable DIRK3/SDIRK4). |
-| `generic_firk.py` | `FIRKStep` + `FIRKStepConfig`: fully-implicit RK; all stages as one coupled `n*stages` Newton system; Kahan-summed output accumulation. |
+| `generic_firk.py` | `FIRKStep` + `FIRKStepConfig`: fully-implicit RK; all stages as one coupled `n*stages` Newton system; owns a `DenseStagePredictor` for fixed-controller warm starts; Kahan-summed output accumulation. |
 | `generic_firk_tableaus.py` | `FIRKTableau` + Gauss-Legendre-2 (default) and Radau IIA-5; `compute_embedded_weights_radauIIA`. |
 | `generic_rosenbrock_w.py` | `GenericRosenbrockWStep` + `RosenbrockWStepConfig`: linearly-implicit Rosenbrock-W using a cached Jacobian and a **linear** (not Newton) solve per stage; needs `driver_del_t` and time-derivative helpers. |
 | `generic_rosenbrockw_tableaus.py` | `RosenbrockTableau` (adds `C`, `gamma`, `gamma_stages`) + ROS3P (default), RODAS3P, SciML Rosenbrock23. RODAS4P/5P and ode23s 2(3) are commented-out / non-working. |
@@ -108,6 +108,26 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
 - **Rosenbrock lazy sizing:** `cached_auxiliary_count` triggers `build_implicit_helpers()`
   on first access to learn the cached-auxiliaries buffer size; `register_buffers` first
   registers it at size 0 and resizes later via `update_buffer`.
+
+### Dense stage prediction (FIRK and DIRK)
+`FIRKStep` and `DIRKStep` each own a `DenseStagePredictor`
+(`../stage_predictors.py`), registered as a buffer-registry child only when
+`ODEImplicitStep.dense_prediction` is true (`attempt_dense_prediction`
+requested and the tableau's stage nodes are pairwise distinct). The compiled
+step reads the previous step's stage-derivative curve ahead over the next
+step as the Newton warm start (for collocation tableaus this equals
+extrapolating the collocation polynomial, RADAU5-style); the transform
+matrix's entries are polynomials in the runtime step-size ratio, so fixed and
+adaptive controllers both benefit. The step judges applicability (not the
+predictor): no prediction on the first step or after a rejected proposal.
+FIRK transforms its persistent coupled stage vector in place; DIRK keeps a
+persistent `stage_increment_history` (`stage_count * n`) that the transform
+updates and each stage solve reads from and writes back to. The predictor's
+only own storage is one persistent step-size scalar, and steps with
+prediction inactive compile without the predictor or its buffers.
+`ODEImplicitStep.update` delegates predictor parameters and pipes
+`predictor_function` through compile settings so predictor rebuilds
+invalidate the step cache, mirroring `solver_function`.
 
 ### FSAL warp-coherence
 - FSAL stage-0 RHS reuse is guarded by `all_sync(activemask(), accepted_flag != 0)` so

--- a/src/cubie/integrators/algorithms/base_algorithm_step.py
+++ b/src/cubie/integrators/algorithms/base_algorithm_step.py
@@ -57,6 +57,7 @@ ALL_ALGORITHM_STEP_PARAMETERS = {
     "algorithm",
     "precision",
     "n",
+    "attempt_dense_prediction",
     "evaluate_f",
     "evaluate_observables",
     "evaluate_driver_at_t",
@@ -78,8 +79,11 @@ ALL_ALGORITHM_STEP_PARAMETERS = {
     "n_drivers",
     # DIRK buffer location parameters
     "stage_increment_location",
+    "stage_increment_history_location",
     "stage_base_location",
     "accumulator_location",
+    # Dense stage predictor buffer location parameters
+    "previous_step_size_location",
     # ERK buffer location parameters
     "stage_rhs_location",
     "stage_accumulator_location",
@@ -629,7 +633,6 @@ class BaseAlgorithmStep(CUDAFactory):
         super().__init__()
         self._controller_defaults = _controller_defaults.copy()
         self.setup_compile_settings(config)
-        self.is_controller_fixed = False  # Set by check_compatibility
 
     def register_buffers(self) -> None:
         """Register buffers required by the algorithm step."""

--- a/src/cubie/integrators/algorithms/generic_dirk.py
+++ b/src/cubie/integrators/algorithms/generic_dirk.py
@@ -62,9 +62,6 @@ from cubie.integrators.stage_predictors import DenseStagePredictor
 from cubie.buffer_registry import buffer_registry
 
 
-
-
-
 DIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
     step_controller={
         "step_controller": "gustafsson",
@@ -109,6 +106,8 @@ Fixed-step controllers maintain a constant step size throughout the
 integration. This is the only valid choice for errorless tableaus since
 adaptive stepping requires an error estimate to adjust the step size.
 """
+
+
 @define
 class DIRKStepConfig(ImplicitStepConfig):
     """Configuration describing the DIRK integrator.
@@ -169,6 +168,7 @@ class DIRKStepConfig(ImplicitStepConfig):
         default='local',
         validator=validators.in_(['local', 'shared'])
     )
+
 
 class DIRKStep(ODEImplicitStep):
     """Diagonally implicit Runge–Kutta step with an embedded error estimate."""
@@ -262,7 +262,7 @@ class DIRKStep(ODEImplicitStep):
         predictor_kwargs = {
             key: value
             for key, value in kwargs.items()
-            if key == "previous_step_size_location" and value is not None
+            if key in self._PREDICTOR_PARAMS and value is not None
         }
         self.dense_predictor = DenseStagePredictor(
             precision=self.compile_settings.precision,
@@ -279,13 +279,16 @@ class DIRKStep(ODEImplicitStep):
         n = config.n
         tableau = config.tableau
 
-        # Clear this step's own registrations only: the nonlinear
-        # solver child keeps its still-valid declarations, and
-        # register_child below re-records it with fresh sizes.
+        # Clear this step's own registrations only: child factories
+        # keep their still-valid declarations, and register_child
+        # below re-records them with fresh sizes.
         buffer_registry.clear_own(self)
 
         # Calculate buffer sizes
         accumulator_length = max(tableau.stage_count - 1, 0) * n
+        history_length = (
+            tableau.stage_count * n if self.dense_prediction else 0
+        )
 
         # Register solver scratch and solver persistent buffers so they can
         # be aliased
@@ -294,19 +297,17 @@ class DIRKStep(ODEImplicitStep):
                 self.solver,
                 name='solver'
         )
-        if self.dense_prediction:
-            buffer_registry.register_child(
-                self, self.dense_predictor, name='dense_predictor'
-            )
-            buffer_registry.register(
-                'stage_increment_history',
-                self,
-                tableau.stage_count * n,
-                config.stage_increment_history_location,
-                persistent=True,
-                precision=precision
-            )
-
+        buffer_registry.register_child(
+            self, self.dense_predictor, name='dense_predictor'
+        )
+        buffer_registry.register(
+            'stage_increment_history',
+            self,
+            history_length,
+            config.stage_increment_history_location,
+            persistent=True,
+            precision=precision
+        )
         buffer_registry.register(
             'stage_increment',
             self,
@@ -322,7 +323,6 @@ class DIRKStep(ODEImplicitStep):
             config.accumulator_location,
             precision=precision
         )
-
 
         buffer_registry.register(
             'stage_base',
@@ -387,7 +387,14 @@ class DIRKStep(ODEImplicitStep):
         )
 
         self.update_compile_settings(
-                {'solver_function': self.solver.device_function}
+            {
+                'solver_function': self.solver.device_function,
+                'predictor_function': (
+                    self.dense_predictor.device_function
+                    if self.dense_prediction
+                    else None
+                ),
+            }
         )
 
     def build_step(
@@ -406,15 +413,8 @@ class DIRKStep(ODEImplicitStep):
         tableau = config.tableau
         nonlinear_solver = solver_function
 
-        # Accepted steps warm-start each stage's Newton solve by
-        # reading the previous step's stage curve ahead over the next
-        # step; the step-size ratio is handled at runtime, so any
-        # controller benefits.
         use_dense_prediction = self.dense_prediction
-        if use_dense_prediction:
-            predict_stages = self.dense_predictor.device_function
-        else:
-            predict_stages = None
+        predict_stages = config.predictor_function
 
         n = int32(n)
         stage_count = int32(tableau.stage_count)
@@ -464,21 +464,14 @@ class DIRKStep(ODEImplicitStep):
         alloc_accumulator = getalloc('accumulator', self)
         alloc_stage_base = getalloc('stage_base', self)
         alloc_stage_rhs = getalloc('stage_rhs', self)
-        if use_dense_prediction:
-            alloc_stage_increment_history = getalloc(
-                'stage_increment_history', self
+        alloc_stage_increment_history = getalloc(
+            'stage_increment_history', self
+        )
+        alloc_predictor_shared, alloc_predictor_persistent = (
+            buffer_registry.get_child_allocators(
+                self, self.dense_predictor, name='dense_predictor'
             )
-            alloc_predictor_shared, alloc_predictor_persistent = (
-                buffer_registry.get_child_allocators(
-                    self, self.dense_predictor, name='dense_predictor'
-                )
-            )
-        else:
-            alloc_stage_increment_history = None
-            alloc_predictor_shared = None
-            alloc_predictor_persistent = None
-
-
+        )
 
         # no cover: start
         @cuda.jit(
@@ -529,16 +522,15 @@ class DIRKStep(ODEImplicitStep):
             solver_shared = alloc_solver_shared(shared, persistent_local)
             solver_persistent = alloc_solver_persistent(shared, persistent_local)
             stage_rhs = alloc_stage_rhs(shared, persistent_local)
-            if use_dense_prediction:
-                stage_increment_history = alloc_stage_increment_history(
-                    shared, persistent_local
-                )
-                predictor_shared = alloc_predictor_shared(
-                    shared, persistent_local
-                )
-                predictor_persistent = alloc_predictor_persistent(
-                    shared, persistent_local
-                )
+            stage_increment_history = alloc_stage_increment_history(
+                shared, persistent_local
+            )
+            predictor_shared = alloc_predictor_shared(
+                shared, persistent_local
+            )
+            predictor_persistent = alloc_predictor_persistent(
+                shared, persistent_local
+            )
 
             for _i in range(accumulator_length):
                 stage_accumulator[_i] = typed_zero
@@ -609,11 +601,10 @@ class DIRKStep(ODEImplicitStep):
 
                 if stage_implicit[0]:
                     if use_dense_prediction:
-                        if apply_prediction:
-                            for idx in range(n):
-                                stage_increment[idx] = (
-                                    stage_increment_history[idx]
-                                )
+                        for idx in range(n):
+                            stage_increment[idx] = (
+                                stage_increment_history[idx]
+                            )
                     solver_status = nonlinear_solver(
                         stage_increment,
                         parameters,
@@ -676,7 +667,7 @@ class DIRKStep(ODEImplicitStep):
                     elif b_hat_row == int32(0):
                         # Direct assignment for error
                         error[idx] = stage_base[idx]
-                        
+
             for idx in range(accumulator_length):
                 stage_accumulator[idx] = typed_zero
 
@@ -719,13 +710,12 @@ class DIRKStep(ODEImplicitStep):
                 if stage_implicit[stage_idx]:
                     if use_dense_prediction:
                         history_offset = stage_idx * n
-                        if apply_prediction:
-                            for idx in range(n):
-                                stage_increment[idx] = (
-                                    stage_increment_history[
-                                        history_offset + idx
-                                    ]
-                                )
+                        for idx in range(n):
+                            stage_increment[idx] = (
+                                stage_increment_history[
+                                    history_offset + idx
+                                ]
+                            )
                     solver_status = nonlinear_solver(
                         stage_increment,
                         parameters,
@@ -742,7 +732,6 @@ class DIRKStep(ODEImplicitStep):
                     status_code = int32(status_code | solver_status)
 
                     if use_dense_prediction:
-                        history_offset = stage_idx * n
                         for idx in range(n):
                             stage_increment_history[
                                 history_offset + idx
@@ -820,7 +809,6 @@ class DIRKStep(ODEImplicitStep):
     def is_multistage(self) -> bool:
         """Return ``True`` as the method has multiple stages."""
         return self.tableau.stage_count > 1
-
 
     @property
     def is_adaptive(self) -> bool:

--- a/src/cubie/integrators/algorithms/generic_dirk.py
+++ b/src/cubie/integrators/algorithms/generic_dirk.py
@@ -39,7 +39,11 @@ from typing import Callable, Optional
 from attrs import define, field, validators
 from cubie.cuda_simsafe import cuda, int32
 
-from cubie._utils import PrecisionDType, build_config
+from cubie._utils import (
+    PrecisionDType,
+    build_config,
+    is_device_validator,
+)
 from cubie.cuda_simsafe import activemask, all_sync
 from cubie.result_codes import CUBIE_RESULT_CODES
 from cubie.integrators.algorithms.base_algorithm_step import (
@@ -54,6 +58,7 @@ from cubie.integrators.algorithms.ode_implicitstep import (
     ImplicitStepConfig,
     ODEImplicitStep,
 )
+from cubie.integrators.stage_predictors import DenseStagePredictor
 from cubie.buffer_registry import buffer_registry
 
 
@@ -106,12 +111,49 @@ adaptive stepping requires an error estimate to adjust the step size.
 """
 @define
 class DIRKStepConfig(ImplicitStepConfig):
-    """Configuration describing the DIRK integrator."""
+    """Configuration describing the DIRK integrator.
+
+    Attributes
+    ----------
+    tableau : DIRKTableau
+        Butcher tableau describing the diagonally implicit method.
+    attempt_dense_prediction : bool
+        Request dense stage prediction: accepted steps warm-start
+        each stage's Newton solve by reading the previous step's
+        stage curve ahead over the next step. Ignored when the
+        tableau does not meet the transform's preconditions.
+    predictor_function : Callable or None
+        Compiled dense-prediction device function, piped through
+        compile settings so predictor rebuilds invalidate the step.
+    stage_increment_location : str
+        Buffer location for the working stage-increment vector.
+    stage_increment_history_location : str
+        Buffer location for the previous step's per-stage increment
+        history consumed by dense prediction.
+    stage_base_location : str
+        Buffer location for the stage base-state vector.
+    accumulator_location : str
+        Buffer location for the explicit stage accumulator.
+    stage_rhs_location : str
+        Buffer location for the cached stage right-hand side.
+    """
 
     tableau: DIRKTableau = field(
         default=DEFAULT_DIRK_TABLEAU,
     )
+    attempt_dense_prediction: bool = field(
+        default=True, validator=validators.instance_of(bool)
+    )
+    predictor_function: Optional[Callable] = field(
+        default=None,
+        validator=validators.optional(is_device_validator),
+        eq=False,
+    )
     stage_increment_location: str = field(
+        default='local',
+        validator=validators.in_(['local', 'shared'])
+    )
+    stage_increment_history_location: str = field(
         default='local',
         validator=validators.in_(['local', 'shared'])
     )
@@ -141,6 +183,7 @@ class DIRKStep(ODEImplicitStep):
         get_solver_helper_fn: Optional[Callable] = None,
         tableau: DIRKTableau = DEFAULT_DIRK_TABLEAU,
         n_drivers: int = 0,
+        attempt_dense_prediction: bool = True,
         **kwargs,
     ) -> None:
         """Initialise the DIRK step configuration.
@@ -170,6 +213,9 @@ class DIRKStep(ODEImplicitStep):
             :data:`DEFAULT_DIRK_TABLEAU`.
         n_drivers
             Number of driver variables in the system.
+        attempt_dense_prediction
+            Request dense stage prediction; ignored when the tableau
+            does not meet the transform's preconditions.
         **kwargs
             Optional parameters passed to config classes. See
             DIRKStepConfig, ImplicitStepConfig, and solver config classes
@@ -198,6 +244,7 @@ class DIRKStep(ODEImplicitStep):
                 'evaluate_driver_at_t': evaluate_driver_at_t,
                 'get_solver_helper_fn': get_solver_helper_fn,
                 'tableau': tableau,
+                'attempt_dense_prediction': attempt_dense_prediction,
                 'beta': 1.0,
                 'gamma': 1.0,
             },
@@ -212,6 +259,17 @@ class DIRKStep(ODEImplicitStep):
 
         super().__init__(config, controller_defaults, **kwargs)
 
+        predictor_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key == "previous_step_size_location" and value is not None
+        }
+        self.dense_predictor = DenseStagePredictor(
+            precision=self.compile_settings.precision,
+            n=n,
+            tableau=tableau,
+            **predictor_kwargs,
+        )
         self.register_buffers()
 
     def register_buffers(self) -> None:
@@ -236,6 +294,18 @@ class DIRKStep(ODEImplicitStep):
                 self.solver,
                 name='solver'
         )
+        if self.dense_prediction:
+            buffer_registry.register_child(
+                self, self.dense_predictor, name='dense_predictor'
+            )
+            buffer_registry.register(
+                'stage_increment_history',
+                self,
+                tableau.stage_count * n,
+                config.stage_increment_history_location,
+                persistent=True,
+                precision=precision
+            )
 
         buffer_registry.register(
             'stage_increment',
@@ -336,6 +406,16 @@ class DIRKStep(ODEImplicitStep):
         tableau = config.tableau
         nonlinear_solver = solver_function
 
+        # Accepted steps warm-start each stage's Newton solve by
+        # reading the previous step's stage curve ahead over the next
+        # step; the step-size ratio is handled at runtime, so any
+        # controller benefits.
+        use_dense_prediction = self.dense_prediction
+        if use_dense_prediction:
+            predict_stages = self.dense_predictor.device_function
+        else:
+            predict_stages = None
+
         n = int32(n)
         stage_count = int32(tableau.stage_count)
         stages_except_first = stage_count - int32(1)
@@ -384,6 +464,19 @@ class DIRKStep(ODEImplicitStep):
         alloc_accumulator = getalloc('accumulator', self)
         alloc_stage_base = getalloc('stage_base', self)
         alloc_stage_rhs = getalloc('stage_rhs', self)
+        if use_dense_prediction:
+            alloc_stage_increment_history = getalloc(
+                'stage_increment_history', self
+            )
+            alloc_predictor_shared, alloc_predictor_persistent = (
+                buffer_registry.get_child_allocators(
+                    self, self.dense_predictor, name='dense_predictor'
+                )
+            )
+        else:
+            alloc_stage_increment_history = None
+            alloc_predictor_shared = None
+            alloc_predictor_persistent = None
 
 
 
@@ -436,6 +529,16 @@ class DIRKStep(ODEImplicitStep):
             solver_shared = alloc_solver_shared(shared, persistent_local)
             solver_persistent = alloc_solver_persistent(shared, persistent_local)
             stage_rhs = alloc_stage_rhs(shared, persistent_local)
+            if use_dense_prediction:
+                stage_increment_history = alloc_stage_increment_history(
+                    shared, persistent_local
+                )
+                predictor_shared = alloc_predictor_shared(
+                    shared, persistent_local
+                )
+                predictor_persistent = alloc_predictor_persistent(
+                    shared, persistent_local
+                )
 
             for _i in range(accumulator_length):
                 stage_accumulator[_i] = typed_zero
@@ -454,6 +557,20 @@ class DIRKStep(ODEImplicitStep):
             # --------------------------------------------------------------- #
 
             first_step = first_step_flag != int32(0)
+
+            if use_dense_prediction:
+                # No previous curve exists on the first step, and a
+                # rejected proposal's curve does not end where this
+                # step starts, so both leave the history unchanged.
+                previous_accepted = accepted_flag != int32(0)
+                apply_prediction = (not first_step) and previous_accepted
+                predict_stages(
+                    stage_increment_history,
+                    dt_scalar,
+                    apply_prediction,
+                    predictor_shared,
+                    predictor_persistent,
+                )
 
             # Only use cache if all threads in warp can - otherwise no gain
             use_cached_rhs = False
@@ -491,6 +608,12 @@ class DIRKStep(ODEImplicitStep):
                         )
 
                 if stage_implicit[0]:
+                    if use_dense_prediction:
+                        if apply_prediction:
+                            for idx in range(n):
+                                stage_increment[idx] = (
+                                    stage_increment_history[idx]
+                                )
                     solver_status = nonlinear_solver(
                         stage_increment,
                         parameters,
@@ -505,6 +628,12 @@ class DIRKStep(ODEImplicitStep):
                         counters,
                     )
                     status_code = int32(status_code | solver_status)
+
+                    if use_dense_prediction:
+                        for idx in range(n):
+                            stage_increment_history[idx] = (
+                                stage_increment[idx]
+                            )
 
                     for idx in range(n):
                         stage_base[idx] += (
@@ -588,6 +717,15 @@ class DIRKStep(ODEImplicitStep):
                 diagonal_coeff = diagonal_coeffs[stage_idx]
 
                 if stage_implicit[stage_idx]:
+                    if use_dense_prediction:
+                        history_offset = stage_idx * n
+                        if apply_prediction:
+                            for idx in range(n):
+                                stage_increment[idx] = (
+                                    stage_increment_history[
+                                        history_offset + idx
+                                    ]
+                                )
                     solver_status = nonlinear_solver(
                         stage_increment,
                         parameters,
@@ -602,6 +740,13 @@ class DIRKStep(ODEImplicitStep):
                         counters,
                     )
                     status_code = int32(status_code | solver_status)
+
+                    if use_dense_prediction:
+                        history_offset = stage_idx * n
+                        for idx in range(n):
+                            stage_increment_history[
+                                history_offset + idx
+                            ] = stage_increment[idx]
 
                     for idx in range(n):
                         stage_base[idx] += diagonal_coeff * stage_increment[idx]

--- a/src/cubie/integrators/algorithms/generic_firk.py
+++ b/src/cubie/integrators/algorithms/generic_firk.py
@@ -42,7 +42,11 @@ from cubie.cuda_simsafe import cuda, int32
 
 from cubie.result_codes import CUBIE_RESULT_CODES
 
-from cubie._utils import PrecisionDType, build_config
+from cubie._utils import (
+    PrecisionDType,
+    build_config,
+    is_device_validator,
+)
 from cubie.integrators.algorithms.base_algorithm_step import (
     StepCache,
     StepControlDefaults,
@@ -56,6 +60,7 @@ from cubie.integrators.algorithms.ode_implicitstep import (
     ODEImplicitStep,
 )
 from cubie.integrators.norms import FIRKCorrectionNorm, TiledScaledNorm
+from cubie.integrators.stage_predictors import DenseStagePredictor
 from cubie.buffer_registry import buffer_registry
 
 
@@ -106,10 +111,38 @@ adaptive stepping requires an error estimate to adjust the step size.
 
 @define
 class FIRKStepConfig(ImplicitStepConfig):
-    """Configuration describing the FIRK integrator."""
+    """Configuration describing the FIRK integrator.
+
+    Attributes
+    ----------
+    tableau : FIRKTableau
+        Butcher tableau describing the fully implicit method.
+    attempt_dense_prediction : bool
+        Request dense stage prediction: accepted steps warm-start
+        Newton by reading the previous step's stage curve ahead over
+        the next step. Ignored when the tableau does not meet the
+        transform's preconditions.
+    predictor_function : Callable or None
+        Compiled dense-prediction device function, piped through
+        compile settings so predictor rebuilds invalidate the step.
+    stage_increment_location : str
+        Buffer location for the coupled stage-increment vector.
+    stage_driver_stack_location : str
+        Buffer location for the per-stage driver samples.
+    stage_state_location : str
+        Buffer location for the stage-state scratch vector.
+    """
 
     tableau: FIRKTableau = field(
         default=DEFAULT_FIRK_TABLEAU,
+    )
+    attempt_dense_prediction: bool = field(
+        default=True, validator=validators.instance_of(bool)
+    )
+    predictor_function: Optional[Callable] = field(
+        default=None,
+        validator=validators.optional(is_device_validator),
+        eq=False,
     )
     stage_increment_location: str = field(
         default="local", validator=validators.in_(["local", "shared"])
@@ -153,6 +186,7 @@ class FIRKStep(ODEImplicitStep):
         get_solver_helper_fn: Optional[Callable] = None,
         tableau: FIRKTableau = DEFAULT_FIRK_TABLEAU,
         n_drivers: int = 0,
+        attempt_dense_prediction: bool = True,
         **kwargs,
     ) -> None:
         """Initialise the FIRK step configuration.
@@ -182,6 +216,9 @@ class FIRKStep(ODEImplicitStep):
             :data:`DEFAULT_FIRK_TABLEAU`.
         n_drivers
             Number of driver variables in the system.
+        attempt_dense_prediction
+            Request dense stage prediction; ignored when the tableau
+            does not meet the transform's preconditions.
         **kwargs
             Optional parameters passed to config classes. See
             FIRKStepConfig, ImplicitStepConfig, and solver config classes
@@ -214,6 +251,7 @@ class FIRKStep(ODEImplicitStep):
                 "evaluate_driver_at_t": evaluate_driver_at_t,
                 "get_solver_helper_fn": get_solver_helper_fn,
                 "tableau": tableau,
+                "attempt_dense_prediction": attempt_dense_prediction,
                 "beta": 1.0,
                 "gamma": 1.0,
             },
@@ -250,6 +288,17 @@ class FIRKStep(ODEImplicitStep):
             krylov_norm=krylov_norm,
             **kwargs,
         )
+        predictor_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key == "previous_step_size_location" and value is not None
+        }
+        self.dense_predictor = DenseStagePredictor(
+            precision=self.compile_settings.precision,
+            n=n,
+            tableau=tableau,
+            **predictor_kwargs,
+        )
         self.register_buffers()
 
     def register_buffers(self) -> None:
@@ -259,6 +308,11 @@ class FIRKStep(ODEImplicitStep):
         n = config.n
         tableau = config.tableau
 
+        # Clear this step's own registrations only: child factories
+        # keep their still-valid declarations, and register_child
+        # below re-records them with fresh sizes.
+        buffer_registry.clear_own(self)
+
         # Calculate buffer sizes
         all_stages_n = tableau.stage_count * n
         stage_driver_stack_elements = tableau.stage_count * config.n_drivers
@@ -266,6 +320,10 @@ class FIRKStep(ODEImplicitStep):
         buffer_registry.register_child(
             self, self.solver, name="solver"
         )
+        if self.dense_prediction:
+            buffer_registry.register_child(
+                self, self.dense_predictor, name="dense_predictor"
+            )
         buffer_registry.register(
             "stage_increment",
             self,
@@ -360,6 +418,15 @@ class FIRKStep(ODEImplicitStep):
         config = self.compile_settings
         tableau = config.tableau
 
+        # Accepted steps warm-start Newton by reading the previous
+        # step's stage curve ahead over the next step; the step-size
+        # ratio is handled at runtime, so any controller benefits.
+        use_dense_prediction = self.dense_prediction
+        if use_dense_prediction:
+            predict_stages = self.dense_predictor.device_function
+        else:
+            predict_stages = None
+
         nonlinear_solver = solver_function
 
         n = int32(n)
@@ -406,6 +473,15 @@ class FIRKStep(ODEImplicitStep):
                 self, self.solver, name="solver"
             )
         )
+        if use_dense_prediction:
+            alloc_predictor_shared, alloc_predictor_persistent = (
+                buffer_registry.get_child_allocators(
+                    self, self.dense_predictor, name="dense_predictor"
+                )
+            )
+        else:
+            alloc_predictor_shared = None
+            alloc_predictor_persistent = None
 
         # no cover: start
         @cuda.jit(
@@ -461,12 +537,34 @@ class FIRKStep(ODEImplicitStep):
             stage_driver_stack = alloc_stage_driver_stack(
                 shared, persistent_local
             )
+            if use_dense_prediction:
+                predictor_shared = alloc_predictor_shared(
+                    shared, persistent_local
+                )
+                predictor_persistent = alloc_predictor_persistent(
+                    shared, persistent_local
+                )
 
             # ----------------------------------------------------------- #
 
             current_time = time_scalar
             end_time = current_time + dt_scalar
             status_code = success
+
+            if use_dense_prediction:
+                # No previous curve exists on the first step, and a
+                # rejected proposal's curve does not end where this
+                # step starts, so both carry the increments unchanged.
+                first_step = first_step_flag != int32(0)
+                previous_accepted = accepted_flag != int32(0)
+                apply_prediction = (not first_step) and previous_accepted
+                predict_stages(
+                    stage_increment,
+                    dt_scalar,
+                    apply_prediction,
+                    predictor_shared,
+                    predictor_persistent,
+                )
 
             for idx in range(n):
                 if accumulates_output:

--- a/src/cubie/integrators/algorithms/generic_firk.py
+++ b/src/cubie/integrators/algorithms/generic_firk.py
@@ -291,7 +291,7 @@ class FIRKStep(ODEImplicitStep):
         predictor_kwargs = {
             key: value
             for key, value in kwargs.items()
-            if key == "previous_step_size_location" and value is not None
+            if key in self._PREDICTOR_PARAMS and value is not None
         }
         self.dense_predictor = DenseStagePredictor(
             precision=self.compile_settings.precision,
@@ -320,10 +320,9 @@ class FIRKStep(ODEImplicitStep):
         buffer_registry.register_child(
             self, self.solver, name="solver"
         )
-        if self.dense_prediction:
-            buffer_registry.register_child(
-                self, self.dense_predictor, name="dense_predictor"
-            )
+        buffer_registry.register_child(
+            self, self.dense_predictor, name="dense_predictor"
+        )
         buffer_registry.register(
             "stage_increment",
             self,
@@ -400,7 +399,14 @@ class FIRKStep(ODEImplicitStep):
         )
 
         self.update_compile_settings(
-            {"solver_function": self.solver.device_function}
+            {
+                "solver_function": self.solver.device_function,
+                "predictor_function": (
+                    self.dense_predictor.device_function
+                    if self.dense_prediction
+                    else None
+                ),
+            }
         )
 
     def build_step(
@@ -418,14 +424,8 @@ class FIRKStep(ODEImplicitStep):
         config = self.compile_settings
         tableau = config.tableau
 
-        # Accepted steps warm-start Newton by reading the previous
-        # step's stage curve ahead over the next step; the step-size
-        # ratio is handled at runtime, so any controller benefits.
         use_dense_prediction = self.dense_prediction
-        if use_dense_prediction:
-            predict_stages = self.dense_predictor.device_function
-        else:
-            predict_stages = None
+        predict_stages = config.predictor_function
 
         nonlinear_solver = solver_function
 
@@ -473,15 +473,11 @@ class FIRKStep(ODEImplicitStep):
                 self, self.solver, name="solver"
             )
         )
-        if use_dense_prediction:
-            alloc_predictor_shared, alloc_predictor_persistent = (
-                buffer_registry.get_child_allocators(
-                    self, self.dense_predictor, name="dense_predictor"
-                )
+        alloc_predictor_shared, alloc_predictor_persistent = (
+            buffer_registry.get_child_allocators(
+                self, self.dense_predictor, name="dense_predictor"
             )
-        else:
-            alloc_predictor_shared = None
-            alloc_predictor_persistent = None
+        )
 
         # no cover: start
         @cuda.jit(
@@ -537,13 +533,12 @@ class FIRKStep(ODEImplicitStep):
             stage_driver_stack = alloc_stage_driver_stack(
                 shared, persistent_local
             )
-            if use_dense_prediction:
-                predictor_shared = alloc_predictor_shared(
-                    shared, persistent_local
-                )
-                predictor_persistent = alloc_predictor_persistent(
-                    shared, persistent_local
-                )
+            predictor_shared = alloc_predictor_shared(
+                shared, persistent_local
+            )
+            predictor_persistent = alloc_predictor_persistent(
+                shared, persistent_local
+            )
 
             # ----------------------------------------------------------- #
 

--- a/src/cubie/integrators/algorithms/generic_firk_tableaus.py
+++ b/src/cubie/integrators/algorithms/generic_firk_tableaus.py
@@ -146,11 +146,69 @@ RADAU_IIA_5_TABLEAU = FIRKTableau(
     order=5,
 )
 
+GAUSS_LEGENDRE_4_TABLEAU = FIRKTableau(
+    a=(
+        (
+            0.08696371128436345,
+            -0.026604180084998798,
+            0.012627462689404742,
+            -0.003555149685795684,
+        ),
+        (
+            0.188118117499868,
+            0.16303628871563644,
+            -0.027880428602470995,
+            0.006735500594538164,
+        ),
+        (
+            0.1671919219741886,
+            0.3539530060337439,
+            0.16303628871563638,
+            -0.014190694931141147,
+        ),
+        (
+            0.17748257225452202,
+            0.3134451147418685,
+            0.3526767575162713,
+            0.08696371128436325,
+        ),
+    ),
+    b=(
+        0.17392742256872662,
+        0.32607257743127305,
+        0.3260725774312722,
+        0.1739274225687269,
+    ),
+    c=(
+        0.06943184420297371,
+        0.33000947820757187,
+        0.6699905217924281,
+        0.9305681557970262,
+    ),
+    order=8,
+)
+"""Four-stage Gauss--Legendre collocation tableau of order eight.
+
+Collocation at the four Gauss--Legendre quadrature nodes on the unit
+interval: each ``a[i][j]`` integrates the j-th Lagrange basis
+polynomial from zero to ``c[i]`` and each ``b[j]`` integrates it over
+the whole step. The coefficients are float64 literals of that
+construction. No embedded error estimate exists, so the method
+requires a fixed step controller.
+
+References
+----------
+Hairer, E., & Wanner, G. (1996). *Solving Ordinary Differential
+Equations II: Stiff and Differential-Algebraic Problems* (2nd ed.).
+Springer. Theorem IV.5.2.
+"""
+
 DEFAULT_FIRK_TABLEAU = GAUSS_LEGENDRE_2_TABLEAU
 
 
 FIRK_TABLEAU_REGISTRY: Dict[str, FIRKTableau] = {
     "firk_gauss_legendre_2": GAUSS_LEGENDRE_2_TABLEAU,
+    "firk_gauss_legendre_4": GAUSS_LEGENDRE_4_TABLEAU,
     "radau_iia_5": RADAU_IIA_5_TABLEAU,
     "radau": RADAU_IIA_5_TABLEAU,
 }

--- a/src/cubie/integrators/algorithms/ode_implicitstep.py
+++ b/src/cubie/integrators/algorithms/ode_implicitstep.py
@@ -45,6 +45,9 @@ from cubie.integrators.algorithms.base_algorithm_step import (
     StepCache,
     StepControlDefaults,
 )
+from cubie.integrators.stage_predictors import (
+    tableau_supports_dense_prediction,
+)
 
 
 @define
@@ -196,6 +199,10 @@ class ODEImplicitStep(BaseAlgorithmStep):
         """
         super().__init__(config, _controller_defaults)
 
+        # Subclasses that support dense stage prediction construct a
+        # DenseStagePredictor here after solver construction.
+        self.dense_predictor = None
+
         if solver_type not in ["newton", "linear"]:
             raise ValueError(
                 f"solver_type must be 'newton' or 'linear', got '{solver_type}'"
@@ -277,8 +284,11 @@ class ODEImplicitStep(BaseAlgorithmStep):
 
         Notes
         -----
-        Delegates solver parameters to owned solver instance.
-        Invalidates step cache only if solver cache was invalidated.
+        Delegates solver parameters to the owned solver instance and,
+        when the algorithm owns a dense stage predictor, predictor
+        parameters to the predictor. The child device functions are
+        piped through compile settings so a child rebuild invalidates
+        the step cache.
         """
         all_updates = {}
         if updates_dict:
@@ -294,9 +304,34 @@ class ODEImplicitStep(BaseAlgorithmStep):
 
         all_updates["solver_function"] = self.solver.device_function
 
+        if self.dense_predictor is not None:
+            recognized |= self.dense_predictor.update(
+                all_updates, silent=True
+            )
+            all_updates["predictor_function"] = (
+                self.dense_predictor.device_function
+                if self.dense_prediction
+                else None
+            )
+
         recognized |= super().update(all_updates, silent=True)
 
         return recognized
+
+    @property
+    def dense_prediction(self) -> bool:
+        """Return whether dense stage prediction compiles into the step.
+
+        True only when the algorithm owns a predictor, prediction is
+        requested, and the tableau meets the transform preconditions.
+        """
+        if self.dense_predictor is None:
+            return False
+        config = self.compile_settings
+        return bool(
+            config.attempt_dense_prediction
+            and tableau_supports_dense_prediction(config.tableau)
+        )
 
     def build(self) -> StepCache:
         """Create and cache the device helpers for the implicit algorithm.

--- a/src/cubie/integrators/algorithms/ode_implicitstep.py
+++ b/src/cubie/integrators/algorithms/ode_implicitstep.py
@@ -171,6 +171,9 @@ class ODEImplicitStep(BaseAlgorithmStep):
         }
     )
 
+    # Parameters accepted by DenseStagePredictor
+    _PREDICTOR_PARAMS = frozenset({"previous_step_size_location"})
+
     def __init__(
         self,
         config: ImplicitStepConfig,

--- a/src/cubie/integrators/algorithms/ode_implicitstep.py
+++ b/src/cubie/integrators/algorithms/ode_implicitstep.py
@@ -289,9 +289,7 @@ class ODEImplicitStep(BaseAlgorithmStep):
         -----
         Delegates solver parameters to the owned solver instance and,
         when the algorithm owns a dense stage predictor, predictor
-        parameters to the predictor. The child device functions are
-        piped through compile settings so a child rebuild invalidates
-        the step cache.
+        parameters to the predictor.
         """
         all_updates = {}
         if updates_dict:

--- a/src/cubie/integrators/stage_predictors.py
+++ b/src/cubie/integrators/stage_predictors.py
@@ -498,17 +498,13 @@ class DenseStagePredictor(CUDAFactory):
             previous_dt = previous_step_size[0]
             previous_step_size[0] = dt_scalar
 
-            # Unwritten storage reads zero before the first step;
-            # substituting the current step size keeps the ratio
-            # finite and the commit predicate discards the result.
+            # Keep the ratio finite on zeroed first-step storage.
             safe_previous_dt = (
                 previous_dt if previous_dt > typed_zero else dt_scalar
             )
             ratio = dt_scalar / safe_previous_dt
 
-            # A truncated previous step can make the ratio arbitrarily
-            # large; the read-ahead is only meaningful within the
-            # controllers' growth bound.
+            # Truncated slivers unbound the ratio; cap application.
             commit_prediction = apply_flag and (
                 ratio <= max_step_ratio
             )

--- a/src/cubie/integrators/stage_predictors.py
+++ b/src/cubie/integrators/stage_predictors.py
@@ -311,7 +311,10 @@ class DenseStagePredictorConfig(CUDAFactoryConfig):
     """
 
     n: int = field(default=1, validator=getype_validator(int, 1))
-    tableau: ButcherTableau = field(default=None)
+    tableau: ButcherTableau = field(
+        default=None,
+        validator=validators.instance_of(ButcherTableau),
+    )
     previous_step_size_location: str = field(
         default="local",
         validator=validators.in_(["local", "shared"]),
@@ -386,15 +389,30 @@ class DenseStagePredictor(CUDAFactory):
         self.register_buffers()
 
     def register_buffers(self) -> None:
-        """Register the previous-step-size scalar with the registry."""
+        """Register the predictor's buffers with the registry."""
 
         config = self.compile_settings
+        stage_count = int(config.stage_count)
         buffer_registry.register(
             "previous_step_size",
             self,
             1,
             config.previous_step_size_location,
             persistent=True,
+            precision=config.precision,
+        )
+        buffer_registry.register(
+            "predictor_transform",
+            self,
+            stage_count * stage_count,
+            "local",
+            precision=config.precision,
+        )
+        buffer_registry.register(
+            "predictor_previous_values",
+            self,
+            stage_count,
+            "local",
             precision=config.precision,
         )
 
@@ -435,11 +453,9 @@ class DenseStagePredictor(CUDAFactory):
         typed_zero = numba_precision(0.0)
         n = int32(config.n)
         stage_count = int32(config.stage_count)
-        # Local scratch shapes must be plain Python ints at compile
-        # time.
-        stage_count_py = int(config.stage_count)
-        transform_size_py = stage_count_py * stage_count_py
-        transform_size = int32(transform_size_py)
+        transform_size = int32(
+            int(config.stage_count) * int(config.stage_count)
+        )
 
         # Flattened power-major coefficient stack: entry
         # [power][row][column] multiplies ratio ** (power + 1).
@@ -452,8 +468,11 @@ class DenseStagePredictor(CUDAFactory):
 
         max_step_ratio = numba_precision(MAX_PREDICTION_STEP_RATIO)
 
-        alloc_previous_step_size = buffer_registry.get_allocator(
-            "previous_step_size", self
+        getalloc = buffer_registry.get_allocator
+        alloc_previous_step_size = getalloc("previous_step_size", self)
+        alloc_transform = getalloc("predictor_transform", self)
+        alloc_previous_values = getalloc(
+            "predictor_previous_values", self
         )
 
         # no cover: start
@@ -472,55 +491,61 @@ class DenseStagePredictor(CUDAFactory):
             previous_step_size = alloc_previous_step_size(
                 shared, persistent_local
             )
+            transform = alloc_transform(shared, persistent_local)
+            previous_values = alloc_previous_values(
+                shared, persistent_local
+            )
             previous_dt = previous_step_size[0]
             previous_step_size[0] = dt_scalar
 
-            if apply_flag:
-                ratio = dt_scalar / previous_dt
+            # Unwritten storage reads zero before the first step;
+            # substituting the current step size keeps the ratio
+            # finite and the commit predicate discards the result.
+            safe_previous_dt = (
+                previous_dt if previous_dt > typed_zero else dt_scalar
+            )
+            ratio = dt_scalar / safe_previous_dt
 
-                # A truncated previous step can make the ratio
-                # arbitrarily large (or infinite on unwritten
-                # storage); the read-ahead is only meaningful within
-                # the controllers' growth bound.
-                if ratio > max_step_ratio:
-                    return
+            # A truncated previous step can make the ratio arbitrarily
+            # large; the read-ahead is only meaningful within the
+            # controllers' growth bound.
+            commit_prediction = apply_flag and (
+                ratio <= max_step_ratio
+            )
 
-                # Evaluate each matrix entry's ratio polynomial,
-                # highest power first.
-                transform = cuda.local.array(
-                    transform_size_py, numba_precision
-                )
-                for entry_idx in range(transform_size):
+            # Evaluate each matrix entry's ratio polynomial, highest
+            # power first.
+            for entry_idx in range(transform_size):
+                accumulator = typed_zero
+                for power_idx in range(stage_count):
+                    flat_idx = (
+                        (stage_count - int32(1) - power_idx)
+                        * transform_size
+                        + entry_idx
+                    )
+                    accumulator = (
+                        accumulator * ratio
+                        + ratio_coefficients[flat_idx]
+                    )
+                transform[entry_idx] = accumulator * ratio
+
+            # Multiply each state's stage vector by the matrix,
+            # committing only when the caller's flag and the ratio
+            # bound allow.
+            for state_idx in range(n):
+                for stage_idx in range(stage_count):
+                    previous_values[stage_idx] = stage_increment[
+                        stage_idx * n + state_idx
+                    ]
+                for stage_idx in range(stage_count):
                     accumulator = typed_zero
-                    for power_idx in range(stage_count):
-                        flat_idx = (
-                            (stage_count - int32(1) - power_idx)
-                            * transform_size
-                            + entry_idx
+                    row_base = stage_idx * stage_count
+                    for source_idx in range(stage_count):
+                        accumulator += (
+                            transform[row_base + source_idx]
+                            * previous_values[source_idx]
                         )
-                        accumulator = (
-                            accumulator * ratio
-                            + ratio_coefficients[flat_idx]
-                        )
-                    transform[entry_idx] = accumulator * ratio
-
-                # Multiply each state's stage vector by the matrix.
-                previous_values = cuda.local.array(
-                    stage_count_py, numba_precision
-                )
-                for state_idx in range(n):
-                    for stage_idx in range(stage_count):
-                        previous_values[stage_idx] = stage_increment[
-                            stage_idx * n + state_idx
-                        ]
-                    for stage_idx in range(stage_count):
-                        accumulator = typed_zero
-                        row_base = stage_idx * stage_count
-                        for source_idx in range(stage_count):
-                            accumulator += (
-                                transform[row_base + source_idx]
-                                * previous_values[source_idx]
-                            )
+                    if commit_prediction:
                         stage_increment[stage_idx * n + state_idx] = (
                             accumulator
                         )

--- a/src/cubie/integrators/stage_predictors.py
+++ b/src/cubie/integrators/stage_predictors.py
@@ -1,0 +1,529 @@
+"""CUDA factory for dense stage prediction of implicit RK methods.
+
+After an implicit Runge--Kutta step converges, its stage increments
+sample the state's derivative curve at the stage times. Reading that
+curve ahead over the next step gives a far better Newton starting
+guess than reusing the previous increments unchanged; for
+collocation tableaus this is exactly the classical extrapolation of
+the collocation polynomial.
+
+:class:`DenseStagePredictor` compiles that read-ahead as an in-place
+device function over a stage-major increment vector. The transform is
+a matrix whose entries are polynomials in the step-size ratio
+``next dt / previous dt``; the polynomial coefficients are fixed by
+the tableau and precomputed on the host, so the device evaluates one
+small polynomial per matrix entry and applies one matrix-vector
+product per state. The only persistent storage is a single scalar
+holding the previous step size.
+
+The predictor does not decide when prediction is valid: the calling
+algorithm judges first-step and rejected-step conditions and passes
+the verdict as a flag. The predictor must be called on every step so
+its stored step size tracks the increments the solver last wrote.
+
+Published Functions
+-------------------
+:func:`dense_predictor_matrix`
+    Return the dense extrapolation matrix for a tableau and ratio.
+
+:func:`dense_predictor_ratio_coefficients`
+    Return the per-power coefficient matrices of the ratio polynomial.
+
+:func:`tableau_supports_dense_prediction`
+    Whether a tableau satisfies the transform's preconditions.
+
+Published Classes
+-----------------
+:class:`DenseStagePredictorConfig`
+    Attrs compile settings for the predictor factory.
+
+:class:`DenseStagePredictor`
+    CUDAFactory building the in-place prediction device function.
+
+See Also
+--------
+:class:`~cubie.integrators.algorithms.generic_firk.FIRKStep`
+    Owns a predictor and applies it to its coupled stage vector.
+:class:`~cubie.integrators.algorithms.generic_dirk.DIRKStep`
+    Owns a predictor and applies it to its stage-increment history.
+"""
+
+from typing import Callable
+
+from attrs import define, field, validators
+from numpy import asarray as np_asarray
+from numpy import ndarray as np_ndarray
+from numpy import zeros as np_zeros
+from numpy.polynomial import polynomial as np_poly
+from numpy.polynomial.legendre import leggauss as np_leggauss
+
+from cubie._utils import (
+    PrecisionDType,
+    build_config,
+    getype_validator,
+    is_device_validator,
+)
+from cubie.buffer_registry import buffer_registry
+from cubie.CUDAFactory import (
+    CUDADispatcherCache,
+    CUDAFactory,
+    CUDAFactoryConfig,
+)
+from cubie.cuda_simsafe import cuda, int32
+from cubie.integrators.algorithms.base_algorithm_step import (
+    ButcherTableau,
+)
+
+
+MAX_PREDICTION_STEP_RATIO = 8.0
+"""Largest step-size ratio the transform is applied at.
+
+Matches the largest single-step growth the default controllers allow
+(RADAU5's ``facr``). Beyond it the read-ahead leaves the sampled
+interval so far that amplification outweighs the guess — a save
+boundary can truncate a step to a sliver, making the next ratio
+arbitrarily large — so the increments carry unchanged instead.
+"""
+
+MAX_NODE_AMPLIFICATION_RATIO = 10.0
+"""Largest amplification allowed relative to ideally spread nodes.
+
+The read-ahead multiplies each sample's contribution by its
+extrapolation weight, so the worst-row sum of absolute weights bounds
+how much sample error (the solver converges only to tolerance) is
+amplified into the guess. That sum grows with stage count even for
+the best possible node spread, so the check compares against the
+Gauss--Legendre nodes of the same stage count: clustered nodes push
+the ratio into the tens, where the guess is no better than carrying
+the increments unchanged, and such tableaus fail the precondition
+check instead.
+"""
+
+
+def _predictor_matrix_from_nodes(
+    stage_nodes: np_ndarray,
+    step_ratio: float,
+) -> np_ndarray:
+    """Return the read-ahead matrix for validated *stage_nodes*."""
+
+    stage_count = len(stage_nodes)
+    # Weight of each previous derivative sample in the curve's value
+    # at each of the next step's stage times, rescaled by the ratio
+    # because increments carry a factor of the step size.
+    predictor = []
+    for target_node in 1.0 + step_ratio * stage_nodes:
+        target_weights = []
+        for basis_index in range(stage_count):
+            weight = step_ratio
+            basis_node = stage_nodes[basis_index]
+            # Scale by distance ratios to every other sample time.
+            for other_index, other_node in enumerate(stage_nodes):
+                if other_index != basis_index:
+                    weight *= (target_node - other_node) / (
+                        basis_node - other_node
+                    )
+            target_weights.append(weight)
+        predictor.append(target_weights)
+
+    return np_asarray(predictor)
+
+
+def _validate_tableau(tableau: ButcherTableau) -> np_ndarray:
+    """Check the transform's preconditions and return the nodes.
+
+    Parameters
+    ----------
+    tableau
+        Runge--Kutta tableau to validate.
+
+    Returns
+    -------
+    numpy.ndarray
+        The tableau's stage nodes in float64.
+
+    Raises
+    ------
+    ValueError
+        If any precondition fails.
+    """
+
+    stage_count = tableau.stage_count
+    stage_nodes = np_asarray(tableau.c, dtype=float)
+
+    # The previous step's derivative samples sit at the stage times;
+    # two coincident times would pin the curve twice with possibly
+    # different values, so no single curve exists.
+    if len(set(stage_nodes.tolist())) != stage_count:
+        raise ValueError(
+            "Dense prediction needs stage nodes distinct from each "
+            "other."
+        )
+    equal_step = _predictor_matrix_from_nodes(stage_nodes, 1.0)
+    amplification = float(abs(equal_step).sum(axis=1).max())
+    gauss_nodes = 0.5 * (np_leggauss(stage_count)[0] + 1.0)
+    reference = float(
+        abs(_predictor_matrix_from_nodes(gauss_nodes, 1.0))
+        .sum(axis=1)
+        .max()
+    )
+    if amplification > MAX_NODE_AMPLIFICATION_RATIO * reference:
+        raise ValueError(
+            "Dense prediction amplifies stage-sample error "
+            f"{amplification:.0f}-fold through this tableau's "
+            f"nodes ({reference:.0f}-fold for ideally spread "
+            "nodes); the guess would be no better than the "
+            "carried increments."
+        )
+    return stage_nodes
+
+
+def dense_predictor_matrix(
+    tableau: ButcherTableau,
+    step_ratio: float = 1.0,
+) -> np_ndarray:
+    """Return the dense extrapolation matrix for *tableau*.
+
+    Each converged stage increment is the step size times the state
+    derivative at that stage's time, so the previous step's
+    increments sample the derivative curve at the stage nodes. The
+    matrix reads the curve through those samples ahead at the next
+    step's stage times and rescales by the step-size ratio, mapping
+    previous increments to a starting guess for the next step's
+    increments. For collocation tableaus this equals extrapolating
+    the collocation polynomial itself.
+
+    Parameters
+    ----------
+    tableau
+        Runge--Kutta tableau with stage nodes distinct from each
+        other.
+    step_ratio
+        Size of the next step relative to the previous step.
+
+    Returns
+    -------
+    numpy.ndarray
+        Dense predictor matrix in float64.
+
+    Raises
+    ------
+    ValueError
+        If the tableau does not meet the transform's preconditions.
+    """
+
+    stage_nodes = _validate_tableau(tableau)
+    return _predictor_matrix_from_nodes(stage_nodes, step_ratio)
+
+
+def dense_predictor_ratio_coefficients(
+    tableau: ButcherTableau,
+) -> np_ndarray:
+    """Return the per-power coefficient matrices of the transform.
+
+    Each entry of the predictor matrix is a polynomial in the
+    step-size ratio with no constant term and degree equal to the
+    stage count. Expanding each stage-value weight about the end of
+    the previous step yields those polynomial coefficients directly.
+
+    Parameters
+    ----------
+    tableau
+        Runge--Kutta tableau meeting the transform's preconditions.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape ``(stage_count, stage_count, stage_count)``
+        where index ``p`` holds the matrix multiplying
+        ``step_ratio ** (p + 1)``.
+
+    Raises
+    ------
+    ValueError
+        If the tableau does not meet the transform's preconditions.
+    """
+
+    stage_nodes = _validate_tableau(tableau)
+    stage_count = tableau.stage_count
+
+    # Weight of each previous derivative sample in the curve's value
+    # at a time (1 + y) step-lengths after the previous step's start,
+    # expanded in powers of y.
+    shift = np_poly.Polynomial([1.0, 1.0])
+    shifted_weight_powers = []
+    for basis_index in range(stage_count):
+        other_nodes = [
+            stage_nodes[node_index]
+            for node_index in range(stage_count)
+            if node_index != basis_index
+        ]
+        coefficients = np_poly.polyfromroots(other_nodes)
+        coefficients = coefficients / np_poly.polyval(
+            stage_nodes[basis_index], coefficients
+        )
+        shifted = np_poly.Polynomial(coefficients)(shift)
+        shifted_weight_powers.append(shifted.coef)
+
+    # The new step's stage times sit at y = ratio * node, so the
+    # weight's power-p term contributes at ratio power p + 1 once
+    # the increments' step-size factor is rescaled.
+    ratio_coefficients = np_zeros(
+        (stage_count, stage_count, stage_count)
+    )
+    for power in range(stage_count):
+        ratio_coefficients[power] = np_asarray(
+            [
+                [
+                    shifted_weight_powers[basis_index][power]
+                    * stage_nodes[target_index] ** power
+                    for basis_index in range(stage_count)
+                ]
+                for target_index in range(stage_count)
+            ]
+        )
+    return ratio_coefficients
+
+
+def tableau_supports_dense_prediction(
+    tableau: ButcherTableau,
+) -> bool:
+    """Return whether *tableau* meets the transform preconditions."""
+
+    try:
+        _validate_tableau(tableau)
+    except ValueError:
+        return False
+    return True
+
+
+@define
+class DenseStagePredictorConfig(CUDAFactoryConfig):
+    """Compile settings for :class:`DenseStagePredictor`.
+
+    Attributes
+    ----------
+    n : int
+        Number of state variables per stage.
+    tableau : ButcherTableau
+        Tableau the prediction matrix derives from.
+    previous_step_size_location : str
+        Buffer location for the previous-step-size scalar.
+    """
+
+    n: int = field(default=1, validator=getype_validator(int, 1))
+    tableau: ButcherTableau = field(default=None)
+    previous_step_size_location: str = field(
+        default="local",
+        validator=validators.in_(["local", "shared"]),
+    )
+
+    @property
+    def stage_count(self) -> int:
+        """Return the number of stages described by the tableau."""
+
+        return self.tableau.stage_count
+
+
+@define
+class DenseStagePredictorCache(CUDADispatcherCache):
+    """Hold the compiled in-place prediction device function."""
+
+    predict: Callable = field(validator=is_device_validator)
+
+
+class DenseStagePredictor(CUDAFactory):
+    """Compile the in-place dense stage prediction transform.
+
+    The compiled device function has signature::
+
+        predict(stage_increment, dt_scalar, apply_flag, shared,
+                persistent_local)
+
+    ``stage_increment`` holds the previous step's converged stage
+    increments in stage-major layout. When ``apply_flag`` is true the
+    vector is transformed in place into the next step's Newton guess,
+    unless the step-size ratio exceeds
+    :data:`MAX_PREDICTION_STEP_RATIO`; otherwise it is left
+    unchanged. Either way the stored previous step size is refreshed,
+    so the caller must invoke the function on every step and must
+    pass ``apply_flag`` false on the first step and after a rejected
+    step.
+    """
+
+    def __init__(
+        self,
+        precision: PrecisionDType,
+        n: int,
+        tableau: ButcherTableau,
+        **kwargs,
+    ) -> None:
+        """Initialise the predictor factory.
+
+        Parameters
+        ----------
+        precision
+            Floating-point precision for the transform.
+        n
+            Number of state variables per stage.
+        tableau
+            Tableau the prediction matrix derives from.
+        **kwargs
+            Optional ``previous_step_size_location`` setting. None
+            values are ignored.
+        """
+
+        super().__init__()
+        config = build_config(
+            DenseStagePredictorConfig,
+            required={
+                "precision": precision,
+                "n": n,
+                "tableau": tableau,
+            },
+            **kwargs,
+        )
+        self.setup_compile_settings(config)
+        self.register_buffers()
+
+    def register_buffers(self) -> None:
+        """Register the previous-step-size scalar with the registry."""
+
+        config = self.compile_settings
+        buffer_registry.register(
+            "previous_step_size",
+            self,
+            1,
+            config.previous_step_size_location,
+            persistent=True,
+            precision=config.precision,
+        )
+
+    def update(self, updates_dict=None, silent=False, **kwargs):
+        """Update compile settings and re-register buffers.
+
+        Returns
+        -------
+        set
+            Set of recognized parameter names that were updated.
+        """
+
+        all_updates = {}
+        if updates_dict:
+            all_updates.update(updates_dict)
+        all_updates.update(kwargs)
+        if not all_updates:
+            return set()
+
+        recognised = self.update_compile_settings(
+            updates_dict=all_updates, silent=silent
+        )
+        if recognised:
+            self.register_buffers()
+        return recognised
+
+    @property
+    def device_function(self) -> Callable:
+        """Return the compiled prediction device function."""
+
+        return self.get_cached_output("predict")
+
+    def build(self) -> DenseStagePredictorCache:
+        """Compile the in-place prediction device function."""
+
+        config = self.compile_settings
+        numba_precision = config.numba_precision
+        typed_zero = numba_precision(0.0)
+        n = int32(config.n)
+        stage_count = int32(config.stage_count)
+        # Local scratch shapes must be plain Python ints at compile
+        # time.
+        stage_count_py = int(config.stage_count)
+        transform_size_py = stage_count_py * stage_count_py
+        transform_size = int32(transform_size_py)
+
+        # Flattened power-major coefficient stack: entry
+        # [power][row][column] multiplies ratio ** (power + 1).
+        ratio_coefficients = tuple(
+            numba_precision(value)
+            for value in dense_predictor_ratio_coefficients(
+                config.tableau
+            ).flat
+        )
+
+        max_step_ratio = numba_precision(MAX_PREDICTION_STEP_RATIO)
+
+        alloc_previous_step_size = buffer_registry.get_allocator(
+            "previous_step_size", self
+        )
+
+        # no cover: start
+        @cuda.jit(
+            device=True,
+            inline=True,
+            **self.jit_kwargs,
+        )
+        def predict(
+            stage_increment,
+            dt_scalar,
+            apply_flag,
+            shared,
+            persistent_local,
+        ):
+            previous_step_size = alloc_previous_step_size(
+                shared, persistent_local
+            )
+            previous_dt = previous_step_size[0]
+            previous_step_size[0] = dt_scalar
+
+            if apply_flag:
+                ratio = dt_scalar / previous_dt
+
+                # A truncated previous step can make the ratio
+                # arbitrarily large (or infinite on unwritten
+                # storage); the read-ahead is only meaningful within
+                # the controllers' growth bound.
+                if ratio > max_step_ratio:
+                    return
+
+                # Evaluate each matrix entry's ratio polynomial,
+                # highest power first.
+                transform = cuda.local.array(
+                    transform_size_py, numba_precision
+                )
+                for entry_idx in range(transform_size):
+                    accumulator = typed_zero
+                    for power_idx in range(stage_count):
+                        flat_idx = (
+                            (stage_count - int32(1) - power_idx)
+                            * transform_size
+                            + entry_idx
+                        )
+                        accumulator = (
+                            accumulator * ratio
+                            + ratio_coefficients[flat_idx]
+                        )
+                    transform[entry_idx] = accumulator * ratio
+
+                # Multiply each state's stage vector by the matrix.
+                previous_values = cuda.local.array(
+                    stage_count_py, numba_precision
+                )
+                for state_idx in range(n):
+                    for stage_idx in range(stage_count):
+                        previous_values[stage_idx] = stage_increment[
+                            stage_idx * n + state_idx
+                        ]
+                    for stage_idx in range(stage_count):
+                        accumulator = typed_zero
+                        row_base = stage_idx * stage_count
+                        for source_idx in range(stage_count):
+                            accumulator += (
+                                transform[row_base + source_idx]
+                                * previous_values[source_idx]
+                            )
+                        stage_increment[stage_idx * n + state_idx] = (
+                            accumulator
+                        )
+
+        # no cover: end
+        return DenseStagePredictorCache(predict=predict)

--- a/tests/integrated_numerical_tests/test_ode_loop.py
+++ b/tests/integrated_numerical_tests/test_ode_loop.py
@@ -670,6 +670,43 @@ def test_dirk_dense_predictor_matches_reference(
         merge_dicts(
             MID_RUN_PARAMS,
             {
+                "algorithm": "trapezoidal_dirk",
+                "step_controller": "fixed",
+            },
+        )
+    ],
+    ids=["dirk-dense-predictor-explicit-first-stage"],
+    indirect=True,
+)
+def test_explicit_stage_dirk_dense_predictor_matches_reference(
+    device_loop_outputs,
+    cpu_loop_outputs,
+    output_functions,
+    tolerance,
+):
+    """History slots no solver writes carry the transform's values.
+
+    An explicit first stage never solves, so its history slot is
+    only ever refreshed by the read-ahead itself; the device and CPU
+    reference must roll it forward identically.
+    """
+
+    assert_integration_outputs(
+        cpu_loop_outputs,
+        device_loop_outputs,
+        output_functions,
+        rtol=tolerance.rel_loose,
+        atol=tolerance.abs_loose,
+    )
+    assert device_loop_outputs.status == 0
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [
+        merge_dicts(
+            MID_RUN_PARAMS,
+            {
                 "algorithm": "radau_iia_5",
                 "step_controller": "PI",
                 "dt_min": 1e-6,

--- a/tests/integrated_numerical_tests/test_ode_loop.py
+++ b/tests/integrated_numerical_tests/test_ode_loop.py
@@ -9,12 +9,81 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from cubie.integrators.algorithms.generic_firk_tableaus import (
+    FIRKTableau,
+    GAUSS_LEGENDRE_4_TABLEAU,
+)
+
 from tests._utils import (
     assert_integration_outputs,
     MID_RUN_PARAMS,
     merge_dicts,
     ALGORITHM_PARAM_SETS,
 )
+
+
+def _gauss_legendre_collocation_tableau(stage_count):
+    """Build the Gauss--Legendre collocation tableau of order ``2s``.
+
+    Collocation at the Gauss--Legendre nodes defines the classical
+    fully implicit method of order ``2 * stage_count`` (Hairer &
+    Wanner, Solving ODEs II, Theorem 7.7): each ``a[i][j]`` is the
+    integral of the j-th Lagrange basis polynomial from 0 to ``c[i]``
+    and each ``b[j]`` its integral over the whole step.
+    """
+    poly = np.polynomial.polynomial
+    legendre_roots, _ = np.polynomial.legendre.leggauss(stage_count)
+    nodes = 0.5 * (legendre_roots + 1.0)
+    basis_integrals = []
+    for basis_index in range(stage_count):
+        other_nodes = [
+            nodes[node_index]
+            for node_index in range(stage_count)
+            if node_index != basis_index
+        ]
+        coefficients = poly.polyfromroots(other_nodes)
+        coefficients = coefficients / poly.polyval(
+            nodes[basis_index], coefficients
+        )
+        basis_integrals.append(poly.polyint(coefficients))
+    a_matrix = tuple(
+        tuple(
+            float(poly.polyval(node, integral))
+            for integral in basis_integrals
+        )
+        for node in nodes
+    )
+    b_weights = tuple(
+        float(poly.polyval(1.0, integral))
+        for integral in basis_integrals
+    )
+    return FIRKTableau(
+        a=a_matrix,
+        b=b_weights,
+        c=tuple(float(node) for node in nodes),
+        order=2 * stage_count,
+    )
+
+
+def test_gauss_legendre_4_registry_literals_match_construction():
+    """The registry's literals reproduce the collocation build."""
+    constructed = _gauss_legendre_collocation_tableau(4)
+    np.testing.assert_allclose(
+        np.asarray(GAUSS_LEGENDRE_4_TABLEAU.a),
+        np.asarray(constructed.a),
+        rtol=1e-15,
+        atol=1e-16,
+    )
+    np.testing.assert_allclose(
+        np.asarray(GAUSS_LEGENDRE_4_TABLEAU.b),
+        np.asarray(constructed.b),
+        rtol=1e-15,
+    )
+    np.testing.assert_allclose(
+        np.asarray(GAUSS_LEGENDRE_4_TABLEAU.c),
+        np.asarray(constructed.c),
+        rtol=1e-15,
+    )
 
 
 def test_initial_observable_seed_matches_reference(
@@ -521,6 +590,140 @@ def test_firk_with_shared_solver_buffer_matches_reference(
     produces a correctly sized pool and that the integration result
     matches the CPU reference within loose tolerances (issue #520).
     """
+    assert_integration_outputs(
+        cpu_loop_outputs,
+        device_loop_outputs,
+        output_functions,
+        rtol=tolerance.rel_loose,
+        atol=tolerance.abs_loose,
+    )
+    assert device_loop_outputs.status == 0
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [
+        merge_dicts(
+            MID_RUN_PARAMS,
+            {
+                "algorithm": "firk_gauss_legendre_4",
+                "step_controller": "fixed",
+            },
+        )
+    ],
+    ids=["firk-four-stage-dense-predictor"],
+    indirect=True,
+)
+def test_four_stage_firk_dense_predictor_matches_reference(
+    device_loop_outputs,
+    cpu_loop_outputs,
+    output_functions,
+    tolerance,
+):
+    """The four-stage predictor path updates every state component."""
+
+    assert_integration_outputs(
+        cpu_loop_outputs,
+        device_loop_outputs,
+        output_functions,
+        rtol=tolerance.rel_loose,
+        atol=tolerance.abs_loose,
+    )
+    assert device_loop_outputs.status == 0
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [
+        merge_dicts(
+            MID_RUN_PARAMS,
+            {
+                "algorithm": "l_stable_dirk_3",
+                "step_controller": "fixed",
+            },
+        )
+    ],
+    ids=["dirk-dense-predictor-fixed"],
+    indirect=True,
+)
+def test_dirk_dense_predictor_matches_reference(
+    device_loop_outputs,
+    cpu_loop_outputs,
+    output_functions,
+    tolerance,
+):
+    """DIRK stage-history prediction matches the CPU reference."""
+
+    assert_integration_outputs(
+        cpu_loop_outputs,
+        device_loop_outputs,
+        output_functions,
+        rtol=tolerance.rel_loose,
+        atol=tolerance.abs_loose,
+    )
+    assert device_loop_outputs.status == 0
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [
+        merge_dicts(
+            MID_RUN_PARAMS,
+            {
+                "algorithm": "radau_iia_5",
+                "step_controller": "PI",
+                "dt_min": 1e-6,
+                "dt": 1e-3,
+                "dt_max": 0.5,
+            },
+        )
+    ],
+    ids=["firk-dense-predictor-adaptive"],
+    indirect=True,
+)
+def test_adaptive_firk_dense_predictor_matches_reference(
+    device_loop_outputs,
+    cpu_loop_outputs,
+    output_functions,
+    tolerance,
+):
+    """Ratio-based prediction under an adaptive controller matches."""
+
+    assert_integration_outputs(
+        cpu_loop_outputs,
+        device_loop_outputs,
+        output_functions,
+        rtol=tolerance.rel_loose,
+        atol=tolerance.abs_loose,
+    )
+    assert device_loop_outputs.status == 0
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [
+        merge_dicts(
+            MID_RUN_PARAMS,
+            {
+                "algorithm": "l_stable_sdirk_4",
+                "step_controller": "PI",
+                "dt_min": 1e-6,
+                "dt": 1e-3,
+                "dt_max": 0.5,
+            },
+        )
+    ],
+    ids=["dirk-dense-predictor-adaptive"],
+    indirect=True,
+)
+def test_adaptive_dirk_dense_predictor_matches_reference(
+    device_loop_outputs,
+    cpu_loop_outputs,
+    output_functions,
+    tolerance,
+):
+    """DIRK stage-history prediction under an adaptive controller."""
+
     assert_integration_outputs(
         cpu_loop_outputs,
         device_loop_outputs,

--- a/tests/integrators/cpu_reference/algorithms.py
+++ b/tests/integrators/cpu_reference/algorithms.py
@@ -1071,34 +1071,34 @@ class CPUDIRKStep(CPUStep):
         all_converged = True
         total_iters = 0
 
-        # Accepted steps read the previous step's stage curve ahead
-        # over the next step to seed every stage's Newton solve; the
-        # first step and rejected proposals keep the existing
-        # carried-increment seeding.
-        predicted_increments = None
-        if (
-            self._dirk_dense_prediction
-            and self._dirk_stage_increment_history is not None
-            and prev_accepted
-        ):
-            ratio = float(dt_value) / float(self._dirk_previous_dt)
-            if ratio <= MAX_PREDICTION_STEP_RATIO:
-                predictor = np.asarray(
-                    dense_predictor_matrix(self.tableau, ratio),
-                    dtype=self.precision,
-                )
-                predicted_increments = (
-                    predictor @ self._dirk_stage_increment_history
-                )
-        self._dirk_previous_dt = dt_value
+        # Mirrors the device: the persistent history is transformed
+        # in place on accepted steps within the ratio bound and
+        # carried unchanged otherwise; stages a solver never touches
+        # (explicit stages) keep the transform's read-ahead values.
+        history = None
         if self._dirk_dense_prediction:
-            new_history = np.zeros(
-                (stage_count, state_dim), dtype=self.precision
-            )
+            if self._dirk_stage_increment_history is None:
+                self._dirk_stage_increment_history = np.zeros(
+                    (stage_count, state_dim), dtype=self.precision
+                )
+            history = self._dirk_stage_increment_history
+            if prev_accepted and self._dirk_previous_dt is not None:
+                ratio = float(dt_value) / float(
+                    self._dirk_previous_dt
+                )
+                if ratio <= MAX_PREDICTION_STEP_RATIO:
+                    predictor = np.asarray(
+                        dense_predictor_matrix(self.tableau, ratio),
+                        dtype=self.precision,
+                    )
+                    history[:] = (predictor @ history).astype(
+                        self.precision
+                    )
+        self._dirk_previous_dt = dt_value
 
         for stage_index in range(stage_count):
-            if predicted_increments is not None:
-                guess = predicted_increments[stage_index]
+            if history is not None:
+                guess = history[stage_index].copy()
             else:
                 guess = self._dirk_increment
 
@@ -1187,11 +1187,8 @@ class CPUDIRKStep(CPUStep):
             )
             stage_derivatives[stage_index, :] = derivative
             self._dirk_increment = increment
-            if self._dirk_dense_prediction:
-                new_history[stage_index] = increment
-
-        if self._dirk_dense_prediction:
-            self._dirk_stage_increment_history = new_history
+            if history is not None:
+                history[stage_index] = increment
 
         # A stage whose A row equals b (or b_hat) already holds the
         # output (or embedded) solution.

--- a/tests/integrators/cpu_reference/algorithms.py
+++ b/tests/integrators/cpu_reference/algorithms.py
@@ -25,6 +25,11 @@ from cubie.integrators.algorithms.generic_firk_tableaus import (
     FIRKTableau,
     DEFAULT_FIRK_TABLEAU,
 )
+from cubie.integrators.stage_predictors import (
+    MAX_PREDICTION_STEP_RATIO,
+    dense_predictor_matrix,
+    tableau_supports_dense_prediction,
+)
 from cubie.integrators.algorithms.generic_erk_tableaus import (
     DEFAULT_ERK_TABLEAU,
     ERKTableau,
@@ -423,6 +428,7 @@ class CPUExplicitEulerStep(CPUStep):
         params: Optional[Array] = None,
         dt: Optional[float] = None,
         time: float = 0.0,
+        prev_accepted: bool = True,
     ) -> StepResultLike:
         state_vector = self.ensure_array(state)
         params_array = self.ensure_array(params)
@@ -544,6 +550,7 @@ class CPUBackwardEulerStep(CPUStep):
         dt: Optional[float] = None,
         initial_guess: Optional[Array] = None,
         time: float = 0.0,
+        prev_accepted: bool = True,
     ) -> StepResultLike:
         state_vector = self.ensure_array(state, copy=True)
         params_array = self.ensure_array(params)
@@ -715,6 +722,7 @@ class CPUCrankNicolsonStep(CPUStep):
         params: Optional[Array] = None,
         dt: Optional[float] = None,
         time: float = 0.0,
+        prev_accepted: bool = True,
     ) -> StepResultLike:
         state_vector = self.ensure_array(state, copy=True)
         params_array = self.ensure_array(params)
@@ -847,6 +855,7 @@ class CPUERKStep(CPUStep):
         params: Optional[Array] = None,
         dt: Optional[float] = None,
         time: float = 0.0,
+        prev_accepted: bool = True,
     ) -> StepResultLike:
         state_vector = self.ensure_array(state)
         params_array = self.ensure_array(params)
@@ -961,6 +970,7 @@ class CPUDIRKStep(CPUStep):
         residual_reduction: Optional[float] = None,
         residual_floor: Optional[float] = None,
         tableau: Optional[DIRKTableau] = None,
+        attempt_dense_prediction: bool = True,
     ) -> None:
         resolved = DEFAULT_DIRK_TABLEAU if tableau is None else tableau
         super().__init__(
@@ -987,6 +997,14 @@ class CPUDIRKStep(CPUStep):
         self._dirk_dt = self.precision(0.0)
         self._dirk_diag_coeff = self.precision(0.0)
         self._dirk_increment = np.zeros(self._state_size, dtype=self.precision)
+        self._dirk_stage_increment_history = None
+        self._dirk_previous_dt = None
+        # Mirrors the device gate: prediction requires both the
+        # request and a tableau meeting the transform preconditions.
+        self._dirk_dense_prediction = bool(
+            attempt_dense_prediction
+            and tableau_supports_dense_prediction(resolved)
+        )
 
     def residual(self, candidate: Array) -> Array:
         base_state = self._dirk_reference
@@ -1027,6 +1045,7 @@ class CPUDIRKStep(CPUStep):
         params: Optional[Array] = None,
         dt: Optional[float] = None,
         time: float = 0.0,
+        prev_accepted: bool = True,
     ) -> StepResultLike:
         state_vector = self.ensure_array(state)
         params_array = self.ensure_array(params)
@@ -1052,8 +1071,36 @@ class CPUDIRKStep(CPUStep):
         all_converged = True
         total_iters = 0
 
+        # Accepted steps read the previous step's stage curve ahead
+        # over the next step to seed every stage's Newton solve; the
+        # first step and rejected proposals keep the existing
+        # carried-increment seeding.
+        predicted_increments = None
+        if (
+            self._dirk_dense_prediction
+            and self._dirk_stage_increment_history is not None
+            and prev_accepted
+        ):
+            ratio = float(dt_value) / float(self._dirk_previous_dt)
+            if ratio <= MAX_PREDICTION_STEP_RATIO:
+                predictor = np.asarray(
+                    dense_predictor_matrix(self.tableau, ratio),
+                    dtype=self.precision,
+                )
+                predicted_increments = (
+                    predictor @ self._dirk_stage_increment_history
+                )
+        self._dirk_previous_dt = dt_value
+        if self._dirk_dense_prediction:
+            new_history = np.zeros(
+                (stage_count, state_dim), dtype=self.precision
+            )
+
         for stage_index in range(stage_count):
-            guess = self._dirk_increment
+            if predicted_increments is not None:
+                guess = predicted_increments[stage_index]
+            else:
+                guess = self._dirk_increment
 
             # Rounding-sensitive: scale by dt once, after accumulating.
             stage_accum = np.zeros_like(state_vector)
@@ -1140,6 +1187,11 @@ class CPUDIRKStep(CPUStep):
             )
             stage_derivatives[stage_index, :] = derivative
             self._dirk_increment = increment
+            if self._dirk_dense_prediction:
+                new_history[stage_index] = increment
+
+        if self._dirk_dense_prediction:
+            self._dirk_stage_increment_history = new_history
 
         # A stage whose A row equals b (or b_hat) already holds the
         # output (or embedded) solution.
@@ -1204,6 +1256,7 @@ class CPUFIRKStep(CPUStep):
         residual_reduction: Optional[float] = None,
         residual_floor: Optional[float] = None,
         tableau: Optional[FIRKTableau] = None,
+        attempt_dense_prediction: bool = True,
     ) -> None:
         resolved = DEFAULT_FIRK_TABLEAU if tableau is None else tableau
         super().__init__(
@@ -1227,10 +1280,17 @@ class CPUFIRKStep(CPUStep):
         self._firk_time = self.precision(0.0)
         self._firk_dt = self.precision(0.0)
         self._firk_stage_increments = None
+        self._firk_previous_dt = None
+        # Mirrors the device gate: prediction requires both the
+        # request and a tableau meeting the transform preconditions.
+        self._firk_dense_prediction = bool(
+            attempt_dense_prediction
+            and tableau_supports_dense_prediction(resolved)
+        )
 
     def residual(self, candidate: Array) -> Array:
         """Compute the residual for the fully implicit stage equations.
-        
+
         For FIRK, all stages are coupled: candidate is a flattened vector
         of all stage increments k_i for i=1..s where s is the stage count.
         The residual for each stage i is:
@@ -1240,15 +1300,15 @@ class CPUFIRKStep(CPUStep):
         state_dim = self._state_size
         a_matrix = self.a_matrix
         c_nodes = self.c_nodes
-        
+
         residual = np.zeros_like(candidate)
-        
+
         for stage_idx in range(stage_count):
             # Extract this stage's increment from the flattened candidate
             k_start = stage_idx * state_dim
             k_end = (stage_idx + 1) * state_dim
             k_i = candidate[k_start:k_end]
-            
+
             # Compute the stage state: x_0 + sum_j(a_ij * k_j)
             stage_state = self._firk_state.copy()
             for j in range(stage_count):
@@ -1256,7 +1316,7 @@ class CPUFIRKStep(CPUStep):
                 j_end = (j + 1) * state_dim
                 k_j = candidate[j_start:j_end]
                 stage_state += a_matrix[stage_idx, j] * k_j
-            
+
             # Evaluate the RHS at this stage
             stage_time = self._firk_time + c_nodes[stage_idx] * self._firk_dt
             drivers_stage = self._firk_drivers[stage_idx]
@@ -1273,16 +1333,16 @@ class CPUFIRKStep(CPUStep):
                 observables_stage,
                 stage_time,
             )
-            
+
             # Residual: M * k_i - dt * f(...)
             mass_term = self.mass_matrix_apply(k_i)
             residual[k_start:k_end] = mass_term - self._firk_dt * derivative
-        
+
         return residual
 
     def jacobian(self, candidate: Array) -> Array:
         """Compute the Jacobian of the residual for the fully implicit system.
-        
+
         The Jacobian is block-structured:
             J[i,j] = delta_ij * M - dt * a_ij * df/dx
         where delta_ij is the Kronecker delta.
@@ -1291,10 +1351,10 @@ class CPUFIRKStep(CPUStep):
         state_dim = self._state_size
         a_matrix = self.a_matrix
         c_nodes = self.c_nodes
-        
+
         all_dim = stage_count * state_dim
         jac = np.zeros((all_dim, all_dim), dtype=self.precision)
-        
+
         for stage_idx in range(stage_count):
             # Compute the stage state to evaluate the Jacobian
             stage_state = self._firk_state.copy()
@@ -1303,7 +1363,7 @@ class CPUFIRKStep(CPUStep):
                 j_end = (j + 1) * state_dim
                 k_j = candidate[j_start:j_end]
                 stage_state += a_matrix[stage_idx, j] * k_j
-            
+
             stage_time = self._firk_time + c_nodes[stage_idx] * self._firk_dt
             drivers_stage = self._firk_drivers[stage_idx]
             _, df_dx = self.observables_and_jac(
@@ -1312,15 +1372,15 @@ class CPUFIRKStep(CPUStep):
                 drivers_stage,
                 stage_time,
             )
-            
+
             # Fill in the block row for this stage
             i_start = stage_idx * state_dim
             i_end = (stage_idx + 1) * state_dim
-            
+
             for dep_idx in range(stage_count):
                 j_start = dep_idx * state_dim
                 j_end = (dep_idx + 1) * state_dim
-                
+
                 if stage_idx == dep_idx:
                     # Diagonal block: M - dt * a_ii * df/dx
                     jac[i_start:i_end, j_start:j_end] = (
@@ -1331,7 +1391,7 @@ class CPUFIRKStep(CPUStep):
                     jac[i_start:i_end, j_start:j_end] = (
                         -self._firk_dt * a_matrix[stage_idx, dep_idx] * df_dx
                     )
-        
+
         return jac
 
     def step(
@@ -1341,6 +1401,7 @@ class CPUFIRKStep(CPUStep):
         params: Optional[Array] = None,
         dt: Optional[float] = None,
         time: float = 0.0,
+        prev_accepted: bool = True,
     ) -> StepResultLike:
         state_vector = self.ensure_array(state)
         params_array = self.ensure_array(params)
@@ -1355,14 +1416,14 @@ class CPUFIRKStep(CPUStep):
 
         state_dim = state_vector.shape[0]
         all_dim = stage_count * state_dim
-        
+
         # Pre-compute driver values for all stages
         stage_drivers = []
         for stage_idx in range(stage_count):
             stage_time = current_time + c_nodes[stage_idx] * dt_value
             drivers_stage = self.drivers(stage_time)
             stage_drivers.append(drivers_stage)
-        
+
         # Set up the fully implicit solve
         self._firk_state = state_vector.copy()
         self._firk_params = params_array
@@ -1373,10 +1434,29 @@ class CPUFIRKStep(CPUStep):
         # state weights every stage block of the coupled residual.
         self._linear_norm_reference = np.tile(state_vector, stage_count)
 
-        # Initial guess: zero increments (or could use previous step's increments)
+        # Accepted steps read the previous step's stage curve ahead
+        # over the next step; the first step and rejected proposals
+        # keep the carried increments unchanged.
         guess = np.zeros(all_dim, dtype=self.precision)
         if self._firk_stage_increments is not None:
-            guess = self._firk_stage_increments.copy()
+            ratio = float(dt_value) / float(self._firk_previous_dt)
+            if (
+                self._firk_dense_prediction
+                and prev_accepted
+                and ratio <= MAX_PREDICTION_STEP_RATIO
+            ):
+                predictor = np.asarray(
+                    dense_predictor_matrix(self.tableau, ratio),
+                    dtype=self.precision,
+                )
+                previous = self._firk_stage_increments.reshape(
+                    stage_count,
+                    state_dim,
+                )
+                guess = (predictor @ previous).reshape(all_dim)
+            else:
+                guess = self._firk_stage_increments.copy()
+        self._firk_previous_dt = dt_value
 
         def correction_norm(update, iterate):
             stage_values = np.zeros(all_dim, dtype=self.precision)
@@ -1531,6 +1611,7 @@ class CPURosenbrockWStep(CPUStep):
         tol: Optional[float] = None,
         max_iters: Optional[int] = None,
         time: float = 0.0,
+        prev_accepted: bool = True,
     ) -> StepResultLike:
         state_vector = self.ensure_array(state, copy=True)
         params_array = self.ensure_array(params)
@@ -1756,6 +1837,7 @@ class CPUBackwardEulerPCStep(CPUStep):
         params: Optional[Array] = None,
         dt: Optional[float] = None,
         time: float = 0.0,
+        prev_accepted: bool = True,
     ) -> StepResultLike:
         state_vector = self.ensure_array(state, copy=True)
         params_array = self.ensure_array(params)
@@ -1875,7 +1957,13 @@ def get_ref_step_factory(
         preconditioner_order: int = 2,
         residual_reduction: Optional[float] = None,
         residual_floor: Optional[float] = None,
+        attempt_dense_prediction: bool = True,
     ) -> Callable:
+        extra_kwargs = {}
+        if step_class in (CPUFIRKStep, CPUDIRKStep):
+            extra_kwargs["attempt_dense_prediction"] = (
+                attempt_dense_prediction
+            )
         if tableau_value is None:
             return step_class(
                 evaluator,
@@ -1890,6 +1978,7 @@ def get_ref_step_factory(
                 preconditioner_order=preconditioner_order,
                 residual_reduction=residual_reduction,
                 residual_floor=residual_floor,
+                **extra_kwargs,
             )
         return step_class(
             evaluator,
@@ -1905,6 +1994,7 @@ def get_ref_step_factory(
             residual_reduction=residual_reduction,
             residual_floor=residual_floor,
             tableau=tableau_value,
+            **extra_kwargs,
         )
 
     return factory
@@ -1926,6 +2016,7 @@ def get_ref_stepper(
     residual_reduction: Optional[float] = None,
     residual_floor: Optional[float] = None,
     tableau: Optional[Union[str, ButcherTableau]] = None,
+    attempt_dense_prediction: bool = True,
 ) -> CPUStep:
     """Return a configured CPU reference stepper for ``algorithm``."""
 
@@ -1943,4 +2034,5 @@ def get_ref_stepper(
         preconditioner_order=preconditioner_order,
         residual_reduction=residual_reduction,
         residual_floor=residual_floor,
+        attempt_dense_prediction=attempt_dense_prediction,
     )

--- a/tests/integrators/cpu_reference/loops.py
+++ b/tests/integrators/cpu_reference/loops.py
@@ -121,6 +121,9 @@ def run_reference_loop(
         residual_reduction=residual_reduction,
         residual_floor=solver_settings.get("krylov_residual_floor"),
         tableau=tableau,
+        attempt_dense_prediction=solver_settings.get(
+            "attempt_dense_prediction", True
+        ),
     )
 
     saved_state_indices = _ensure_array(
@@ -183,6 +186,8 @@ def run_reference_loop(
     end_time = precision(warmup + t0 + duration)
 
     status_flags = 0
+    # Mirrors the device loop's previous-proposal-accepted flag.
+    prev_accepted = True
 
     # Track when we need to sample for summaries vs save for output
     while next_save_time <= end_time or next_summary_sample_time <= end_time:
@@ -218,6 +223,7 @@ def run_reference_loop(
             params=params,
             dt=dt,
             time=t32,
+            prev_accepted=prev_accepted,
         )
 
         step_status = int(result.status)
@@ -229,6 +235,7 @@ def run_reference_loop(
             niters=result.niters,
             truncated=truncated,
         )
+        prev_accepted = bool(accept)
         if not accept:
             continue
 

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -408,7 +408,6 @@ def test_errorless_euler_with_adaptive_warns_and_replaces(system):
         assert "fixed" in msg
         assert "error estimate" in msg
         assert not core._step_controller.is_adaptive
-        assert core._algo_step.is_controller_fixed
 
 
 def test_replacement_controller_uses_original_dt(system):
@@ -451,7 +450,6 @@ def test_errorless_rk4_with_adaptive_warns(system):
         compat = [x for x in w if "cannot be used with" in str(x.message)]
         assert len(compat) >= 1
         assert not core._step_controller.is_adaptive
-        assert core._algo_step.is_controller_fixed
 
 
 def test_adaptive_algo_with_adaptive_controller_no_warning(system):
@@ -474,7 +472,6 @@ def test_adaptive_algo_with_adaptive_controller_no_warning(system):
         assert len(compat) == 0
         assert core._algo_step.is_adaptive
         assert core._step_controller.is_adaptive
-        assert not core._algo_step.is_controller_fixed
 
 
 def test_errorless_euler_with_fixed_no_warning(system):
@@ -493,7 +490,6 @@ def test_errorless_euler_with_fixed_no_warning(system):
         assert len(compat) == 0
         assert not core._algo_step.is_adaptive
         assert not core._step_controller.is_adaptive
-        assert core._algo_step.is_controller_fixed
 
 
 # ── update ──────────────────────────────────────────────────────────────── #
@@ -729,7 +725,6 @@ def test_update_check_compatibility_after_switch(
         compat = [x for x in w if "cannot be used with" in str(x.message)]
         assert len(compat) >= 1
         assert not run._step_controller.is_adaptive
-        assert run._algo_step.is_controller_fixed
 
 
 def test_update_process_loop_timing_called(

--- a/tests/integrators/test_stage_predictors.py
+++ b/tests/integrators/test_stage_predictors.py
@@ -1,0 +1,280 @@
+"""Unit tests for the dense stage predictor factory."""
+
+import numpy as np
+import pytest
+
+from cubie import create_ODE_system, solve_ivp
+from cubie.integrators.algorithms.base_algorithm_step import (
+    ButcherTableau,
+)
+from cubie.integrators.algorithms.generic_dirk_tableaus import (
+    DIRK_TABLEAU_REGISTRY,
+)
+from cubie.integrators.algorithms.generic_firk_tableaus import (
+    DEFAULT_FIRK_TABLEAU,
+    FIRK_TABLEAU_REGISTRY,
+    RADAU_IIA_5_TABLEAU,
+)
+from cubie.integrators.stage_predictors import (
+    DenseStagePredictor,
+    dense_predictor_matrix,
+    dense_predictor_ratio_coefficients,
+    tableau_supports_dense_prediction,
+)
+
+
+REPEATED_NODE_TABLEAU = ButcherTableau(
+    a=((0.5, 0.0), (0.0, 0.5)),
+    b=(0.5, 0.5),
+    c=(0.5, 0.5),
+    order=1,
+)
+
+ZERO_NODE_SINGULAR_TABLEAU = ButcherTableau(
+    a=((0.0, 0.0), (0.5, 0.5)),
+    b=(0.5, 0.5),
+    c=(0.0, 1.0),
+    order=2,
+)
+
+
+def test_repeated_node_tableau_is_rejected():
+    """Coincident stage times pin the curve twice; no curve exists."""
+    assert not tableau_supports_dense_prediction(REPEATED_NODE_TABLEAU)
+    with pytest.raises(ValueError, match="distinct"):
+        dense_predictor_matrix(REPEATED_NODE_TABLEAU)
+
+
+def test_zero_node_singular_tableau_is_supported():
+    """Derivative samples need neither nonzero nodes nor invertible A."""
+    assert tableau_supports_dense_prediction(
+        ZERO_NODE_SINGULAR_TABLEAU
+    )
+
+
+NEAR_DUPLICATE_NODE_TABLEAU = ButcherTableau(
+    a=((0.5, 0.0, 0.0), (0.0, 0.5, 0.0), (0.0, 0.0, 0.5)),
+    b=(0.4, 0.3, 0.3),
+    c=(0.5, 0.5 + 1e-9, 1.0),
+    order=1,
+)
+
+
+def test_near_duplicate_node_tableau_is_rejected():
+    """Nearly coincident nodes amplify sample error into garbage."""
+    assert not tableau_supports_dense_prediction(
+        NEAR_DUPLICATE_NODE_TABLEAU
+    )
+    with pytest.raises(ValueError, match="amplifies"):
+        dense_predictor_matrix(NEAR_DUPLICATE_NODE_TABLEAU)
+
+
+def test_registry_tableaus_support_expectations():
+    """Every registry tableau lands on the expected side of the gate."""
+    firk_support = {
+        name: tableau_supports_dense_prediction(tableau)
+        for name, tableau in FIRK_TABLEAU_REGISTRY.items()
+    }
+    assert firk_support == {
+        "firk_gauss_legendre_2": True,
+        "firk_gauss_legendre_4": True,
+        "radau_iia_5": True,
+        "radau": True,
+    }
+    dirk_support = {
+        name: tableau_supports_dense_prediction(tableau)
+        for name, tableau in DIRK_TABLEAU_REGISTRY.items()
+    }
+    assert dirk_support == {
+        "implicit_midpoint": True,
+        "trapezoidal_dirk": True,
+        "ode23t": True,
+        "kvaerno3": False,
+        "kvaerno5": False,
+        "lobatto_iiic_3": True,
+        "sdirk_2_2": True,
+        "l_stable_dirk_3": True,
+        "l_stable_sdirk_4": True,
+    }
+
+
+@pytest.mark.parametrize(
+    "tableau",
+    [
+        DIRK_TABLEAU_REGISTRY["l_stable_dirk_3"],
+        DIRK_TABLEAU_REGISTRY["lobatto_iiic_3"],
+        RADAU_IIA_5_TABLEAU,
+    ],
+)
+@pytest.mark.parametrize("step_ratio", [0.5, 1.0, 1.7])
+def test_dense_predictor_reads_derivative_samples_ahead(
+    tableau, step_ratio
+):
+    """The matrix equals an independent derivative-sample fit."""
+    stage_nodes = np.asarray(tableau.c)
+    increments = np.arange(1, tableau.stage_count + 1, dtype=float)
+    polynomial = np.polynomial.polynomial.polyfit(
+        stage_nodes, increments, tableau.stage_count - 1
+    )
+    expected = step_ratio * np.polynomial.polynomial.polyval(
+        1.0 + step_ratio * stage_nodes, polynomial
+    )
+    predictor = dense_predictor_matrix(tableau, step_ratio)
+    np.testing.assert_allclose(predictor @ increments, expected)
+
+
+@pytest.mark.parametrize(
+    "tableau",
+    [DEFAULT_FIRK_TABLEAU, RADAU_IIA_5_TABLEAU],
+)
+@pytest.mark.parametrize("step_ratio", [0.5, 1.0, 1.7])
+def test_dense_predictor_extrapolates_stage_curve(tableau, step_ratio):
+    """For collocation tableaus the read-ahead extrapolates the
+    state collocation polynomial, checked by an independent fit."""
+    stage_matrix = np.asarray(tableau.a)
+    stage_nodes = np.asarray(tableau.c)
+    increments = np.arange(1, tableau.stage_count + 1, dtype=float)
+    old_stage_values = stage_matrix @ increments
+
+    polynomial = np.polynomial.polynomial.polyfit(
+        np.concatenate(([0.0], stage_nodes)),
+        np.concatenate(([0.0], old_stage_values)),
+        tableau.stage_count,
+    )
+    shifted_stage_values = np.polynomial.polynomial.polyval(
+        1.0 + step_ratio * stage_nodes, polynomial
+    ) - np.polynomial.polynomial.polyval(1.0, polynomial)
+    expected = np.linalg.solve(stage_matrix, shifted_stage_values)
+
+    predictor = dense_predictor_matrix(tableau, step_ratio)
+    np.testing.assert_allclose(predictor @ increments, expected)
+
+
+@pytest.mark.parametrize(
+    "tableau",
+    [
+        DEFAULT_FIRK_TABLEAU,
+        RADAU_IIA_5_TABLEAU,
+        DIRK_TABLEAU_REGISTRY["l_stable_dirk_3"],
+        DIRK_TABLEAU_REGISTRY["lobatto_iiic_3"],
+    ],
+)
+@pytest.mark.parametrize("step_ratio", [0.65, 1.3])
+def test_ratio_coefficients_reconstruct_matrix(tableau, step_ratio):
+    """Summing the power stack reproduces the matrix at any ratio."""
+    coefficients = dense_predictor_ratio_coefficients(tableau)
+    reconstructed = np.zeros_like(coefficients[0])
+    for power_index in range(tableau.stage_count):
+        reconstructed += (
+            coefficients[power_index] * step_ratio ** (power_index + 1)
+        )
+    direct = dense_predictor_matrix(tableau, step_ratio)
+    scale = np.max(np.abs(direct))
+    assert np.max(np.abs(reconstructed - direct)) < 1e-12 * scale
+
+
+def test_radau_dense_predictor_coefficients_are_pinned():
+    expected = np.asarray(
+        [
+            [0.19107136, -0.89141154, 1.7003402],
+            [1.5580782, -5.5244045, 4.9663267],
+            [3.2735543, -10.606888, 8.333333],
+        ],
+        dtype=np.float32,
+    )
+
+    actual = np.asarray(
+        dense_predictor_matrix(RADAU_IIA_5_TABLEAU),
+        dtype=np.float32,
+    )
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_predictor_update_recognises_parameters(precision):
+    """The predictor participates in the standard update flow."""
+    predictor = DenseStagePredictor(
+        precision=precision,
+        n=3,
+        tableau=DEFAULT_FIRK_TABLEAU,
+    )
+    recognised = predictor.update(
+        previous_step_size_location="shared", n=5
+    )
+    assert recognised == {"previous_step_size_location", "n"}
+    assert callable(predictor.device_function)
+
+
+ITERATION_CASES = [
+    pytest.param(
+        "firk",
+        {"step_controller": "fixed", "dt": 0.005},
+        id="firk-fixed",
+    ),
+    pytest.param(
+        "l_stable_dirk_3",
+        {"step_controller": "fixed", "dt": 0.005},
+        id="dirk-fixed",
+    ),
+    pytest.param(
+        "radau",
+        {
+            "step_controller": "gustafsson",
+            "dt_min": 1e-6,
+            "dt_max": 0.02,
+            "atol": 1e-6,
+            "rtol": 1e-6,
+        },
+        id="firk-adaptive",
+    ),
+]
+
+
+@pytest.mark.parametrize("method,controller_settings", ITERATION_CASES)
+def test_dense_prediction_reduces_newton_iterations(
+    precision, method, controller_settings
+):
+    """A live predictor strictly beats carried increments.
+
+    Guards against the predictor silently compiling to a no-op
+    (e.g. its persistent step-size scalar missing from the loop's
+    layout): converged results cannot distinguish a dead predictor,
+    but the Newton iteration count can.
+    """
+    system = create_ODE_system(
+        "\n".join(
+            (
+                "dx = sigma*(y - x)",
+                "dy = x*(rho - z) - y",
+                "dz = x*y - b_const*z",
+            )
+        ),
+        states={"x": 1.05, "y": 0.97, "z": 1.02},
+        parameters={"sigma": 10.0, "rho": 28.0},
+        constants={"b_const": 8.0 / 3.0},
+        precision=precision,
+        name="dense_prediction_iteration_probe",
+    )
+    common = {
+        "y0": {
+            "x": np.array([1.05]),
+            "y": np.array([0.97]),
+            "z": np.array([1.02]),
+        },
+        "grid_type": "verbatim",
+        "method": method,
+        "duration": 0.1,
+        "save_every": 0.025,
+        "output_types": ["state", "iteration_counters"],
+    }
+    common.update(controller_settings)
+
+    def newton_total(result):
+        assert not np.any(result.status_codes)
+        counters = np.asarray(result.iteration_counters)
+        return int(counters.sum(axis=0).T[0, 0])
+
+    predicted = newton_total(solve_ivp(system, **common))
+    carried = newton_total(
+        solve_ivp(system, attempt_dense_prediction=False, **common)
+    )
+    assert predicted < carried

--- a/tests/integrators/test_stage_predictors.py
+++ b/tests/integrators/test_stage_predictors.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pytest
 
-from cubie import create_ODE_system, solve_ivp
 from cubie.integrators.algorithms.base_algorithm_step import (
     ButcherTableau,
 )
@@ -16,7 +15,6 @@ from cubie.integrators.algorithms.generic_firk_tableaus import (
     RADAU_IIA_5_TABLEAU,
 )
 from cubie.integrators.stage_predictors import (
-    DenseStagePredictor,
     dense_predictor_matrix,
     dense_predictor_ratio_coefficients,
     tableau_supports_dense_prediction,
@@ -69,33 +67,37 @@ def test_near_duplicate_node_tableau_is_rejected():
         dense_predictor_matrix(NEAR_DUPLICATE_NODE_TABLEAU)
 
 
+FIRK_SUPPORT_EXPECTATIONS = {
+    "firk_gauss_legendre_2": True,
+    "firk_gauss_legendre_4": True,
+    "radau_iia_5": True,
+}
+
+DIRK_SUPPORT_EXPECTATIONS = {
+    "implicit_midpoint": True,
+    "trapezoidal_dirk": True,
+    "ode23t": True,
+    "kvaerno3": False,
+    "kvaerno5": False,
+    "lobatto_iiic_3": True,
+    "sdirk_2_2": True,
+    "l_stable_dirk_3": True,
+    "l_stable_sdirk_4": True,
+}
+
+
 def test_registry_tableaus_support_expectations():
-    """Every registry tableau lands on the expected side of the gate."""
-    firk_support = {
-        name: tableau_supports_dense_prediction(tableau)
-        for name, tableau in FIRK_TABLEAU_REGISTRY.items()
-    }
-    assert firk_support == {
-        "firk_gauss_legendre_2": True,
-        "firk_gauss_legendre_4": True,
-        "radau_iia_5": True,
-        "radau": True,
-    }
-    dirk_support = {
-        name: tableau_supports_dense_prediction(tableau)
-        for name, tableau in DIRK_TABLEAU_REGISTRY.items()
-    }
-    assert dirk_support == {
-        "implicit_midpoint": True,
-        "trapezoidal_dirk": True,
-        "ode23t": True,
-        "kvaerno3": False,
-        "kvaerno5": False,
-        "lobatto_iiic_3": True,
-        "sdirk_2_2": True,
-        "l_stable_dirk_3": True,
-        "l_stable_sdirk_4": True,
-    }
+    """Known registry tableaus land on the expected side of the gate."""
+    for name, expected in FIRK_SUPPORT_EXPECTATIONS.items():
+        tableau = FIRK_TABLEAU_REGISTRY[name]
+        assert (
+            tableau_supports_dense_prediction(tableau) is expected
+        ), name
+    for name, expected in DIRK_SUPPORT_EXPECTATIONS.items():
+        tableau = DIRK_TABLEAU_REGISTRY[name]
+        assert (
+            tableau_supports_dense_prediction(tableau) is expected
+        ), name
 
 
 @pytest.mark.parametrize(
@@ -173,51 +175,63 @@ def test_ratio_coefficients_reconstruct_matrix(tableau, step_ratio):
     assert np.max(np.abs(reconstructed - direct)) < 1e-12 * scale
 
 
-def test_radau_dense_predictor_coefficients_are_pinned():
-    expected = np.asarray(
-        [
-            [0.19107136, -0.89141154, 1.7003402],
-            [1.5580782, -5.5244045, 4.9663267],
-            [3.2735543, -10.606888, 8.333333],
-        ],
-        dtype=np.float32,
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [{"algorithm": "radau"}],
+    indirect=True,
+)
+def test_predictor_update_flows_through_solver(solver_mutable):
+    """Predictor settings ride the standard solver update path."""
+    algo_step = solver_mutable.kernel.single_integrator._algo_step
+    predictor = algo_step.dense_predictor
+    assert (
+        predictor.compile_settings.previous_step_size_location
+        == "local"
     )
-
-    actual = np.asarray(
-        dense_predictor_matrix(RADAU_IIA_5_TABLEAU),
-        dtype=np.float32,
+    solver_mutable.update(previous_step_size_location="shared")
+    assert (
+        predictor.compile_settings.previous_step_size_location
+        == "shared"
     )
-    np.testing.assert_array_equal(actual, expected)
+    assert algo_step.dense_prediction
+    solver_mutable.update(attempt_dense_prediction=False)
+    assert not algo_step.dense_prediction
 
 
-def test_predictor_update_recognises_parameters(precision):
-    """The predictor participates in the standard update flow."""
-    predictor = DenseStagePredictor(
-        precision=precision,
-        n=3,
-        tableau=DEFAULT_FIRK_TABLEAU,
-    )
-    recognised = predictor.update(
-        previous_step_size_location="shared", n=5
-    )
-    assert recognised == {"previous_step_size_location", "n"}
-    assert callable(predictor.device_function)
+_LORENZ_ITERATION_BASE = {
+    "system_type": "lorenz_julia",
+    "output_types": ["state", "iteration_counters"],
+    "saved_state_indices": [0, 1, 2],
+    "saved_observable_indices": [],
+    "summarised_state_indices": [],
+    "summarised_observable_indices": [],
+    "summarise_every": None,
+    "sample_summaries_every": None,
+}
 
-
-ITERATION_CASES = [
+DENSE_PREDICTION_ITERATION_CASES = [
     pytest.param(
-        "firk",
-        {"step_controller": "fixed", "dt": 0.005},
+        {
+            **_LORENZ_ITERATION_BASE,
+            "algorithm": "firk",
+            "step_controller": "fixed",
+            "dt": 0.005,
+        },
         id="firk-fixed",
     ),
     pytest.param(
-        "l_stable_dirk_3",
-        {"step_controller": "fixed", "dt": 0.005},
+        {
+            **_LORENZ_ITERATION_BASE,
+            "algorithm": "l_stable_dirk_3",
+            "step_controller": "fixed",
+            "dt": 0.005,
+        },
         id="dirk-fixed",
     ),
     pytest.param(
-        "radau",
         {
+            **_LORENZ_ITERATION_BASE,
+            "algorithm": "radau",
             "step_controller": "gustafsson",
             "dt_min": 1e-6,
             "dt_max": 0.02,
@@ -229,52 +243,41 @@ ITERATION_CASES = [
 ]
 
 
-@pytest.mark.parametrize("method,controller_settings", ITERATION_CASES)
-def test_dense_prediction_reduces_newton_iterations(
-    precision, method, controller_settings
-):
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    DENSE_PREDICTION_ITERATION_CASES,
+    indirect=True,
+)
+def test_dense_prediction_reduces_newton_iterations(solver_mutable):
     """A live predictor strictly beats carried increments.
 
     Guards against the predictor silently compiling to a no-op
     (e.g. its persistent step-size scalar missing from the loop's
     layout): converged results cannot distinguish a dead predictor,
-    but the Newton iteration count can.
+    but the Newton iteration count can. The chaotic ``rho = 28``
+    regime is critical: there the stage curve moves enough between
+    steps for the read-ahead to strictly beat carried increments on
+    every method; the fixture default ``rho = 21`` settles onto a
+    fixed point where both seeds are equally converged.
     """
-    system = create_ODE_system(
-        "\n".join(
-            (
-                "dx = sigma*(y - x)",
-                "dy = x*(rho - z) - y",
-                "dz = x*y - b_const*z",
-            )
-        ),
-        states={"x": 1.05, "y": 0.97, "z": 1.02},
-        parameters={"sigma": 10.0, "rho": 28.0},
-        constants={"b_const": 8.0 / 3.0},
-        precision=precision,
-        name="dense_prediction_iteration_probe",
-    )
-    common = {
-        "y0": {
+    solve_kwargs = dict(
+        initial_values={
             "x": np.array([1.05]),
             "y": np.array([0.97]),
             "z": np.array([1.02]),
         },
-        "grid_type": "verbatim",
-        "method": method,
-        "duration": 0.1,
-        "save_every": 0.025,
-        "output_types": ["state", "iteration_counters"],
-    }
-    common.update(controller_settings)
+        parameters={"rho": np.array([28.0])},
+        grid_type="verbatim",
+        duration=0.1,
+        save_every=0.025,
+    )
 
     def newton_total(result):
         assert not np.any(result.status_codes)
         counters = np.asarray(result.iteration_counters)
-        return int(counters.sum(axis=0).T[0, 0])
+        return int(counters.sum(axis=0)[0].sum())
 
-    predicted = newton_total(solve_ivp(system, **common))
-    carried = newton_total(
-        solve_ivp(system, attempt_dense_prediction=False, **common)
-    )
+    predicted = newton_total(solver_mutable.solve(**solve_kwargs))
+    solver_mutable.update(attempt_dense_prediction=False)
+    carried = newton_total(solver_mutable.solve(**solve_kwargs))
     assert predicted < carried


### PR DESCRIPTION
## Summary

Replaces #655 with the same optimisation in reusable, generalised form, reworked per review. The branch is squash-rebased onto `main` (including #658's Gustafsson `gamma` fix, which clears the previously failing julia adaptive-radau test).

- `DenseStagePredictor(CUDAFactory)` (`src/cubie/integrators/stage_predictors.py`) compiles a read-ahead of the previous step's **stage-derivative samples**: converged increments are step-size-scaled derivative samples at the stage times, so interpolating them and evaluating one step ahead warm-starts Newton. For collocation tableaus this is exactly the classical extrapolation of the collocation polynomial (RADAU5's predictor) — the Radau IIA-5 transform matrix is bit-identical to the state-curve `A⁻¹LA` form — but unlike that form it needs neither an invertible `A` nor nonzero nodes, and it stays well-conditioned for non-collocation DIRKs (where `A⁻¹LA` amplifies sample error up to 11,700× and diverged in testing).
- **Runtime step-size-ratio extrapolation**: the transform's entries are degree-`s` polynomials in `next dt / previous dt` with host-precomputed coefficient matrices; the device evaluates them by Horner per entry. Application is bounded at `MAX_PREDICTION_STEP_RATIO = 8` (RADAU5's `facr`): a save boundary can truncate a step to a sliver, and the next ratio would otherwise be unbounded (`ratio^s` overflow → NaN, reproduced and fixed).
- **Preconditions** collapse to: pairwise-distinct stage nodes, with node spread within `MAX_NODE_AMPLIFICATION_RATIO = 10` of the same-stage-count Gauss–Legendre nodes. Every registry FIRK and DIRK tableau qualifies except `kvaerno3`/`kvaerno5` (repeated nodes — #657 pins the lift). Zero-node/explicit-first-stage tableaus predict without special handling; #657 also covers recording the explicit stage's true `dt·f` sample instead of letting the transform roll its slot forward.
- **DIRK support**: `DIRKStep` owns a predictor and a persistent `stage_increment_history` (`stage_count × n`, own declared location field); each stage solve seeds from and writes back to the history. `FIRKStep` transforms its existing coupled stage vector in place.
- **Pattern compliance** per both review rounds:
  - `predictor_function` pipes through compile settings **and is consumed there by `build_step`**, exactly mirroring `solver_function` (`build_implicit_helpers` sets both).
  - The predictor child and the DIRK history buffer **register unconditionally**; the history registers at **size 0 when prediction is inactive** (Rosenbrock-style), so `build_step` and the device body fetch and run every allocator unconditionally — no conditional allocator branches remain.
  - **Single gate, predicated commit**: the step computes one `apply` flag (not-first-step ∧ previous-accepted) and passes it to `predict`; the DIRK per-stage seed loads are unconditional behind the compile-time bool. Inside `predict` the transform and matvec always compute; only the commit is predicated on `apply ∧ ratio ≤ 8` (no early return, no runtime branch body).
  - The predictor's `transform` and `previous_values` scratch are **buffer-registry managed** (no raw `cuda.local.array`).
  - Predictor kwargs filter through `ODEImplicitStep._PREDICTOR_PARAMS`, symmetric with the solver frozensets.
  - `attempt_dense_prediction` (default `True`, bool-validated, explicit init arg) is the request; the `dense_prediction` property reports whether it is actually active. `DenseStagePredictorConfig.tableau` is type-validated.
- The CPU reference mirrors the device exactly, including the explicit-stage history semantics: slots no solver writes keep the transform's read-ahead values (previously the reference zeroed them each step — a genuine device/reference divergence). A `trapezoidal_dirk` loop test pins the explicit-first-stage path device-vs-reference.
- `is_controller_fixed` is gone entirely; `SingleIntegratorRunCore.check_compatibility` no longer touches the algorithm.
- `GAUSS_LEGENDRE_4_TABLEAU` (order 8, alias `firk_gauss_legendre_4`) joins the FIRK registry as float64 literals of the collocation construction, with a test regenerating it from scratch. It has no OrdinaryDiffEq counterpart (Julia's FIRKs are the RadauIIA family), so its accuracy check is the device-vs-CPU-reference loop test rather than a julia golden row.
- Predictor tests live in `tests/integrators/test_stage_predictors.py` on the shared fixtures: the update-flow test drives `solver_mutable` and asserts the predictor's settings through the standard update path; the iteration guards parametrise `solver_settings_override` over the shared `lorenz_julia` system.

## Measured evidence (Newton totals, lorenz_julia at `rho = 28`, 20 fixed steps dt = 0.005 / gustafsson, CUDASIM)

| method | predicted | carried |
|---|---:|---:|
| DIRK `l_stable_dirk_3` (fixed) | 26 | 33 (−21%) |
| FIRK `firk_gauss_legendre_2` (fixed) | 35 | 44 (−20%) |
| FIRK `radau_iia_5` (gustafsson) | 53 | 79 (−33%) |

The chaotic `rho = 28` regime is critical for the strict-reduction guards: at the fixture default `rho = 21` the trajectory settles onto a fixed point where carried increments are already converged and prediction measures neutral (±1 iteration) — the same neutrality holds on the stiff, three-chamber, large, and diagonally-dominant fixture systems. The iteration guards therefore pass `rho = 28` explicitly and document why.

## Validation (rebased tree, vs `origin/main`)

- full CUDASIM suite: 3026 passed, 0 failed
- full real-GPU suite: 3102 passed, 0 failed — including `test_adaptive_matched_controller_tracks_julia[radau_iia_5]`, previously failing on main and fixed by #658
- device-vs-CPU-reference loop tests: four-stage Gauss–Legendre FIRK (fixed), `l_stable_dirk_3` (fixed), `trapezoidal_dirk` (fixed, explicit first stage), `radau_iia_5` (PI adaptive), `l_stable_sdirk_4` (PI adaptive)
- unit tests: derivative-sample fit and collocation-extrapolation identities vs independent `polyfit` constructions at multiple ratios, ratio-coefficient reconstruction at unsampled ratios, precondition rejections and acceptances, registry support expectations (per-name, robust to registry additions), solver-driven predictor update flow, and the iteration-count guards
- ruff on changed files and the blocking flake8 gate: passed

### Performance gate

Two `python benchmarks/ab_gate.py` runs (A = `origin/main`, B = this branch). Occupancy, registers, and spills identical A vs B on every config. **Other GPU work was in flight on this machine during both runs**; the DISTRUST rows and the both-ways aggregate swings (e.g. numba-cuda wave A/B aggregates ±17% while the paired delta is +2.9%) carry the parallel-load contamination signature. No row regresses consistently across the two runs; the adaptive improvement reproduces in both.

Run 1 (numba-cuda section lost to output truncation; mlir rows verbatim):

```
mlir       fixed     kernel  A   104.685  B    84.653   +1.90%  REGRESSION
mlir       fixed     wall    A   118.952  B    98.695   +1.72%  ok
mlir       adaptive  kernel  A     7.327  B     5.780  -21.21%  improvement
mlir       adaptive  wall    A     9.398  B     7.856  -16.51%  improvement
mlir       chunked   kernel  A    62.840  B    63.002   +0.26%  ok  DISTRUST
mlir       chunked   wall    A    78.939  B    79.081   +0.11%  ok
mlir       wave      kernel  A    32.327  B    32.467   +0.04%  ok
mlir       wave      wall    A    35.359  B    35.423   -0.33%  ok
```

Run 2 (full, quieter but still contaminated):

```
numba-cuda fixed     kernel  A    83.609  B    84.217   +0.01%  ok
numba-cuda fixed     wall    A    97.175  B    97.755   -0.01%  ok
numba-cuda adaptive  kernel  A     7.979  B     5.564  -25.31%  improvement
numba-cuda adaptive  wall    A    10.127  B     7.665  -20.04%  improvement
numba-cuda chunked   kernel  A    78.847  B    84.462   +0.08%  ok
numba-cuda chunked   wall    A    95.012  B   100.386   -0.24%  ok
numba-cuda wave      kernel  A    31.231  B    36.494   +2.89%  REGRESSION  DISTRUST
numba-cuda wave      wall    A    34.106  B    39.457   +3.05%  ok
mlir       fixed     kernel  A    84.814  B   106.534   +0.27%  ok  DISTRUST
mlir       fixed     wall    A    99.419  B   120.963   -0.12%  ok
mlir       adaptive  kernel  A     5.892  B     6.551   -3.12%  improvement  DISTRUST
mlir       adaptive  wall    A     8.248  B     8.815   -1.63%  ok  DISTRUST
mlir       chunked   kernel  A    62.838  B    62.989   +0.25%  ok
mlir       chunked   wall    A    79.635  B    79.525   -0.43%  ok
mlir       wave      kernel  A    25.904  B    25.837   -0.18%  ok
mlir       wave      wall    A    28.847  B    28.789   -0.14%  ok
```

The mlir-fixed row flipped REGRESSION → ok DISTRUST between runs; numba-cuda wave is a single DISTRUST reading. A clean-GPU rerun is warranted before merge if either row is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
