### PR TITLE
fix: Gustafsson controller setting "gamma" disambiguated

### DIFF
--- a/docs/source/examples/controller_step_analysis.py
+++ b/docs/source/examples/controller_step_analysis.py
@@ -123,8 +123,10 @@ def build_solver_settings(precision: type[np.floating[Any]]) -> Dict[str, Any]:
         "preconditioner_order": 2,
         "krylov_max_iters": 500,
         "newton_max_iters": 500,
+        "newton_target_iters": 20,
         "min_gain": precision(0.2),
         "max_gain": precision(2.0),
+        "safety": precision(0.9),
         "kp": precision(0.7),
         "ki": precision(-0.4),
         "kd": precision(0.0),
@@ -203,7 +205,10 @@ def build_step_controller_settings(
         "kd": precision(solver_settings["kd"]),
         "deadband_min": precision(solver_settings["deadband_min"]),
         "deadband_max": precision(solver_settings["deadband_max"]),
-        "newton_max_iters": int(solver_settings["newton_max_iters"]),
+        "newton_target_iters": int(
+            solver_settings["newton_target_iters"]
+        ),
+        "safety": precision(solver_settings["safety"]),
     }
 
     if overrides:

--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -156,7 +156,7 @@ below may be passed directly to :func:`~cubie.solve_ivp`,
      - ``step_controller``, ``dt``, ``dt_min``, ``dt_max``,
        ``atol``, ``rtol``, ``safety``, ``min_gain``, ``max_gain``,
        ``kp``, ``ki``, ``kd``, ``deadband_min``, ``deadband_max``,
-       ``gamma``
+       ``newton_target_iters``
      - :doc:`optional_arguments`
    * - Algorithm
      - ``newton_atol``, ``newton_rtol``, ``newton_max_iters``,

--- a/docs/source/user_guide/optional_arguments.rst
+++ b/docs/source/user_guide/optional_arguments.rst
@@ -108,18 +108,10 @@ Controller-specific gains:
 
     - Default: ``0.0``
 
-**gamma** — damping factor (``gustafsson`` only).
-    Lower values make step-size changes more conservative.
-
-    - Default: ``0.9``
-
-**newton_max_iters** — Newton-iteration budget (``gustafsson`` only).
+**newton_target_iters** — Newton-work reference (``gustafsson`` only).
     The Gustafsson controller scales its prediction by how hard the
-    implicit solver is working; this is the iteration count it treats
-    as "full effort".  This is the same option name as the implicit
-    solver's Newton iteration limit below: passing it once sets both,
-    so keep it equal to the Newton budget you actually intend.  Left
-    unset, the controller uses 20 while the solver uses 100.
+    implicit solver is working; this reference count sets the strength
+    of that damping.  It does not limit Newton solver execution.
 
     - Default: ``20``
 

--- a/src/cubie/integrators/algorithms/AGENTS.md
+++ b/src/cubie/integrators/algorithms/AGENTS.md
@@ -74,8 +74,8 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
   families — DIRK/FIRK/Rosenbrock-W/Crank-Nicolson — with RADAU5's gain limits and
   deadband). **Errorless tableaus must use a fixed controller** — constructors enforce
   this; never pair an adaptive controller with an errorless tableau. Controller-defaults
-  dicts must never contain keys that are also algorithm parameters (e.g. `gamma`,
-  `newton_max_iters`): on hot-swap the defaults merge into the shared `updates_dict`
+  dicts must never contain keys that are also algorithm parameters: on hot-swap
+  the defaults merge into the shared `updates_dict`
   and would overwrite the algorithm's own setting.
 - **`update` additions:** new keywords must be added to `ALL_ALGORITHM_STEP_PARAMETERS`
   (`base_algorithm_step.py`) or `update` rejects them; `ODEImplicitStep` routes solver

--- a/src/cubie/integrators/step_control/AGENTS.md
+++ b/src/cubie/integrators/step_control/AGENTS.md
@@ -24,7 +24,7 @@ controllers.
 | `adaptive_I_controller.py` | `AdaptiveIController` — integral-only; gain `safety·norm^(-1/(2(1+order)))`; no history. |
 | `adaptive_PI_controller.py` | `AdaptivePIController` (`kp=0.7`, `ki=-0.4`) — uses previous + current norm. |
 | `adaptive_PID_controller.py` | `AdaptivePIDController` (`PIDStepControlConfig` extends PI with `kd=0.0`) — uses two previous norms. |
