### PR TITLE
fix: FSAL predicate requires an explicit first stage; DIRK tableaus validate stage nodes

### DIFF
--- a/docs/source/API_reference/integrators/algorithms.rst
+++ b/docs/source/API_reference/integrators/algorithms.rst
@@ -79,8 +79,8 @@ same family.
      - 5(4)
      - PI: ``kp=0.7``, ``ki=-0.4``, gain clamp 0.2–10.0
    * - ``dirk``
-     - ``lobatto_iiic_3`` (diagonally implicit, three stages)
-     - 4
+     - ``l_stable_dirk_3`` (diagonally implicit, three stages)
+     - 3
      - Fixed step — the default tableau has no error estimate
    * - ``firk``
      - ``firk_gauss_legendre_2`` (fully implicit, two coupled

--- a/docs/source/API_reference/integrators/algorithms/generic_dirk_step.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_dirk_step.rst
@@ -13,9 +13,9 @@ adaptive error control through embedded weights.
 Defaults
 --------
 
-``algorithm="dirk"`` integrates with the ``lobatto_iiic_3`` tableau
-(L-stable Lobatto IIIC, three stages, order 4). That tableau has no
-embedded error estimate, so the default is fixed-step control;
+``algorithm="dirk"`` integrates with the ``l_stable_dirk_3`` tableau
+(L-stable, stiffly accurate, three stages, order 3). That tableau has
+no embedded error estimate, so the default is fixed-step control;
 choosing a DIRK tableau that provides an estimate enables the
 family's Gustafsson predictive defaults (step-size growth clamped
 to 0.2–8.0×). Each stage runs one Newton–Krylov

--- a/docs/source/API_reference/integrators/algorithms/generic_dirk_tableaus.rst
+++ b/docs/source/API_reference/integrators/algorithms/generic_dirk_tableaus.rst
@@ -6,15 +6,15 @@ DIRK tableau registry
 ``DIRK_TABLEAU_REGISTRY`` exposes diagonally implicit Runge--Kutta schemes as
 :class:`~cubie.integrators.algorithms.generic_dirk.DIRKTableau` instances.
 Aliases in the registry integrate with :func:`get_algorithm_step` so callers can
-select stiffly accurate SDIRK, ESDIRK, and Lobatto families without repeating
+select stiffly accurate SDIRK and ESDIRK families without repeating
 coefficients.
 
 .. autodata:: DIRK_TABLEAU_REGISTRY
     :annotation: Dict[str, DIRKTableau]
 
-The :class:`DIRKStep` factory defaults to ``"sdirk_2_2"``—Alexander's
-second-order, L-stable SDIRK pair—providing embedded error estimates for
-adaptive controllers.
+The :class:`DIRKStep` factory defaults to ``"l_stable_dirk_3"``—a
+three-stage, third-order L-stable, stiffly accurate DIRK scheme with no
+embedded error estimate, so the default runs fixed-step.
 
 Available aliases
 -----------------
@@ -31,9 +31,6 @@ Available aliases
    * - ``"trapezoidal_dirk"``
      - Two-stage trapezoidal (Crank--Nicolson) ESDIRK scheme.
      - [CrankNicolson1947]_
-   * - ``"lobatto_iiic_3"``
-     - Three-stage Lobatto IIIC method with stiff accuracy.
-     - [HairerLubichWanner2006]_
    * - ``"sdirk_2_2"``
      - Alexander's L-stable SDIRK pair with embedded error weights.
      - [Alexander1977]_
@@ -59,8 +56,6 @@ References
 .. [CrankNicolson1947] J. Crank and P. Nicolson. "A practical method for numerical
    solution of partial differential equations of the heat-conduction type."
    *Math. Proc. Camb. Phil. Soc.* 43(1), 1947.
-.. [HairerLubichWanner2006] E. Hairer, C. Lubich, and G. Wanner. *Geometric Numerical
-   Integration* (2nd ed.). Springer, 2006.
 .. [Alexander1977] R. Alexander. "Diagonally implicit Runge--Kutta methods for stiff
    ODEs." *SIAM J. Numer. Anal.* 14(6), 1977.
 .. [MOOSELStableDirk3] Idaho National Laboratory. "LStableDirk3 time integrator."

