### PR TITLE
fix: tighten direct Rosenbrock Krylov defaults

### DIFF
--- a/src/cubie/integrators/SingleIntegratorRunCore.py
+++ b/src/cubie/integrators/SingleIntegratorRunCore.py
@@ -350,11 +350,11 @@ class SingleIntegratorRunCore(CUDAFactory):
         controller's ``atol``/``rtol`` directly: they weight the
         linear stopping norm, placing its absolute floor at the step
         tolerance envelope.  Unset ``krylov_residual_reduction``
-        defaults to the adaptive controller's ``rtol`` (its tightest
-        entry), so each linear solve reduces its residual by the same
-        relative tolerance the controller enforces on steps; for
-        non-adaptive runs it defaults to machine epsilon, leaving the
-        floor governing.  Values the user set explicitly (tracked in
+        defaults to the adaptive controller's tightest ``rtol`` entry
+        for Newton-owned solves, and one hundredth of that entry for
+        direct Rosenbrock solves.  For non-adaptive or pure-absolute
+        runs it defaults to machine epsilon, leaving the floor
+        governing.  Values the user set explicitly (tracked in
         ``_user_given_inner_tols``) are preserved.  The solver norms'
         tolerance converter broadcasts uniform arrays to their own
         vector length; a non-uniform per-state vector must match the
@@ -386,6 +386,8 @@ class SingleIntegratorRunCore(CUDAFactory):
         # the floor governing.
         controller_rtol_floor = float(controller_rtol.min())
         if self._step_controller.is_adaptive and controller_rtol_floor > 0.0:
+            if self._algo_step.linear_solver_is_direct:
+                controller_rtol_floor *= 0.01
             derived_source["krylov_residual_reduction"] = (
                 controller_rtol_floor
             )

--- a/src/cubie/integrators/SingleIntegratorRunCore.py
+++ b/src/cubie/integrators/SingleIntegratorRunCore.py
@@ -350,11 +350,10 @@ class SingleIntegratorRunCore(CUDAFactory):
         controller's ``atol``/``rtol`` directly: they weight the
         linear stopping norm, placing its absolute floor at the step
         tolerance envelope.  Unset ``krylov_residual_reduction``
-        defaults to the adaptive controller's tightest ``rtol`` entry
-        for Newton-owned solves, and one hundredth of that entry for
-        direct Rosenbrock solves.  For non-adaptive or pure-absolute
-        runs it defaults to machine epsilon, leaving the floor
-        governing.  Values the user set explicitly (tracked in
+        defaults to the adaptive controller's tightest ``rtol`` entry,
+        divided by one hundred for linearly-implicit (``is_linear``)
+        steps; non-adaptive runs default to machine epsilon, leaving
+        the floor governing.  Values the user set explicitly (tracked in
         ``_user_given_inner_tols``) are preserved.  The solver norms'
         tolerance converter broadcasts uniform arrays to their own
         vector length; a non-uniform per-state vector must match the
@@ -386,7 +385,7 @@ class SingleIntegratorRunCore(CUDAFactory):
         # the floor governing.
         controller_rtol_floor = float(controller_rtol.min())
         if self._step_controller.is_adaptive and controller_rtol_floor > 0.0:
-            if self._algo_step.linear_solver_is_direct:
+            if self._algo_step.is_linear:
                 controller_rtol_floor *= 0.01
             derived_source["krylov_residual_reduction"] = (
                 controller_rtol_floor

--- a/src/cubie/integrators/algorithms/AGENTS.md
+++ b/src/cubie/integrators/algorithms/AGENTS.md
@@ -96,11 +96,9 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
 - **Implicit** (`ODEImplicitStep`, owns a solver): `BackwardsEulerStep`,
   `BackwardsEulerPCStep`, `CrankNicolsonStep`, `DIRKStep`, `FIRKStep`,
   `GenericRosenbrockWStep`. All use **Newton-Krylov except `GenericRosenbrockWStep`**,
-  which is linearly-implicit and constructs a `LinearSolver`
-  (`solver_type="linear"`, no Newton iteration).
-  `ODEImplicitStep.linear_solver_is_direct` exposes this ownership
-  distinction to the composition root without inspecting concrete
-  algorithm classes.
+  which is linearly-implicit and constructs a `LinearSolver` directly
+  (no Newton iteration). The class attribute `is_linear` (`True` on
+  `GenericRosenbrockWStep`, `False` elsewhere) exposes the distinction.
 
 ### Registered buffers
 - Each step registers its working buffers (e.g. DIRK `stage_base`/`accumulator`,

--- a/src/cubie/integrators/algorithms/AGENTS.md
+++ b/src/cubie/integrators/algorithms/AGENTS.md
@@ -96,8 +96,11 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
 - **Implicit** (`ODEImplicitStep`, owns a solver): `BackwardsEulerStep`,
   `BackwardsEulerPCStep`, `CrankNicolsonStep`, `DIRKStep`, `FIRKStep`,
   `GenericRosenbrockWStep`. All use **Newton-Krylov except `GenericRosenbrockWStep`**,
-  which is linearly-implicit and constructs a `LinearSolver` (`solver_type="linear"`,
-  no Newton iteration).
+  which is linearly-implicit and constructs a `LinearSolver`
+  (`solver_type="linear"`, no Newton iteration).
+  `ODEImplicitStep.linear_solver_is_direct` exposes this ownership
+  distinction to the composition root without inspecting concrete
+  algorithm classes.
 
 ### Registered buffers
 - Each step registers its working buffers (e.g. DIRK `stage_base`/`accumulator`,

--- a/src/cubie/integrators/algorithms/base_algorithm_step.py
+++ b/src/cubie/integrators/algorithms/base_algorithm_step.py
@@ -649,6 +649,10 @@ class BaseAlgorithmStep(CUDAFactory):
     usage.
     """
 
+    #: Linearly-implicit steps own their linear solver directly (no
+    #: Newton iteration) and override this to ``True``.
+    is_linear = False
+
     def __init__(
         self,
         config: BaseStepConfig,

--- a/src/cubie/integrators/algorithms/generic_rosenbrock_w.py
+++ b/src/cubie/integrators/algorithms/generic_rosenbrock_w.py
@@ -151,6 +151,8 @@ class RosenbrockWStepConfig(ImplicitStepConfig):
 class GenericRosenbrockWStep(ODEImplicitStep):
     """Rosenbrock-W step with an embedded error estimate."""
 
+    is_linear = True
+
     def __init__(
         self,
         precision: PrecisionDType,
@@ -240,9 +242,7 @@ class GenericRosenbrockWStep(ODEImplicitStep):
         else:
             controller_defaults = ROSENBROCK_FIXED_DEFAULTS
 
-        super().__init__(
-            config, controller_defaults, solver_type="linear", **kwargs
-        )
+        super().__init__(config, controller_defaults, **kwargs)
 
         self.register_buffers()
 

--- a/src/cubie/integrators/algorithms/ode_implicitstep.py
+++ b/src/cubie/integrators/algorithms/ode_implicitstep.py
@@ -210,6 +210,7 @@ class ODEImplicitStep(BaseAlgorithmStep):
             raise ValueError(
                 f"solver_type must be 'newton' or 'linear', got '{solver_type}'"
             )
+        self._solver_type = solver_type
 
         newton_norm = kwargs.pop("newton_norm", None)
         krylov_norm = kwargs.pop("krylov_norm", None)
@@ -454,6 +455,11 @@ class ODEImplicitStep(BaseAlgorithmStep):
     def is_implicit(self) -> bool:
         """Return ``True`` to indicate the algorithm is implicit."""
         return True
+
+    @property
+    def linear_solver_is_direct(self) -> bool:
+        """Return whether the step owns its linear solver directly."""
+        return self._solver_type == "linear"
 
     @property
     def beta(self) -> float:

--- a/src/cubie/integrators/algorithms/ode_implicitstep.py
+++ b/src/cubie/integrators/algorithms/ode_implicitstep.py
@@ -178,7 +178,6 @@ class ODEImplicitStep(BaseAlgorithmStep):
         self,
         config: ImplicitStepConfig,
         _controller_defaults: StepControlDefaults,
-        solver_type: str = "newton",
         **kwargs,
     ) -> None:
         """Initialise the implicit step with its configuration.
@@ -189,8 +188,6 @@ class ODEImplicitStep(BaseAlgorithmStep):
             Configuration describing the implicit step.
         _controller_defaults
            Per-algorithm default runtime collaborators.
-        solver_type
-            Type of solver to create: 'newton' or 'linear'.
         **kwargs
             Optional solver parameters (krylov_atol, krylov_max_iters,
             newton_rtol, etc.). None values are ignored and defaults
@@ -199,18 +196,18 @@ class ODEImplicitStep(BaseAlgorithmStep):
             ``krylov_norm`` supplies a :class:`ScaledNorm` for the
             linear solver's convergence weighting; when absent each
             solver builds its default.
+
+        Notes
+        -----
+        The class attribute ``is_linear`` selects the solver
+        arrangement: linearly-implicit steps own their linear solver
+        directly, all others wrap it in a :class:`NewtonKrylov`.
         """
         super().__init__(config, _controller_defaults)
 
         # Subclasses that support dense stage prediction construct a
         # DenseStagePredictor here after solver construction.
         self.dense_predictor = None
-
-        if solver_type not in ["newton", "linear"]:
-            raise ValueError(
-                f"solver_type must be 'newton' or 'linear', got '{solver_type}'"
-            )
-        self._solver_type = solver_type
 
         newton_norm = kwargs.pop("newton_norm", None)
         krylov_norm = kwargs.pop("krylov_norm", None)
@@ -233,8 +230,8 @@ class ODEImplicitStep(BaseAlgorithmStep):
         solver_n = config.solver_n
 
         # Newton solves weight the norm by the stage base state,
-        # direct Rosenbrock solves by the model state.
-        norm_reference = "base_state" if solver_type == "newton" else "state"
+        # linearly-implicit solves by the model state.
+        norm_reference = "state" if self.is_linear else "base_state"
 
         if correction_type == "bicgstab":
             linear_solver = BiCGSTABSolver(
@@ -254,7 +251,9 @@ class ODEImplicitStep(BaseAlgorithmStep):
                 **linear_kwargs,
             )
 
-        if solver_type == "newton":
+        if self.is_linear:
+            self.solver = linear_solver
+        else:
             self.solver = NewtonKrylov(
                 precision=config.precision,
                 n=solver_n,
@@ -262,8 +261,6 @@ class ODEImplicitStep(BaseAlgorithmStep):
                 norm=newton_norm,
                 **newton_kwargs,
             )
-        else:
-            self.solver = linear_solver
 
     def register_buffers(self) -> None:
         """Register buffers with buffer_registry."""
@@ -455,11 +452,6 @@ class ODEImplicitStep(BaseAlgorithmStep):
     def is_implicit(self) -> bool:
         """Return ``True`` to indicate the algorithm is implicit."""
         return True
-
-    @property
-    def linear_solver_is_direct(self) -> bool:
-        """Return whether the step owns its linear solver directly."""
-        return self._solver_type == "linear"
 
     @property
     def beta(self) -> float:

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -89,9 +89,8 @@ compiled callable from `.device_function`.
   (direct) — `norm_reference` config field, bound at compile time.
   Derived defaults: `krylov_atol`/`krylov_rtol` = the step
   controller's `atol`/`rtol`; reduction = adaptive controller min
-  `rtol` for Newton-owned solves and one hundredth of it for direct
-  Rosenbrock solves (machine epsilon for non-adaptive or
-  pure-absolute runs); floor = `sqrt(eps)`.
+  `rtol`, divided by 100 for linearly-implicit (`is_linear`) steps
+  (machine epsilon for non-adaptive runs); floor = `sqrt(eps)`.
 - **Newton convergence follows OrdinaryDiffEq's NLNewton.** Consecutive
   full steps estimate the contraction `theta` (decay-floored at
   `0.3 * prev_theta`, warm-started across solves via the persistent

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -89,8 +89,9 @@ compiled callable from `.device_function`.
   (direct) — `norm_reference` config field, bound at compile time.
   Derived defaults: `krylov_atol`/`krylov_rtol` = the step
   controller's `atol`/`rtol`; reduction = adaptive controller min
-  `rtol` (machine epsilon for non-adaptive runs); floor =
-  `sqrt(eps)`.
+  `rtol` for Newton-owned solves and one hundredth of it for direct
+  Rosenbrock solves (machine epsilon for non-adaptive or
+  pure-absolute runs); floor = `sqrt(eps)`.
 - **Newton convergence follows OrdinaryDiffEq's NLNewton.** Consecutive
   full steps estimate the contraction `theta` (decay-floored at
   `0.3 * prev_theta`, warm-started across solves via the persistent

--- a/src/cubie/integrators/matrix_free_solvers/linear_solver_base.py
+++ b/src/cubie/integrators/matrix_free_solvers/linear_solver_base.py
@@ -75,7 +75,9 @@ class LinearSolverBaseConfig(MatrixFreeSolverConfig):
         resolves to machine epsilon at construction so the floor
         criterion governs;
         :class:`~cubie.integrators.SingleIntegratorRunCore.SingleIntegratorRunCore`
-        derives the step controller's ``rtol`` for adaptive runs.
+        derives the step controller's ``rtol`` for adaptive
+        Newton-owned solves and one hundredth of it for adaptive direct
+        Rosenbrock solves.
     _residual_floor : Optional[float]
         Absolute term of the stopping rule, in weighted-norm units
         (one sits at the ``krylov_atol``/``krylov_rtol`` envelope).

--- a/src/cubie/integrators/matrix_free_solvers/linear_solver_base.py
+++ b/src/cubie/integrators/matrix_free_solvers/linear_solver_base.py
@@ -75,9 +75,8 @@ class LinearSolverBaseConfig(MatrixFreeSolverConfig):
         resolves to machine epsilon at construction so the floor
         criterion governs;
         :class:`~cubie.integrators.SingleIntegratorRunCore.SingleIntegratorRunCore`
-        derives the step controller's ``rtol`` for adaptive
-        Newton-owned solves and one hundredth of it for adaptive direct
-        Rosenbrock solves.
+        derives the adaptive controller's ``rtol``, divided by one
+        hundred for linearly-implicit (``is_linear``) steps.
     _residual_floor : Optional[float]
         Absolute term of the stopping rule, in weighted-norm units
         (one sits at the ``krylov_atol``/``krylov_rtol`` envelope).

--- a/tests/_inventory.json
+++ b/tests/_inventory.json
@@ -11381,7 +11381,7 @@
       "file": "ode_implicitstep.py",
       "section": "`__init__`",
       "num": 4,
-      "text": "Raises `ValueError` when `solver_type` is not 'newton' or 'linear'",
+      "text": "Class attribute `is_linear` is False on Newton-owned steps and True on linearly-implicit steps",
       "tags": [
         "error",
         "init"
@@ -11418,7 +11418,7 @@
       "file": "ode_implicitstep.py",
       "section": "`__init__`",
       "num": 8,
-      "text": "Creates `NewtonKrylov` wrapping `LinearSolver` when `solver_type='newton'`",
+      "text": "Creates `NewtonKrylov` wrapping `LinearSolver` when `is_linear` is False",
       "tags": [
         "init"
       ]
@@ -11427,7 +11427,7 @@
       "file": "ode_implicitstep.py",
       "section": "`__init__`",
       "num": 9,
-      "text": "Assigns `LinearSolver` directly when `solver_type='linear'`",
+      "text": "Assigns `LinearSolver` directly when `is_linear` is True",
       "tags": [
         "init"
       ]
@@ -12989,7 +12989,7 @@
       "file": "generic_rosenbrock_w.py",
       "section": "`__init__`",
       "num": 18,
-      "text": "Passes `solver_type='linear'` to parent (not Newton)",
+      "text": "Sets `is_linear = True`, so the parent assigns the linear solver directly (not Newton)",
       "tags": [
         "init"
       ]

--- a/tests/integrators/algorithms/test_ode_implicitstep.py
+++ b/tests/integrators/algorithms/test_ode_implicitstep.py
@@ -4,6 +4,9 @@ import numpy as np
 import pytest
 
 from cubie.integrators.algorithms.backwards_euler import BackwardsEulerStep
+from cubie.integrators.algorithms.generic_rosenbrock_w import (
+    GenericRosenbrockWStep,
+)
 
 
 def test_implicit_step_accepts_tolerance_arrays(precision):
@@ -60,14 +63,8 @@ def test_implicit_step_exposes_tolerance_properties(precision):
 
 
 def test_implicit_step_linear_solver_newton_atol_returns_none(precision):
-    """Verify newton_atol/rtol return None when solver is MRLinearSolver."""
-    n = 3
-
-    step = BackwardsEulerStep(
-        precision=precision,
-        n=n,
-        solver_type='linear',
-    )
+    """Verify newton_atol/rtol return None for a linearly-implicit step."""
+    step = GenericRosenbrockWStep(precision=precision, n=3)
 
     # MRLinearSolver doesn't have newton_atol/rtol, so properties return None
     assert step.newton_atol is None
@@ -78,14 +75,12 @@ def test_implicit_step_linear_solver_newton_atol_returns_none(precision):
     assert step.krylov_rtol is not None
 
 
-def test_implicit_step_rejects_invalid_solver_type(precision):
-    """Constructing with an unknown solver_type raises ValueError."""
-    with pytest.raises(ValueError, match="solver_type must be"):
-        BackwardsEulerStep(
-            precision=precision,
-            n=3,
-            solver_type='not_a_real_solver',
-        )
+def test_is_linear_marks_direct_linear_solver_ownership(precision):
+    """is_linear is True only for linearly-implicit step classes."""
+    assert GenericRosenbrockWStep.is_linear
+    assert not BackwardsEulerStep.is_linear
+    step = BackwardsEulerStep(precision=precision, n=3)
+    assert not step.is_linear
 
 
 def test_implicit_config_settings_dict_includes_implicit_fields(precision):

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -979,10 +979,9 @@ def test_update_controller_swap_builds(single_integrator_run_mutable):
 
 # ── Inner-solver tolerance defaults ─────────────────────────────────── #
 
-# Adaptive implicit configuration with one explicit inner tolerance;
-# the rest are left unset (``None`` marks not-given) and must be
-# derived from the controller. The derivation ratio is a tuning
-# constant and is deliberately not pinned here.
+# Adaptive Newton-owned configuration with one explicit inner
+# tolerance; the rest are left unset (``None`` marks not-given) and
+# must be derived from the controller.
 _CN_ADAPTIVE_KRYLOV_GIVEN = {
     "algorithm": "crank_nicolson",
     "step_controller": "pid",
@@ -994,6 +993,21 @@ _CN_ADAPTIVE_KRYLOV_GIVEN = {
     "krylov_rtol": None,
     "newton_atol": None,
     "newton_rtol": None,
+}
+
+_RODAS3P_ADAPTIVE_KRYLOV_DEFAULT = {
+    "algorithm": "rodas3p",
+    "step_controller": "pid",
+    "atol": 3e-7,
+    "rtol": 2e-4,
+    "dt_min": 1e-10,
+    "dt_max": 0.1,
+    "krylov_residual_reduction": None,
+}
+
+_RODAS3P_ADAPTIVE_KRYLOV_GIVEN = {
+    **_RODAS3P_ADAPTIVE_KRYLOV_DEFAULT,
+    "krylov_residual_reduction": 0.03125,
 }
 
 
@@ -1009,6 +1023,7 @@ def test_explicit_inner_tolerance_survives_derivation(
     controller = run._step_controller
     assert controller.is_adaptive
     assert algo.is_implicit
+    assert not algo.linear_solver_is_direct
 
     assert np.allclose(algo.krylov_atol, 3e-5)
     # The unset linear weight derives the controller's tolerance
@@ -1026,13 +1041,52 @@ def test_explicit_inner_tolerance_survives_derivation(
     assert np.all(
         np.asarray(algo.newton_rtol) <= np.asarray(controller.rtol)
     )
-    # The unset linear stopping terms derive the controller's rtol
-    # and sqrt(eps) of the precision.
-    assert np.isclose(
-        float(algo.krylov_residual_reduction),
-        float(np.min(np.asarray(controller.rtol))),
+    # Newton-owned linear solves retain the controller's rtol directly.
+    expected_reduction = run.precision(
+        float(np.min(np.asarray(controller.rtol)))
     )
+    assert algo.krylov_residual_reduction == expected_reduction
     assert np.isclose(
         float(algo.krylov_residual_floor),
         float(np.finfo(run.precision).eps) ** 0.5,
     )
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [_RODAS3P_ADAPTIVE_KRYLOV_DEFAULT],
+    indirect=True,
+)
+def test_direct_rosenbrock_reduction_defaults_to_rtol_over_100(
+    single_integrator_run,
+):
+    """A direct Rosenbrock solve defaults to one percent of rtol."""
+    run = single_integrator_run
+    algo = run._algo_step
+    controller = run._step_controller
+    assert controller.is_adaptive
+    assert algo.is_implicit
+    assert algo.linear_solver_is_direct
+
+    controller_rtol_floor = float(
+        np.min(np.asarray(controller.rtol))
+    )
+    expected_reduction = run.precision(
+        0.01 * controller_rtol_floor
+    )
+    assert algo.krylov_residual_reduction == expected_reduction
+
+
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [_RODAS3P_ADAPTIVE_KRYLOV_GIVEN],
+    indirect=True,
+)
+def test_direct_rosenbrock_reduction_override_is_preserved(
+    single_integrator_run,
+):
+    """An explicit Rosenbrock reduction bypasses default derivation."""
+    run = single_integrator_run
+    algo = run._algo_step
+    assert algo.linear_solver_is_direct
+    assert algo.krylov_residual_reduction == run.precision(0.03125)

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -979,9 +979,8 @@ def test_update_controller_swap_builds(single_integrator_run_mutable):
 
 # ── Inner-solver tolerance defaults ─────────────────────────────────── #
 
-# Adaptive Newton-owned configuration with one explicit inner
-# tolerance; the rest are left unset (``None`` marks not-given) and
-# must be derived from the controller.
+# One explicit inner tolerance; the rest are left unset (``None``
+# marks not-given) and must derive from the controller.
 _CN_ADAPTIVE_KRYLOV_GIVEN = {
     "algorithm": "crank_nicolson",
     "step_controller": "pid",
@@ -1023,7 +1022,7 @@ def test_explicit_inner_tolerance_survives_derivation(
     controller = run._step_controller
     assert controller.is_adaptive
     assert algo.is_implicit
-    assert not algo.linear_solver_is_direct
+    assert not algo.is_linear
 
     assert np.allclose(algo.krylov_atol, 3e-5)
     # The unset linear weight derives the controller's tolerance
@@ -1057,16 +1056,16 @@ def test_explicit_inner_tolerance_survives_derivation(
     [_RODAS3P_ADAPTIVE_KRYLOV_DEFAULT],
     indirect=True,
 )
-def test_direct_rosenbrock_reduction_defaults_to_rtol_over_100(
+def test_linear_step_reduction_defaults_to_rtol_over_100(
     single_integrator_run,
 ):
-    """A direct Rosenbrock solve defaults to one percent of rtol."""
+    """A linearly-implicit step defaults to one percent of rtol."""
     run = single_integrator_run
     algo = run._algo_step
     controller = run._step_controller
     assert controller.is_adaptive
     assert algo.is_implicit
-    assert algo.linear_solver_is_direct
+    assert algo.is_linear
 
     controller_rtol_floor = float(
         np.min(np.asarray(controller.rtol))
@@ -1082,11 +1081,11 @@ def test_direct_rosenbrock_reduction_defaults_to_rtol_over_100(
     [_RODAS3P_ADAPTIVE_KRYLOV_GIVEN],
     indirect=True,
 )
-def test_direct_rosenbrock_reduction_override_is_preserved(
+def test_linear_step_reduction_override_is_preserved(
     single_integrator_run,
 ):
-    """An explicit Rosenbrock reduction bypasses default derivation."""
+    """An explicit reduction on a linearly-implicit step is kept."""
     run = single_integrator_run
     algo = run._algo_step
-    assert algo.linear_solver_is_direct
+    assert algo.is_linear
     assert algo.krylov_residual_reduction == run.precision(0.03125)


### PR DESCRIPTION
## Summary

- derive adaptive Rosenbrock `krylov_residual_reduction` as `0.01 * min(controller.rtol)` for linearly-implicit steps
- retain `min(controller.rtol)` for Newton-owned linear solves
- retain machine epsilon for non-adaptive control
- preserve explicit `krylov_residual_reduction` overrides
- expose linear-solver ownership as the class attribute `BaseAlgorithmStep.is_linear` (`True` on `GenericRosenbrockWStep`, `False` elsewhere)

## Root cause

The composition root applied the adaptive controller's full relative
tolerance as the residual-reduction target for every implicit linear
solve. That is appropriate as the existing default for Newton-owned
inner solves, but it is too loose for a linearly-implicit Rosenbrock
stage solve: at `rtol=1e-2`, Rodas3P could leave roughly one percent
of the stage right-hand-side residual, entering the integrator at the
same scale as the entire step-error budget. Rosenbrock practice uses a
linear target around `TOL/100`.

The solver already distinguishes the two ownership modes and their norm
references. This change makes that distinction explicit to the
tolerance-derivation layer and changes only the linearly-implicit path.

## Review fixes

- The `solver_type` constructor parameter and the
  `linear_solver_is_direct` property are replaced by the class
  attribute `is_linear` (`True` on `GenericRosenbrockWStep`, `False`
  on `BaseAlgorithmStep`), queryable on any step class or instance —
  the shape requested in the #668 review. `GenericRosenbrockWStep`
  no longer passes `solver_type="linear"`; `ODEImplicitStep` reads
  `self.is_linear` for solver arrangement and norm reference.
- Docstrings, AGENTS.md entries, and test names use the
  linearly-implicit / `is_linear` language instead of "direct"; the
  "pure-absolute" aside is dropped. The machine-epsilon default for
  non-adaptive runs is accurate to the code: the derivation guards on
  `controller.is_adaptive` (`SingleIntegratorRunCore.py`), so a fixed
  controller's tolerances feed `krylov_atol`/`krylov_rtol` but never
  the reduction.
- The verbose test comment is trimmed; the two `solver_type` unit
  tests are replaced (`GenericRosenbrockWStep` covers the
  newton-tolerances-are-None path; a new test asserts the `is_linear`
  markings), and `tests/_inventory.json` entries are updated to match.

PR #668 stacks on this branch and consumes `is_linear` and the same
validation/`linear_solver` surface.

## Numerical equivalence

Ran the complete GPUODEBenchmarks adaptive workflow on an RTX 4070
SUPER, regenerating the Julia Float32 references and every CuBIE
adaptive tier. Rodas3P now reports:

- matched controller: **TRACKING**, worst CuBIE/Julia error ratio `1.05`
- CuBIE default controller: **MORE ACCURATE**, worst ratio `0.36`

Same-controller A/B against `origin/main`:

| tolerance | main error / Julia | patched error / Julia |
|---:|---:|---:|
| `1e-2` | 2.794 | 0.289 |
| `1e-3` | 1.914 | 0.209 |
| `1e-4` | 2.438 | 0.292 |
| `1e-5` | 2.270 | 0.252 |
| `1e-6` | 1.221 | 0.355 |

With Julia-matched controllers, patched CuBIE/Julia error ratios are
`1.021`, `1.018`, `1.048`, `1.006`, and `0.594` across those
tolerances. The mutual RMS distance divided by Julia's own error is
`0.118`, `0.040`, `0.055`, `0.086`, and `0.882`.

The aggregate comparator still reports unrelated existing fixed-step
mismatches and two explicit matched-controller adaptive mismatches; the
targeted Rodas3P adaptive verdict passes.

## Verification (post-review-fix, rebased on current main)

- full CUDASIM suite (`NUMBA_ENABLE_CUDASIM=1`,
  `-m "not nocudasim and not cupy and not specific_algos"`):
  **3049 passed**
- full real-GPU suite (`-m "not specific_algos and not sim_only"`):
  **3125 passed**
- Ruff and blocking flake8 on every touched file: pass

## Performance gate

A = origin/main (10cc1cfb), B = this branch:

```
numba-cuda fixed     kernel  A    61.879  B    62.244   +0.25%  ok
numba-cuda fixed     wall    A    75.620  B    76.033   +0.01%  ok
numba-cuda adaptive  kernel  A    17.668  B    17.679   +0.10%  ok
numba-cuda adaptive  wall    A    22.045  B    22.176   +0.10%  ok
numba-cuda chunked   kernel  A    62.199  B    62.506   +0.07%  ok
numba-cuda chunked   wall    A    78.417  B    79.321   +0.04%  ok
numba-cuda wave      kernel  A    25.644  B    25.610   -0.14%  ok
numba-cuda wave      wall    A    28.419  B    28.396   -0.19%  ok
mlir       fixed     kernel  A    61.848  B    61.841   -0.00%  ok
mlir       fixed     wall    A    76.341  B    76.036   -0.35%  ok
mlir       adaptive  kernel  A    17.254  B    17.270   +0.21%  ok
mlir       adaptive  wall    A    21.877  B    21.811   +0.15%  ok
mlir       chunked   kernel  A    62.192  B    62.191   -0.02%  ok
mlir       chunked   wall    A    78.706  B    78.886   +0.39%  ok
mlir       wave      kernel  A    25.609  B    25.616   +0.04%  ok
mlir       wave      wall    A    28.435  B    28.395   -0.26%  ok
GATE: PASS (kernel threshold 0.50%, wall threshold 10.00%)
```