-| `gustafsson_controller.py` | `GustafssonController` (`gamma=0.9`, `newton_max_iters=20`) — min of a basic gain and a Newton-iteration-aware predictive gain; stores previous `dt` + norm. |
+| `gustafsson_controller.py` | `GustafssonController` (`safety=0.9`, `newton_target_iters=20`) — min of a basic gain and a Newton-iteration-aware predictive gain; stores previous `dt` + norm. |
 
 ## For AI Agents
 

--- a/src/cubie/integrators/step_control/base_step_controller.py
+++ b/src/cubie/integrators/step_control/base_step_controller.py
@@ -72,8 +72,7 @@ ALL_STEP_CONTROLLER_PARAMETERS = {
     "kd",
     "deadband_min",
     "deadband_max",
-    "gamma",
-    "newton_max_iters",
+    "newton_target_iters",
     "timestep_memory_location",
 }
 """All keyword arguments accepted by step controllers.
@@ -140,12 +139,9 @@ by parent components to filter kwargs before forwarding them.
    * - ``deadband_max``
      - :class:`~cubie.integrators.step_control.adaptive_step_controller.AdaptiveStepControlConfig`
      - Upper gain threshold for the unity deadband.
-   * - ``gamma``
+   * - ``newton_target_iters``
      - :class:`~cubie.integrators.step_control.gustafsson_controller.GustafssonStepControlConfig`
-     - Damping factor for the Gustafsson predictor.
-   * - ``newton_max_iters``
-     - :class:`~cubie.integrators.step_control.gustafsson_controller.GustafssonStepControlConfig`
-     - Maximum Newton iterations considered by the predictor.
+     - Reference Newton-work count used to damp step-size proposals.
    * - ``timestep_memory_location``
      - :class:`BaseStepControllerConfig`
      - Memory location for the timestep buffer (``'local'`` or

--- a/src/cubie/integrators/step_control/gustafsson_controller.py
+++ b/src/cubie/integrators/step_control/gustafsson_controller.py
@@ -9,8 +9,8 @@ Published Classes
 
     >>> from numpy import float64
     >>> config = GustafssonStepControlConfig(precision=float64)
-    >>> config.gamma
-    0.9
+    >>> config.newton_target_iters
+    20
 
 :class:`GustafssonController`
     Adaptive controller using Gustafsson acceleration for implicit
@@ -44,7 +44,6 @@ from cubie.integrators.step_control.adaptive_step_controller import (
 from cubie._utils import (
     PrecisionDType,
     getype_validator,
-    inrangetype_validator,
 )
 from cubie.cuda_simsafe import selp
 from cubie.result_codes import CUBIE_RESULT_CODES
@@ -57,15 +56,11 @@ class GustafssonStepControlConfig(AdaptiveStepControlConfig):
 
     Notes
     -----
-    Includes damping and Newton iteration limits used by Gustafsson's
-    predictor for implicit integrators.
+    Includes the reference Newton iteration count used by Gustafsson's
+    work-sensitive damping for implicit integrators.
     """
 
