### PR TITLE
fix: preserve controller history across rejected steps

### DIFF
--- a/src/cubie/integrators/step_control/adaptive_PID_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_PID_controller.py
@@ -176,7 +176,6 @@ class AdaptivePIDController(BaseAdaptiveStepController):
         step_too_small = int32(CUBIE_RESULT_CODES.STEP_TOO_SMALL)
         # step sizes and norms can be approximate - fastmath is fine
         # no cover: start
-
         @cuda.jit(
             device=True,
             inline=True,
@@ -266,14 +265,14 @@ class AdaptivePIDController(BaseAdaptiveStepController):
             gain = selp(accept, gain, min(gain, safety))
 
             # A truncated step's error norm carries no step-size
-            # info: on accept, freeze dt/history and report success.
+            # info: on accept, freeze dt and report success. History
+            # commits only after ordinary accepted steps, so rejected
+            # or truncated attempts never overwrite it.
             freeze = accept and truncated
             commit_history = accept and not truncated
             dt_new_raw = dt[0] * gain
             dt[0] = selp(freeze, dt[0], clamp(dt_new_raw, dt_min, dt_max))
-            timestep_buffer[1] = selp(
-                commit_history, err_prev, err_prev_prev
-            )
+            timestep_buffer[1] = selp(commit_history, err_prev, err_prev_prev)
             timestep_buffer[0] = selp(commit_history, nrm2, err_prev)
 
             ret = (

--- a/src/cubie/integrators/step_control/adaptive_PID_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_PID_controller.py
@@ -176,6 +176,7 @@ class AdaptivePIDController(BaseAdaptiveStepController):
         step_too_small = int32(CUBIE_RESULT_CODES.STEP_TOO_SMALL)
         # step sizes and norms can be approximate - fastmath is fine
         # no cover: start
+
         @cuda.jit(
             device=True,
             inline=True,
@@ -267,10 +268,13 @@ class AdaptivePIDController(BaseAdaptiveStepController):
             # A truncated step's error norm carries no step-size
             # info: on accept, freeze dt/history and report success.
             freeze = accept and truncated
+            commit_history = accept and not truncated
             dt_new_raw = dt[0] * gain
             dt[0] = selp(freeze, dt[0], clamp(dt_new_raw, dt_min, dt_max))
-            timestep_buffer[1] = selp(freeze, err_prev_prev, err_prev)
-            timestep_buffer[0] = selp(freeze, err_prev, nrm2)
+            timestep_buffer[1] = selp(
+                commit_history, err_prev, err_prev_prev
+            )
+            timestep_buffer[0] = selp(commit_history, nrm2, err_prev)
 
             ret = (
                 success

--- a/src/cubie/integrators/step_control/adaptive_PI_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_PI_controller.py
@@ -253,9 +253,10 @@ class AdaptivePIController(BaseAdaptiveStepController):
             # A truncated step's error norm carries no step-size
             # info: on accept, freeze dt/history and report success.
             freeze = accept and truncated
+            commit_history = accept and not truncated
             dt_new_raw = dt[0] * gain
             dt[0] = selp(freeze, dt[0], clamp(dt_new_raw, dt_min, dt_max))
-            timestep_buffer[0] = selp(freeze, err_prev, nrm2)
+            timestep_buffer[0] = selp(commit_history, nrm2, err_prev)
 
             ret = (
                 success

--- a/src/cubie/integrators/step_control/adaptive_PI_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_PI_controller.py
@@ -251,7 +251,9 @@ class AdaptivePIController(BaseAdaptiveStepController):
             gain = selp(accept, gain, min(gain, safety))
 
             # A truncated step's error norm carries no step-size
-            # info: on accept, freeze dt/history and report success.
+            # info: on accept, freeze dt and report success. History
+            # commits only after ordinary accepted steps, so rejected
+            # or truncated attempts never overwrite it.
             freeze = accept and truncated
             commit_history = accept and not truncated
             dt_new_raw = dt[0] * gain

--- a/src/cubie/integrators/step_control/gustafsson_controller.py
+++ b/src/cubie/integrators/step_control/gustafsson_controller.py
@@ -263,13 +263,16 @@ class GustafssonController(BaseAdaptiveStepController):
             # A truncated step's error norm carries no step-size
             # info: on accept, freeze dt/history and report success.
             freeze = accept and truncated
+            commit_history = accept and not truncated
             dt_new_raw = current_dt * gain
             dt[0] = selp(freeze, current_dt, clamp(dt_new_raw, dt_min, dt_max))
 
             timestep_buffer[0] = selp(
-                freeze, timestep_buffer[0], current_dt
+                commit_history, current_dt, timestep_buffer[0]
             )
-            timestep_buffer[1] = selp(freeze, timestep_buffer[1], nrm2)
+            timestep_buffer[1] = selp(
+                commit_history, nrm2, timestep_buffer[1]
+            )
 
             ret = (
                 success

--- a/src/cubie/integrators/step_control/gustafsson_controller.py
+++ b/src/cubie/integrators/step_control/gustafsson_controller.py
@@ -261,7 +261,9 @@ class GustafssonController(BaseAdaptiveStepController):
             gain = selp(accept, gain, min(gain, safety))
 
             # A truncated step's error norm carries no step-size
-            # info: on accept, freeze dt/history and report success.
+            # info: on accept, freeze dt and report success. History
+            # commits only after ordinary accepted steps, so rejected
+            # or truncated attempts never overwrite it.
             freeze = accept and truncated
             commit_history = accept and not truncated
             dt_new_raw = current_dt * gain

--- a/tests/integrated_numerical_tests/test_step_controllers.py
+++ b/tests/integrated_numerical_tests/test_step_controllers.py
@@ -94,12 +94,11 @@ def cpu_step_results(cpu_step_controller, precision, step_setup):
         error_vector=error_vec,
         niters=1,
     )
-    errornorm = controller.error_norm(state_prev, state, error_vec)
 
     if kind == 'i':
         out_local = np.zeros(0, dtype=precision)
     elif kind == 'pi':
-        out_local = np.array([errornorm], dtype=precision)
+        out_local = np.array([controller._prev_nrm2], dtype=precision)
     elif kind == 'pid':
         out_local = np.array([
             controller._prev_nrm2,
@@ -108,7 +107,7 @@ def cpu_step_results(cpu_step_controller, precision, step_setup):
     elif kind == 'gustafsson':
         out_local = np.array([
             controller._prev_dt,
-            errornorm,
+            controller._prev_nrm2,
         ], dtype=precision)
     else:
         out_local = np.zeros(0, dtype=precision)

--- a/tests/integrators/cpu_reference/step_controllers.py
+++ b/tests/integrators/cpu_reference/step_controllers.py
@@ -127,9 +127,10 @@ class CPUAdaptiveController:
         unclamped_dt = self.precision(current_dt * gain)
         new_dt = min(self.dt_max, max(self.dt_min, unclamped_dt))
         self.dt = new_dt
-        self._prev_dt = current_dt
-        self._prev_prev_nrm2 = self._prev_nrm2
-        self._prev_nrm2 = errornorm
+        if accept:
+            self._prev_dt = current_dt
+            self._prev_prev_nrm2 = self._prev_nrm2
+            self._prev_nrm2 = errornorm
 
         return accept
 

--- a/tests/integrators/step_control/test_controllers.py
+++ b/tests/integrators/step_control/test_controllers.py
@@ -4,6 +4,15 @@ import numpy as np
 import pytest
 from cubie.cuda_simsafe import cuda
 
+from cubie.integrators.step_control.adaptive_PI_controller import (
+    AdaptivePIController,
+)
+from cubie.integrators.step_control.adaptive_PID_controller import (
+    AdaptivePIDController,
+)
+from cubie.integrators.step_control.gustafsson_controller import (
+    GustafssonController,
+)
 from cubie.result_codes import CUBIE_RESULT_CODES
 from tests._utils import run_controller_device_step
 
@@ -11,6 +20,11 @@ from tests._utils import run_controller_device_step
 _CONTROLLER_SETTINGS = {
     controller: {"step_controller": controller, "atol": 1e-3, "rtol": 0.0}
     for controller in ("i", "pi", "pid", "gustafsson")
+}
+
+_HISTORY_CONTROLLER_SETTINGS = {
+    controller: _CONTROLLER_SETTINGS[controller]
+    for controller in ("pi", "pid", "gustafsson")
 }
 
 _DT_CLAMP_LIMITS = {"dt": 0.15, "dt_min": 0.1, "dt_max": 0.2}
@@ -87,12 +101,7 @@ class TestControllers:
     def test_rejected_step_never_grows_dt(
         self, step_controller, precision, system
     ):
-        """A rejected step shrinks dt despite a huge stored error history.
-
-        The error history from a failed step (the loop stores 1e16 on
-        solver failure) feeds the PI/PID history term on the next call;
-        the gain on a rejected step must stay below one regardless.
-        """
+        """A rejected step shrinks dt after a solver failure."""
         device_func = step_controller.device_function
         n = system.sizes.states
 
@@ -118,8 +127,7 @@ class TestControllers:
                      accept, shared_scratch, persistent_local)
         assert int(accept[0]) == 0
 
-        # Second step: moderate rejection (nrm2 just above one). The
-        # stored history from the failed step must not grow dt.
+        # Second step: moderate rejection (nrm2 just above one).
         dt_before = precision(0.017)
         dt[0] = dt_before
         moderate_error = np.full(n, 1.23e-3, dtype=precision)
@@ -213,3 +221,75 @@ class TestControllers:
         assert result.accepted == 1
         assert result.dt == dt_min
         assert result.status == int(CUBIE_RESULT_CODES.SUCCESS)
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    list(_HISTORY_CONTROLLER_SETTINGS.values()),
+    ids=list(_HISTORY_CONTROLLER_SETTINGS),
+    indirect=True,
+)
+class TestControllerHistory:
+    @pytest.mark.parametrize(
+        "accepted, truncated",
+        (
+            (False, False),
+            (False, True),
+            (True, False),
+            (True, True),
+        ),
+        ids=(
+            "rejection",
+            "truncated-rejection",
+            "acceptance",
+            "truncated-acceptance",
+        ),
+    )
+    def test_history_commits_only_untruncated_acceptance(
+        self,
+        step_controller,
+        precision,
+        system,
+        accepted,
+        truncated,
+    ):
+        """History advances only after an ordinary accepted step."""
+        controller_names = {
+            AdaptivePIController: "pi",
+            AdaptivePIDController: "pid",
+            GustafssonController: "gustafsson",
+        }
+        controller_name = controller_names[type(step_controller)]
+        seeds = {
+            "pi": np.asarray([0.25], dtype=precision),
+            "pid": np.asarray([0.25, 0.5], dtype=precision),
+            "gustafsson": np.asarray([0.0125, 0.25], dtype=precision),
+        }
+        accepted_history = {
+            "pi": np.asarray([1.0], dtype=precision),
+            "pid": np.asarray([1.0, 0.25], dtype=precision),
+            "gustafsson": np.asarray([0.017, 1.0], dtype=precision),
+        }
+        error_value = 1e-3 if accepted else 2e-3
+        error = np.full(system.sizes.states, error_value, dtype=precision)
+        state = np.ones(system.sizes.states, dtype=precision)
+        seed = seeds[controller_name]
+
+        result = run_controller_device_step(
+            step_controller.device_function,
+            precision,
+            precision(0.017),
+            error,
+            local_mem=seed.copy(),
+            state=state,
+            state_prev=state,
+            truncated=truncated,
+        )
+
+        assert result.accepted == int(accepted)
+        expected = (
+            accepted_history[controller_name]
+            if accepted and not truncated
+            else seed
+        )
+        np.testing.assert_array_equal(result.local_mem, expected)

--- a/tests/integrators/step_control/test_controllers.py
+++ b/tests/integrators/step_control/test_controllers.py
@@ -4,15 +4,6 @@ import numpy as np
 import pytest
 from cubie.cuda_simsafe import cuda
 
-from cubie.integrators.step_control.adaptive_PI_controller import (
-    AdaptivePIController,
-)
-from cubie.integrators.step_control.adaptive_PID_controller import (
-    AdaptivePIDController,
-)
-from cubie.integrators.step_control.gustafsson_controller import (
-    GustafssonController,
-)
 from cubie.result_codes import CUBIE_RESULT_CODES
 from tests._utils import run_controller_device_step
 
@@ -248,27 +239,27 @@ class TestControllerHistory:
     def test_history_commits_only_untruncated_acceptance(
         self,
         step_controller,
+        step_controller_settings,
         precision,
         system,
         accepted,
         truncated,
     ):
         """History advances only after an ordinary accepted step."""
-        controller_names = {
-            AdaptivePIController: "pi",
-            AdaptivePIDController: "pid",
-            GustafssonController: "gustafsson",
-        }
-        controller_name = controller_names[type(step_controller)]
+        controller_name = step_controller_settings["step_controller"]
+        dt0 = precision(0.017)
         seeds = {
             "pi": np.asarray([0.25], dtype=precision),
             "pid": np.asarray([0.25, 0.5], dtype=precision),
             "gustafsson": np.asarray([0.0125, 0.25], dtype=precision),
         }
+        # The accepted error equals atol with rtol zero, so the
+        # committed norm is exactly one and history slots either take
+        # these values verbatim or stay bit-identical to the seed.
         accepted_history = {
             "pi": np.asarray([1.0], dtype=precision),
             "pid": np.asarray([1.0, 0.25], dtype=precision),
-            "gustafsson": np.asarray([0.017, 1.0], dtype=precision),
+            "gustafsson": np.asarray([dt0, 1.0], dtype=precision),
         }
         error_value = 1e-3 if accepted else 2e-3
         error = np.full(system.sizes.states, error_value, dtype=precision)
@@ -278,7 +269,7 @@ class TestControllerHistory:
         result = run_controller_device_step(
             step_controller.device_function,
             precision,
-            precision(0.017),
+            dt0,
             error,
             local_mem=seed.copy(),
             state=state,


### PR DESCRIPTION
## Summary

- preserve PI, PID, and Gustafsson controller history across rejected attempts
- advance history only after accepted, non-truncated steps
- align the CPU reference with the device recurrence
- add seeded-history coverage for ordinary/truncated rejection and acceptance

## Root cause

The stateful controllers used `freeze = accept and truncated` as the sole
history-preservation condition. Every non-frozen attempt therefore committed
its error norm (and, for Gustafsson, its step size), including rejected
attempts. Subsequent proposals consumed rejected candidate data instead of the
previous accepted-step history.

The device controllers now use
`commit_history = accept and not truncated`. The memoryless I controller is
unchanged.

## Validation

- real GPU, MLIR backend, CUDASIM disabled: `81 passed`
- independent verifier: PASS
- `ruff check`: passed
- blocking `flake8 . --select=E9,F63,F7,F82 --show-source`: passed
- `git diff --check`: passed

## Performance gate

Compile metrics were identical on both sides for registers, spills, shared
memory, occupancy, launch geometry, run counts, and chunk counts.

Authoritative trusted rows from the stable full MLIR run and the final isolated
numba-cuda rerun:

| backend | config | kernel delta | kernel verdict | wall delta | wall verdict |
|---|---|---:|---|---:|---|
| numba-cuda | fixed | -1.26% | improvement | -1.39% | ok |
| numba-cuda | adaptive | +0.23% | ok | -0.10% | ok |
| numba-cuda | chunked | -0.83% | improvement | -1.29% | ok |
| numba-cuda | wave | -0.52% | improvement | -2.09% | ok |
| mlir | fixed | -0.08% | ok | +0.37% | ok |
| mlir | adaptive | -0.22% | ok | -2.17% | ok |
| mlir | chunked | +0.20% | ok | -0.61% | ok |
| mlir | wave | +0.15% | ok | +1.42% | ok |

Thresholds: kernel 0.50%, wall 10.00%.

An eight-pair A-vs-A MLIR calibration measured kernel null medians of -0.04%,
-0.10%, -0.09%, and -0.04% for fixed, adaptive, chunked, and wave respectively.
Windows worker processes were explicitly reaped between authoritative backend
runs.
