### PR TITLE
fix: kernel cache keys no longer depend on solver-helper build order

### DIFF
--- a/src/cubie/odesystems/ODEData.py
+++ b/src/cubie/odesystems/ODEData.py
@@ -158,8 +158,9 @@ class ODEData(CUDAFactoryConfig):
     _solver_beta: float = field(default=1.0, converter=float)
     _solver_gamma: float = field(default=1.0, converter=float)
     preconditioner_order: int = field(default=2, converter=int)
+    # Set during builds; hashing it makes cache keys order-dependent.
     tableau_digest: str = field(
-        default="", validator=attrsval_instance_of(str)
+        default="", validator=attrsval_instance_of(str), eq=False
     )
 
     def __attrs_post_init__(self):


### PR DESCRIPTION
## Summary

`SymbolicODE`'s `tableau_digest` compile setting is excluded from config equality and hashing (`eq=False`), with a one-line comment stating why.

The digest is written *during* kernel builds (helper generation records which tableau the n-stage helpers were specialised for), and `config_hash` recurses into the system factory. Hashing it therefore keyed kernel disk-cache entries on whichever tableau happened to build helpers last on a shared system object — the same logical kernel got different cache keys depending on build order:

```
dirk keyed on a fresh system:            130339a4…
dirk keyed after a radau build
on the same system:                      e6b84c03…
```

Under the precompiled-CI flow this is a silent miss machine: the CPU precompile lane populates entries under its per-worker build order, the GPU lane computes keys under its own xdist order, and every mismatch is a recompile on the GPU runner. Correctness was never at risk — the stale digest only over-discriminated (the algorithm config's hashed tableau already distinguishes kernels) — but a less-than-100% hit rate is a CI failure.

`eq=False` removes the field from `values_tuple`/`values_hash` only. Change detection in `_CubieConfigBase.update` compares attribute values directly (`CUDAFactory.py:225`), so a digest change still invalidates the `ODECache` and helpers regenerate on tableau switches, exactly as before (same mechanism that makes the `eq=False` `solver_function`/`predictor_function` piping invalidate step caches).

Pre-existing since #624; surfaced while verifying #656's precompile-lane behaviour.

## Validation (vs `origin/main` @ e553e94b)

- Kernel `config_hash` is now stable across a build (was `47bcbf91… → 47a803e8…` on main) and independent of build order (the two-key repro above collapses to one key).
- Tableau hot-swap control (`radau → firk_gauss_legendre_4 → radau` via `solver.update` on one solver): identical statuses on this branch and on pristine main, with the swapped GL4 solve clean — helper regeneration is unaffected.
- Full CUDASIM suite: 3044 passed, 0 failed.
- Full real-GPU suite: 3120 passed, 0 failed.
- ruff / blocking flake8 gate: pass.

### Performance gate

`python benchmarks/ab_gate.py` (quiet GPU, no DISTRUST rows):

| backend | config | kernel delta | wall delta | verdict |
|---|---|---:|---:|---|
| numba-cuda | fixed | -0.09% | -0.02% | ok |
| numba-cuda | adaptive | +0.05% | +0.32% | ok |
| numba-cuda | chunked | +0.00% | -0.29% | ok |
| numba-cuda | wave | +0.08% | +1.23% | ok |
| mlir | fixed | +0.02% | -0.23% | ok |
| mlir | adaptive | -0.19% | -1.13% | ok |
| mlir | chunked | -0.02% | -0.13% | ok |
| mlir | wave | -0.06% | -1.49% | ok |

GATE: PASS on both installed CUDA backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