-    _gamma: float = field(
-        default=0.9,
-        validator=inrangetype_validator(float, 0, 1),
-    )
-    _newton_max_iters: int = field(
+    _newton_target_iters: int = field(
         default=20,
         validator=getype_validator(int, 0),
     )
@@ -74,23 +69,15 @@ class GustafssonStepControlConfig(AdaptiveStepControlConfig):
         super().__attrs_post_init__()
 
     @property
-    def gamma(self) -> float:
-        """Return the damping factor applied to the gain."""
-
-        return self.precision(self._gamma)
-
-    @property
-    def newton_max_iters(self) -> int:
-        """Return the maximum number of Newton iterations considered."""
-        return int(self._newton_max_iters)
+    def newton_target_iters(self) -> int:
+        """Return the Newton-work reference used for gain damping."""
+        return int(self._newton_target_iters)
 
     @property
     def settings_dict(self) -> dict[str, object]:
         """Return the configuration as a dictionary."""
         settings_dict = super().settings_dict
-        settings_dict.update(
-            {"gamma": self.gamma, "newton_max_iters": self.newton_max_iters}
-        )
+        settings_dict.update({"newton_target_iters": self.newton_target_iters})
         return settings_dict
 
 
@@ -100,16 +87,10 @@ class GustafssonController(BaseAdaptiveStepController):
     _config_class = GustafssonStepControlConfig
 
     @property
-    def gamma(self) -> float:
-        """Return the damping factor applied to the gain."""
+    def newton_target_iters(self) -> int:
+        """Return the Newton-work reference used for gain damping."""
 
-        return self.compile_settings.gamma
-
-    @property
-    def newton_max_iters(self) -> int:
-        """Return the maximum number of Newton iterations considered."""
-
-        return self.compile_settings.newton_max_iters
+        return self.compile_settings.newton_target_iters
 
     _timestep_buffer_elements = 2  # previous dt and error norm
 
@@ -164,9 +145,9 @@ class GustafssonController(BaseAdaptiveStepController):
         )
 
         expo = precision(1.0 / (2 * (algorithm_order + 1)))
-        gamma = precision(self.gamma)
-        newton_max_iters = int(self.newton_max_iters)
-        gain_numerator = precision((1 + 2 * newton_max_iters)) * gamma
+        safety = precision(safety)
+        newton_target_iters = int(self.newton_target_iters)
+        gain_numerator = precision((1 + 2 * newton_target_iters)) * safety
         typed_one = precision(1.0)
         typed_zero = precision(0.0)
         deadband_min = precision(self.deadband_min)
@@ -176,7 +157,6 @@ class GustafssonController(BaseAdaptiveStepController):
         deadband_disabled = (deadband_min == typed_one) and (
             deadband_max == typed_one
         )
-        numba_precision = self.compile_settings.numba_precision
         n = int32(n)
         inv_n = precision(1.0 / n)
         typed_large = precision(1e16)
@@ -253,14 +233,14 @@ class GustafssonController(BaseAdaptiveStepController):
             accept = nrm2 <= typed_one
             accept_out[0] = int32(1) if accept else int32(0)
 
-            denom = precision(niters + 2 * newton_max_iters)
+            denom = precision(niters + 2 * newton_target_iters)
             tmp = gain_numerator / denom