--- a/docs/source/user_guide/choosing_algorithms.rst
+++ b/docs/source/user_guide/choosing_algorithms.rst
@@ -31,7 +31,7 @@ Decision Guide
 
 The bare family names ``erk``, ``dirk``, ``firk``, and ``rosenbrock``
 are also accepted and select each family's default tableau
-(``dormand-prince-54``, ``lobatto_iiic_3``, ``firk_gauss_legendre_2``,
+(``dormand-prince-54``, ``l_stable_dirk_3``, ``firk_gauss_legendre_2``,
 and ``ros3p`` respectively).
 
 Adaptive or fixed?
@@ -124,11 +124,7 @@ Available Algorithms
    * - ``l_stable_dirk_3``
      - 3
      - No
-     - L-stable, 3 stages.
-   * - ``lobatto_iiic_3``
-     - 4
-     - No
-     - Default DIRK tableau; stiffly accurate.
+     - Default DIRK tableau; L-stable, stiffly accurate, 3 stages.
    * - ``l_stable_sdirk_4``
      - 4
      - Yes

--- a/docs/source/user_guide/optional_arguments.rst
+++ b/docs/source/user_guide/optional_arguments.rst
@@ -209,7 +209,7 @@ Choosing the method's coefficients
     defaults:
 
     - ERK: ``dormand-prince-54`` (adaptive)
-    - DIRK: ``lobatto_iiic_3`` (fixed-step)
+    - DIRK: ``l_stable_dirk_3`` (fixed-step)
     - FIRK: ``firk_gauss_legendre_2`` (fixed-step)
     - Rosenbrock-W: ``ros3p`` (adaptive)
 

--- a/src/cubie/integrators/algorithms/AGENTS.md
+++ b/src/cubie/integrators/algorithms/AGENTS.md
@@ -32,7 +32,7 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
 | `generic_erk.py` | `ERKStep` + `ERKStepConfig`: streamed-accumulator explicit RK; FSAL caching; controller auto-selected from `tableau.has_error_estimate`. |
 | `generic_erk_tableaus.py` | `ERKTableau` + ERK sets (Heun, Ralston, Bogacki-Shampine, Dormand-Prince 5(4)/8(5,3), RK4, Cash-Karp, Fehlberg, Tsit5, Vern7); `ERK_TABLEAU_REGISTRY`, `DEFAULT_ERK_TABLEAU`. |
 | `generic_dirk.py` | `DIRKStep` + `DIRKStepConfig`: diagonally-implicit RK, one Newton solve per implicit stage, stage-skipping for explicit stages, FSAL caching, dense-predictor warm starts. |
-| `generic_dirk_tableaus.py` | `DIRKTableau` (adds `diagonal()`) + tableaus (implicit midpoint, trapezoidal/ESDIRK, Lobatto IIIC-3 default, SDIRK_2_2, L-stable DIRK3/SDIRK4). |
+| `generic_dirk_tableaus.py` | `DIRKTableau` (adds `diagonal()`, validates `c[i] == sum(a[i])`) + tableaus (implicit midpoint, trapezoidal/ESDIRK, Kvaerno 3/5, SDIRK_2_2, L-stable DIRK3 default, L-stable SDIRK4). |
 | `generic_firk.py` | `FIRKStep` + `FIRKStepConfig`: fully-implicit RK; all stages as one coupled `n*stages` Newton system; dense-predictor warm starts; Kahan-summed output accumulation. |
 | `generic_firk_tableaus.py` | `FIRKTableau` + Gauss-Legendre-2 (default) and Radau IIA-5; `compute_embedded_weights_radauIIA`. |
 | `generic_rosenbrock_w.py` | `GenericRosenbrockWStep` + `RosenbrockWStepConfig`: linearly-implicit Rosenbrock-W using a cached Jacobian and a **linear** (not Newton) solve per stage; needs `driver_del_t` and time-derivative helpers. |

--- a/src/cubie/integrators/algorithms/base_algorithm_step.py
+++ b/src/cubie/integrators/algorithms/base_algorithm_step.py
@@ -264,6 +264,27 @@ class ButcherTableau(_CubieConfigBase):
         if abs(1.0 - np_sum(self.b)) > 1e-8:
             raise ValueError("b must sum to one")
 
+    def _validate_stage_node_consistency(self) -> None:
+        """Validate that every stage node matches its ``A`` row sum.
+
+        Runge--Kutta stage equations evaluate stage ``i`` at the state
+        implied by row ``i`` of ``A``, so ``c[i]`` must equal
+        ``sum(a[i])`` for the stage times and stage states to describe
+        the same point. Predicates that infer stage meaning from ``c``
+        (such as first-same-as-last detection) rely on this relation.
+        Rosenbrock-W tableaus obey a different consistency condition
+        and do not use this check.
+        """
+        for stage_index in range(self.stage_count):
+            row = self.a[stage_index]
+            node = self.c[stage_index]
+            if abs(node - np_sum(row)) > 1e-8:
+                raise ValueError(
+                    f"Stage {stage_index} node c={node} does not equal "
+                    f"its A row sum {np_sum(row)}; the stage time and "
+                    "stage state disagree."
+                )
+
     @property
     def d(self) -> Optional[Tuple[float, ...]]:
         """Return coefficients for embedded error estimation."""
@@ -375,18 +396,32 @@ class ButcherTableau(_CubieConfigBase):
 
     @property
     def first_same_as_last(self) -> bool:
-        """Return ``True`` when the first and last stages align."""
+        """Return ``True`` when the first and last stages align.
+
+        Stage-0 RHS reuse requires the first stage to evaluate at the
+        step-start state itself: ``c[0] == 0`` with an all-zero first
+        ``A`` row (an explicit first stage). A tableau whose first
+        stage is implicit evaluates a different state even when its
+        node sits at the step start, so ``c[0]`` alone is not enough.
+        """
 
         return bool(
             self.c
             and self.c[0] == 0.0
             and self.c[-1] == 1.0
             and self.a[-1] == self.b
+            and not any(self.a[0])
         )
 
     @property
     def can_reuse_accepted_start(self) -> bool:
-        """Return ``True`` when an accepted step can reuse the start state."""
+        """Return ``True`` when stage 0 evaluates at the step-start time.
+
+        Licenses reuse of quantities that depend only on the stage
+        time, such as driver values sampled at the step start;
+        state-dependent reuse additionally needs
+        :attr:`first_same_as_last`.
+        """
 
         return bool(self.c and (self.c[0] == 0.0))
 

--- a/src/cubie/integrators/algorithms/generic_dirk_tableaus.py
+++ b/src/cubie/integrators/algorithms/generic_dirk_tableaus.py
@@ -20,9 +20,6 @@ Constants
 :data:`KVAERNO5_TABLEAU`
     Seven-stage, fifth-order A-L stable stiffly accurate ESDIRK method.
 
-:data:`LOBATTO_IIIC_3_TABLEAU`
-    Three-stage, fourth-order Lobatto IIIC scheme.
-
 :data:`SDIRK_2_2_TABLEAU`
     Two-stage, second-order L-stable SDIRK by Alexander.
 
@@ -36,7 +33,7 @@ Constants
     Name → tableau mapping for alias-based lookup.
 
 :data:`DEFAULT_DIRK_TABLEAU`
-    Default tableau (Lobatto IIIC 3-stage).
+    Default tableau (three-stage L-stable DIRK).
 
 See Also
 --------
@@ -76,9 +73,10 @@ class DIRKTableau(ButcherTableau):
     """
 
     def __attrs_post_init__(self) -> None:
-        """Validate structure and Runge--Kutta weight sums."""
+        """Validate structure, weight sums, and stage-node consistency."""
         super().__attrs_post_init__()
         self._validate_weight_sums()
+        self._validate_stage_node_consistency()
 
     def diagonal(self, precision: type) -> Tuple[float, ...]:
         """Return the diagonal entries of the tableau."""
@@ -267,29 +265,6 @@ with an explicit first stage. *BIT Numerical Mathematics*, 44,
 489--502.
 """
 
-LOBATTO_IIIC_3_TABLEAU = DIRKTableau(
-    a=(
-        (1.0 / 6.0, 0.0, 0.0),
-        (2.0 / 3.0, 1.0 / 6.0, 0.0),
-        (1.0 / 6.0, 2.0 / 3.0, 1.0 / 6.0),
-    ),
-    b=(1.0 / 6.0, 2.0 / 3.0, 1.0 / 6.0),
-    c=(0.0, 0.5, 1.0),
-    order=4,
-)
-"""Three-stage Lobatto IIIC DIRK tableau of order four.
-
-All stages share the same diagonal coefficient, so the tableau may be
-solved sequentially without resorting to coupled implicit systems. The
-method is symplectic and stiffly accurate, making it attractive for high
-accuracy integrations.
-
-References
-----------
-Hairer, E., Lubich, C., & Wanner, G. (2006). *Geometric Numerical
-Integration* (2nd ed.). Springer.
-"""
-
 SQRT2 = 2**0.5
 SDIRK2_GAMMA = (2 - SQRT2) / 2.0
 SDIRK_2_2_TABLEAU = DIRKTableau(
@@ -425,12 +400,11 @@ DIRK_TABLEAU_REGISTRY: Dict[str, DIRKTableau] = {
     "ode23t": TRAPEZOIDAL_DIRK_TABLEAU,
     "kvaerno3": KVAERNO3_TABLEAU,
     "kvaerno5": KVAERNO5_TABLEAU,
-    "lobatto_iiic_3": LOBATTO_IIIC_3_TABLEAU,
     "sdirk_2_2": SDIRK_2_2_TABLEAU,
     "l_stable_dirk_3": L_STABLE_DIRK3_TABLEAU,
     "l_stable_sdirk_4": L_STABLE_SDIRK4_TABLEAU,
 }
 """Registry of named DIRK tableaus available to the integrator."""
 
-DEFAULT_DIRK_TABLEAU_NAME = "lobatto_iiic_3"
+DEFAULT_DIRK_TABLEAU_NAME = "l_stable_dirk_3"
 DEFAULT_DIRK_TABLEAU = DIRK_TABLEAU_REGISTRY[DEFAULT_DIRK_TABLEAU_NAME]

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -134,11 +134,6 @@ STEP_CASES = [
         marks=pytest.mark.specific_algos,
     ),
     pytest.param(
-        {"algorithm": "lobatto_iiic_3", "step_controller": "fixed"},
-        id="dirk-lobatto-iiic-3",
-        marks=pytest.mark.specific_algos,
-    ),
-    pytest.param(
         {"algorithm": "l_stable_dirk_3", "step_controller": "fixed"},
         id="dirk-l-stable-3",
         marks=pytest.mark.specific_algos,

--- a/tests/integrators/algorithms/test_dirk_tableaus.py
+++ b/tests/integrators/algorithms/test_dirk_tableaus.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from cubie.integrators.algorithms.base_algorithm_step import ButcherTableau
 from cubie.integrators.algorithms.generic_dirk import DIRKStep
 from cubie.integrators.algorithms.generic_dirk_tableaus import (
     DEFAULT_DIRK_TABLEAU,
@@ -19,10 +20,11 @@ from cubie.integrators.algorithms.generic_dirk_tableaus import (
     [
         "implicit_midpoint",
         "trapezoidal_dirk",
-        "lobatto_iiic_3",
         "sdirk_2_2",
         "kvaerno3",
         "kvaerno5",
+        "l_stable_dirk_3",
+        "l_stable_sdirk_4",
     ],
 )
 def test_dirk_tableau_registry_contains_expected_entries(expected_key):
@@ -49,10 +51,56 @@ def test_l_stable_sdirk4_fourth_stage_is_consistent():
 def test_dirk_step_accepts_tableau_instance(precision):
     """DIRKStep should consume explicit tableau instances."""
 
-    custom_name = "lobatto_iiic_3"
+    custom_name = "sdirk_2_2"
     custom_tableau = DIRK_TABLEAU_REGISTRY[custom_name]
     step = DIRKStep(precision=precision, n=2, tableau=custom_tableau)
     assert step.compile_settings.tableau is custom_tableau
+
+
+def test_dirk_tableau_rejects_inconsistent_stage_nodes():
+    """A ``c`` entry that disagrees with its ``A`` row sum must raise.
+
+    The coefficients are the former ``lobatto_iiic_3`` tableau, whose
+    first two stage nodes disagreed with their ``A`` row sums.
+    """
+
+    with pytest.raises(ValueError, match="row sum"):
+        DIRKTableau(
+            a=(
+                (1.0 / 6.0, 0.0, 0.0),
+                (2.0 / 3.0, 1.0 / 6.0, 0.0),
+                (1.0 / 6.0, 2.0 / 3.0, 1.0 / 6.0),
+            ),
+            b=(1.0 / 6.0, 2.0 / 3.0, 1.0 / 6.0),
+            c=(0.0, 0.5, 1.0),
+            order=4,
+        )
+
+
+def test_fsal_requires_explicit_first_stage():
+    """An implicit first stage disqualifies stage-0 RHS reuse even
+    when ``c[0] == 0``, ``c[-1] == 1``, and the last row equals ``b``."""
+
+    implicit_first = ButcherTableau(
+        a=(
+            (1.0 / 6.0, 0.0, 0.0),
+            (2.0 / 3.0, 1.0 / 6.0, 0.0),
+            (1.0 / 6.0, 2.0 / 3.0, 1.0 / 6.0),
+        ),
+        b=(1.0 / 6.0, 2.0 / 3.0, 1.0 / 6.0),
+        c=(0.0, 0.5, 1.0),
+        order=4,
+    )
+    assert not implicit_first.first_same_as_last
+    assert implicit_first.can_reuse_accepted_start
+
+
+def test_fsal_true_for_stiffly_accurate_esdirk():
+    """ESDIRK tableaus with an explicit first stage keep FSAL reuse."""
+
+    assert KVAERNO3_TABLEAU.first_same_as_last
+    assert DIRK_TABLEAU_REGISTRY["trapezoidal_dirk"].first_same_as_last
+    assert not DEFAULT_DIRK_TABLEAU.first_same_as_last
 
 
 @pytest.mark.parametrize(

--- a/tests/integrators/algorithms/test_step_algorithms.py
+++ b/tests/integrators/algorithms/test_step_algorithms.py
@@ -234,14 +234,6 @@ ALIAS_CASES = [
         id="dirk-sdirk-2-2",
     ),
     pytest.param(
-        "lobatto_iiic_3",
-        DIRKStep,
-        DIRK_TABLEAU_REGISTRY["lobatto_iiic_3"],
-        CPUDIRKStep,
-        marks=pytest.mark.specific_algos,
-        id="dirk-lobatto-iiic-3",
-    ),
-    pytest.param(
         "l_stable_dirk_3",
         DIRKStep,
         DIRK_TABLEAU_REGISTRY["l_stable_dirk_3"],

--- a/tests/integrators/test_stage_predictors.py
+++ b/tests/integrators/test_stage_predictors.py
@@ -79,7 +79,6 @@ DIRK_SUPPORT_EXPECTATIONS = {
     "ode23t": True,
     "kvaerno3": False,
     "kvaerno5": False,
-    "lobatto_iiic_3": True,
     "sdirk_2_2": True,
     "l_stable_dirk_3": True,
     "l_stable_sdirk_4": True,
@@ -104,7 +103,7 @@ def test_registry_tableaus_support_expectations():
     "tableau",
     [
         DIRK_TABLEAU_REGISTRY["l_stable_dirk_3"],
-        DIRK_TABLEAU_REGISTRY["lobatto_iiic_3"],
+        DIRK_TABLEAU_REGISTRY["sdirk_2_2"],
         RADAU_IIA_5_TABLEAU,
     ],
 )
@@ -158,7 +157,7 @@ def test_dense_predictor_extrapolates_stage_curve(tableau, step_ratio):
         DEFAULT_FIRK_TABLEAU,
         RADAU_IIA_5_TABLEAU,
         DIRK_TABLEAU_REGISTRY["l_stable_dirk_3"],
-        DIRK_TABLEAU_REGISTRY["lobatto_iiic_3"],
+        DIRK_TABLEAU_REGISTRY["sdirk_2_2"],
     ],
 )
 @pytest.mark.parametrize("step_ratio", [0.65, 1.3])


### PR DESCRIPTION
## Summary

Closes #663.

`ButcherTableau.first_same_as_last` inferred stage-0 meaning from `c[0] == 0` alone, and `DIRKTableau` never validated the Runge–Kutta consistency relation `c_i == sum_j A_ij`. The default `lobatto_iiic_3` tableau exposed both gaps.

### Audit of `lobatto_iiic_3` — not textbook-correct

The genuine three-stage Lobatto IIIC method (Hairer & Wanner, *Solving Ordinary Differential Equations II*, 2nd ed., Table 5.11) is **fully implicit**:

```
c = (0, 1/2, 1)
A = [[1/6, -1/3,  1/6 ],
     [1/6, 5/12, -1/12],
     [1/6, 2/3,   1/6 ]]
b = (1/6, 2/3, 1/6)          order 4, L-stable, stiffly accurate
```

It cannot be expressed as a DIRK. The registered lower-triangular coefficients (`src/cubie/integrators/algorithms/generic_dirk_tableaus.py:270` before this change) violated the stage-node relation on stages 0 and 1 — row sums 1/6 and 5/6 against nodes 0 and 1/2 — so the stage times and stage states described different points. In autonomous form the effective nodes are the row sums, under which the order-2 condition already fails (`b·c_eff = 1/6·1/6 + 2/3·5/6 + 1/6·1 = 3/4 ≠ 1/2`): the method was effectively order 1, not 4, and its implicit first stage made the FSAL stage-0 RHS reuse invalid. Since the new validation would have caught it (and does — the removal regression test constructs exactly these coefficients), the tableau is removed rather than kept: there is no textbook DIRK with these coefficients, and rebinding the name to the true fully-implicit method would silently change method families.

## Changes

- `ButcherTableau.first_same_as_last` additionally requires an all-zero first `A` row (explicit first stage). Stage-0 RHS reuse is only valid when stage 0 evaluates the step-start state itself; `c[0] == 0` alone does not guarantee that. ESDIRK tableaus (trapezoidal, kvaerno3/5) and FSAL ERK tableaus keep their eligibility.
- `ButcherTableau._validate_stage_node_consistency` validates `c[i] == sum(a[i])` (tolerance 1e-8, matching the existing weight-sum check); `DIRKTableau.__attrs_post_init__` calls it. All remaining registry tableaus pass.
- `can_reuse_accepted_start` is unchanged (in `DIRKStep` it only licenses reusing step-start *driver* values — a time-only decision correct with `c[0] == 0`); its docstring now states exactly what it licenses.
- `lobatto_iiic_3` removed from the DIRK registry; `DEFAULT_DIRK_TABLEAU_NAME` is `l_stable_dirk_3` (closest honest drop-in: three stages, L-stable, stiffly accurate, errorless → stays fixed-step, matching the previous default's documented behaviour). Docs and tests updated accordingly.
- Regression tests: inconsistent `A`/`c` input raises; FSAL predicate rejects an implicit first stage even when `c[0] == 0`, `c[-1] == 1`, and `a[-1] == b`; stiffly accurate ESDIRKs remain FSAL.

## Test evidence

All run in this branch's worktree against the shared venv:

- CUDASIM (`NUMBA_ENABLE_CUDASIM=1 pytest -m "not nocudasim and not cupy and not specific_algos"`): **3047 passed**.
- Real GPU (`pytest -m "not specific_algos and not sim_only"`): **3123 passed**.
- DIRK-relevant `specific_algos` GPU tests (`test_step_algorithms.py` both dirs, `-k "dirk or kvaerno or midpoint or sdirk or trapezoidal or ode23t"`): **43 passed**.

## Performance gate

`python benchmarks/ab_gate.py` — A = origin/main (e553e94b), B = this branch, 4 block pairs × 15 solves/block/side:

```
numba-cuda fixed     kernel  A    62.219  B    62.137   -0.10%  ok
numba-cuda fixed     wall    A    77.168  B    76.779   -0.02%  ok
numba-cuda adaptive  kernel  A    17.936  B    17.915   -0.18%  ok
numba-cuda adaptive  wall    A    23.026  B    22.944   -0.37%  ok
numba-cuda chunked   kernel  A    62.567  B    62.596   +0.01%  ok
numba-cuda chunked   wall    A    79.012  B    81.899   +3.90%  ok
numba-cuda wave      kernel  A    25.788  B    25.757   -0.05%  ok
numba-cuda wave      wall    A    29.173  B    28.898   -1.09%  ok
mlir       fixed     kernel  A    62.192  B    62.513   +0.07%  ok
mlir       fixed     wall    A    76.608  B    77.199   +0.40%  ok
mlir       adaptive  kernel  A    17.522  B    17.530   +0.06%  ok
mlir       adaptive  wall    A    22.441  B    22.752   +1.67%  ok
mlir       chunked   kernel  A    62.552  B    62.565   +0.05%  ok
mlir       chunked   wall    A    79.042  B    79.274   +0.15%  ok
mlir       wave      kernel  A    25.754  B    25.741   +0.03%  ok
mlir       wave      wall    A    28.726  B    28.997   +1.11%  ok

GATE: PASS (kernel threshold 0.50%, wall threshold 10.00%)
```

(The gate's benchmark configs pin their own algorithms, so the DIRK default change does not enter the comparison.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