-            fac = gamma if gamma < tmp else tmp
+            fac = safety if safety < tmp else tmp
             gain_basic = precision(fac * (nrm2 ** (-expo)))
 
             ratio = nrm2 * nrm2 / err_prev
             gain_gus = precision(
-                safety * (dt[0] / dt_prev) * (ratio**-expo) * gamma
+                safety * (dt[0] / dt_prev) * (ratio**-expo)
             )
             gain = gain_gus if gain_gus < gain_basic else gain_basic
             gain = (

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1328,7 +1328,9 @@ def _build_cpu_step_controller(
         deadband_min=step_controller_settings["deadband_min"],
         deadband_max=step_controller_settings["deadband_max"],
         safety=step_controller_settings["safety"],
-        newton_max_iters=step_controller_settings["newton_max_iters"],
+        newton_target_iters=step_controller_settings[
+            "newton_target_iters"
+        ],
     )
     if kind == "pi":
         controller.kp = step_controller_settings["kp"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -582,6 +582,7 @@ def solver_settings(solver_settings_override, system, precision):
         "preconditioner_order": 2,
         "krylov_max_iters": 50,
         "newton_max_iters": 50,
+        "newton_target_iters": 20,
         "min_gain": precision(0.1),
         "max_gain": precision(5.0),
         "safety": precision(0.9),

--- a/tests/integrated_numerical_tests/julia_reference/ne_gate.py
+++ b/tests/integrated_numerical_tests/julia_reference/ne_gate.py
@@ -159,7 +159,7 @@ def matched_controller_settings(constants, alias, order):
     if c["controller"] == "PredictiveController":
         return {
             "step_controller": "gustafsson",
-            "gamma": c["gamma"],
+            "safety": c["gamma"],
         }
     return None
 

--- a/tests/integrators/cpu_reference/step_controllers.py
+++ b/tests/integrators/cpu_reference/step_controllers.py
@@ -24,11 +24,10 @@ class CPUAdaptiveController:
         kp: float = 0.7,
         ki: float = -0.4,
         kd: float = 0.0,
-        gamma: float = 0.9,
         safety: float = 0.9,
         min_gain: float = 0.5,
         max_gain: float = 2.0,
-        newton_max_iters: int = 0,
+        newton_target_iters: int = 20,
         deadband_min: float = 1.0,
         deadband_max: float = 1.2,
     ) -> None:
@@ -52,8 +51,7 @@ class CPUAdaptiveController:
         self.kp = precision(kp)
         self.ki = precision(ki)
         self.kd = precision(kd)
-        self.gamma = precision(gamma)
-        self.newton_max_iters = int(newton_max_iters)
+        self.newton_target_iters = int(newton_target_iters)
         self.deadband_min = precision(deadband_min)
         self.deadband_max = precision(deadband_max)
         self.unity_gain = precision(1.0)
@@ -183,12 +181,13 @@ class CPUAdaptiveController:
             one = precision(1.0)
             two = precision(2.0)
             niters_eff = precision(max(niters, 1))
-            M = self.newton_max_iters
+            target_iters = self.newton_target_iters
             dt_prev = max(precision(1e-16), self._prev_dt)
             nrm2_prev = max(precision(1e-16), self._prev_nrm2)
             fac = min(
-                self.gamma,
-                ((one + two * M) * self.gamma) / (niters_eff + two * M),
+                self.safety,
+                ((one + two * target_iters) * self.safety)
+                / (niters_eff + two * target_iters),
             )
             gain_basic = precision(fac * (errornorm**-expo_fraction))
 
@@ -198,7 +197,6 @@ class CPUAdaptiveController:
                 self.safety
                 * (current_dt / dt_prev)
                 * precision(ratio**-expo_fraction)
-                * self.gamma
             )
             gain = gain_gus if gain_gus < gain_basic else gain_basic
             # Fallback to gain_basic if step not accepted or no previous dt

--- a/tests/integrators/step_control/test_gustafsson_controller.py
+++ b/tests/integrators/step_control/test_gustafsson_controller.py
@@ -6,6 +6,12 @@ import pytest
 from cubie.integrators.step_control.adaptive_step_controller import (
     AdaptiveStepControlConfig,
 )
+from cubie.integrators.algorithms.base_algorithm_step import (
+    ALL_ALGORITHM_STEP_PARAMETERS,
+)
+from cubie.integrators.step_control.base_step_controller import (
+    ALL_STEP_CONTROLLER_PARAMETERS,
+)
 from cubie.integrators.step_control.gustafsson_controller import (
     GustafssonStepControlConfig,
 )
@@ -18,55 +24,49 @@ def test_config_defaults():
     """Gustafsson-specific fields default correctly."""
     # Inline construction permitted per Rule 9: __init__ test.
     cfg = GustafssonStepControlConfig(precision=np.float64)
-    assert cfg.gamma == pytest.approx(0.9)
-    assert cfg.newton_max_iters == 20
+    assert cfg.newton_target_iters == 20
 
 
-def test_config_gamma_applies_precision():
-    """gamma is returned in the configured precision."""
-    cfg = GustafssonStepControlConfig(precision=np.float32, gamma=0.8)
-    assert cfg.gamma == np.float32(0.8)
-    assert isinstance(cfg.gamma, np.float32)
-
-
-@pytest.mark.parametrize("bad_gamma", [-0.1, 1.5])
-def test_config_gamma_validates_range(bad_gamma):
-    """gamma rejects values outside [0, 1]."""
-    with pytest.raises((ValueError, TypeError)):
-        GustafssonStepControlConfig(
-            precision=np.float64, gamma=bad_gamma
-        )
-
-
-def test_config_newton_max_iters_returns_int():
-    """newton_max_iters is exposed as a plain int."""
+def test_config_newton_target_iters_returns_int():
+    """newton_target_iters is exposed as a plain int."""
     cfg = GustafssonStepControlConfig(
-        precision=np.float64, newton_max_iters=7
+        precision=np.float64, newton_target_iters=7
     )
-    assert cfg.newton_max_iters == 7
-    assert isinstance(cfg.newton_max_iters, int)
+    assert cfg.newton_target_iters == 7
+    assert isinstance(cfg.newton_target_iters, int)
 
 
-def test_config_newton_max_iters_validates_nonnegative():
-    """newton_max_iters rejects negative values."""
+def test_config_newton_target_iters_validates_nonnegative():
+    """newton_target_iters rejects negative values."""
     with pytest.raises((ValueError, TypeError)):
         GustafssonStepControlConfig(
-            precision=np.float64, newton_max_iters=-1
+            precision=np.float64, newton_target_iters=-1
         )
 
 
 def test_config_settings_dict_extends_parent():
-    """settings_dict adds gamma and newton_max_iters to parent keys."""
+    """settings_dict adds the controller's Newton-work target."""
     cfg = GustafssonStepControlConfig(
-        precision=np.float64, gamma=0.85, newton_max_iters=11
+        precision=np.float64, safety=0.85, newton_target_iters=11
     )
     settings = cfg.settings_dict
-    assert settings["gamma"] == pytest.approx(0.85)
-    assert settings["newton_max_iters"] == 11
+    assert settings["safety"] == pytest.approx(0.85)
+    assert settings["newton_target_iters"] == 11
+    assert "gamma" not in settings
+    assert "newton_max_iters" not in settings
     parent_keys = set(
         AdaptiveStepControlConfig(precision=np.float64).settings_dict
     )
     assert parent_keys <= set(settings)
+
+
+def test_algorithm_and_controller_names_only_share_identical_values():
+    """Flat settings share only system precision and state count."""
+    shared = ALL_ALGORITHM_STEP_PARAMETERS & ALL_STEP_CONTROLLER_PARAMETERS
+    assert shared == {"precision", "n"}
+    assert "gamma" in ALL_ALGORITHM_STEP_PARAMETERS
+    assert "newton_max_iters" in ALL_ALGORITHM_STEP_PARAMETERS
+    assert "newton_target_iters" in ALL_STEP_CONTROLLER_PARAMETERS
 
 
 # ── GustafssonController: property forwarding ─────────────────────── #
@@ -79,13 +79,9 @@ def test_config_settings_dict_extends_parent():
     indirect=True,
 )
 def test_controller_forwards_config_properties(step_controller):
-    """Controller gamma/newton_max_iters mirror compile_settings."""
+    """Controller Newton-work target mirrors compile_settings."""
     assert (
-        step_controller.gamma
-        == step_controller.compile_settings.gamma
+        step_controller.newton_target_iters
+        == step_controller.compile_settings.newton_target_iters
     )
-    assert (
-        step_controller.newton_max_iters
-        == step_controller.compile_settings.newton_max_iters
-    )
-    assert isinstance(step_controller.newton_max_iters, int)
+    assert isinstance(step_controller.newton_target_iters, int)

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -1041,31 +1041,3 @@ def test_explicit_inner_tolerance_survives_derivation(
         float(algo.krylov_residual_floor),
         float(np.finfo(run.precision).eps) ** 0.5,
     )
-
-
-@pytest.mark.parametrize(
-    "solver_settings_override",
-    [
-        {
-            "algorithm": "radau_iia_5",
-            "step_controller": "gustafsson",
-            "gamma": 0.375,
-            "newton_max_iters": 37,
-            "newton_target_iters": 9,
-        }
-    ],
-    indirect=True,
-)
-def test_implicit_algorithm_and_controller_settings_are_independent(
-    single_integrator_run,
-):
-    """Flat settings preserve distinct algorithm/controller meanings."""
-    run = single_integrator_run
-    algorithm = run._algo_step
-    controller = run._step_controller
-
-    assert algorithm.gamma == pytest.approx(0.375)
-    assert algorithm.newton_max_iters == 37
-    assert controller.newton_target_iters == 9
-    assert "gamma" not in controller.settings_dict
-    assert "newton_max_iters" not in controller.settings_dict

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -1041,3 +1041,31 @@ def test_explicit_inner_tolerance_survives_derivation(
         float(algo.krylov_residual_floor),
         float(np.finfo(run.precision).eps) ** 0.5,
     )
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [
+        {
+            "algorithm": "radau_iia_5",
+            "step_controller": "gustafsson",
+            "gamma": 0.375,
+            "newton_max_iters": 37,
+            "newton_target_iters": 9,
+        }
+    ],
+    indirect=True,
+)
+def test_implicit_algorithm_and_controller_settings_are_independent(
+    single_integrator_run,
+):
+    """Flat settings preserve distinct algorithm/controller meanings."""
+    run = single_integrator_run
+    algorithm = run._algo_step
+    controller = run._step_controller
+
+    assert algorithm.gamma == pytest.approx(0.375)
+    assert algorithm.newton_max_iters == 37
+    assert controller.newton_target_iters == 9
+    assert "gamma" not in controller.settings_dict
+    assert "newton_max_iters" not in controller.settings_dict


### PR DESCRIPTION
## Summary

- remove `gamma` from the Gustafsson controller and use the inherited `safety` factor exactly once in each gain candidate
- rename the controller's Newton-work tuning constant to `newton_target_iters`, leaving the algorithm's terminating `newton_max_iters` independent
- update the CPU reference, Julia PredictiveController adapter, settings allowlists, documentation, and regression coverage

## Root cause

The flat settings surface routed unrelated values to every matching consumer. For Radau, algorithm `gamma` scales the effective residual step, while the Gustafsson controller's former `gamma` was a safety factor. Julia's PredictiveController `gamma=0.9` therefore overwrote Radau's algorithm `gamma=1.0`, so residual stages used `0.9h` while the loop advanced by `h`. The controller also named its work-damping reference `newton_max_iters`, aliasing the actual Newton solver termination limit despite having a separate meaning and default.

After this change, the only algorithm/controller setting-name intersection is the intentional `{precision, n}` pair.

## Verification

- `pytest tests/integrators/step_control tests/integrated_numerical_tests/julia_reference/test_julia_reference.py -q -n 0 --no-cov`: **165 passed** on real GPU
- `pytest tests/integrators/test_SingleIntegratorRunCore.py -q -n 0 --no-cov`: **61 passed**
- Julia comparison suite: **37/37 passed**, including adaptive `radau_iia_5`
- Additional focused core/algorithm run before transplanting onto current main: **185 passed**
- Ruff on all modified Python files: **passed**
- `flake8 . --select=E9,F63,F7,F82 --show-source`: **passed**
- `git diff --check`: **passed**

## Performance gate

The GPU was hot/noisy. Compile metrics were identical for A and B on every run (registers, spills, occupancy, launch geometry, run counts, and chunk counts). All median kernel deltas were below the 0.50% regression threshold, and all wall deltas were below the 10% threshold, but the harness marked changing rows `DISTRUST`; results are included rather than presented as a trusted pass.

Three runs were made:

- 4 pairs: `INCONCLUSIVE`; `DISTRUST` on numba-cuda adaptive, MLIR adaptive, and MLIR wave
- 8 pairs: `INCONCLUSIVE`; `DISTRUST` on numba-cuda adaptive, MLIR fixed, and MLIR chunked
- 16 pairs: `INCONCLUSIVE`; exact final table below

| backend | config | kernel delta | kernel verdict | wall delta | wall verdict |
|---|---:|---:|---|---:|---|
| numba-cuda | fixed | -0.11% | ok, **DISTRUST** | -0.01% | ok |
| numba-cuda | adaptive | -0.28% | ok, **DISTRUST** | -0.14% | ok |
| numba-cuda | chunked | +0.08% | ok, **DISTRUST** | -0.15% | ok |
| numba-cuda | wave | +0.10% | ok, **DISTRUST** | -0.16% | ok |
| MLIR | fixed | -0.32% | ok | -0.47% | ok |
| MLIR | adaptive | -0.47% | ok, **DISTRUST** | -1.75% | ok |
| MLIR | chunked | -0.34% | ok | -0.62% | ok |
| MLIR | wave | -0.03% | ok, **DISTRUST** | -0.16% | ok |

Command: `python benchmarks/ab_gate.py --pairs 16`

Final harness verdict: **GATE: INCONCLUSIVE**.