### PR TITLE
refactor: driver sample spacing is named driver_sample_period

### DIFF
--- a/benchmarks/memory_location_sweep.py
+++ b/benchmarks/memory_location_sweep.py
@@ -362,7 +362,7 @@ def run_single(cfg):
             ).astype(precision)
             for j in range(cfg["n_drivers"])
         }
-        drivers["dt"] = precision(DURATION / 15)
+        drivers["driver_sample_period"] = precision(DURATION / 15)
         drivers["wrap"] = False
         solve_kwargs["drivers"] = drivers
 

--- a/docs/source/examples/controller_step_analysis.py
+++ b/docs/source/examples/controller_step_analysis.py
@@ -283,7 +283,7 @@ def build_driver_settings(
         name: np.array(driver_matrix[:, idx], dtype=precision, copy=True)
         for idx, name in enumerate(driver_names)
     }
-    drivers_dict["dt"] = precision(dt_sample)
+    drivers_dict["driver_sample_period"] = precision(dt_sample)
     drivers_dict["wrap"] = bool(solver_settings["driverspline_wrap"])
     drivers_dict["boundary_condition"] = solver_settings.get(
         "driverspline_boundary_condition",
@@ -428,7 +428,7 @@ def create_driver_evaluator(
         coeffs = np.array(
             driver_array.coefficients, dtype=precision, copy=True
         )
-        dt_value = precision(driver_array.dt)
+        dt_value = precision(driver_array.driver_sample_period)
         t0_value = precision(driver_array.t0)
         wrap_value = bool(driver_array.wrap)
         boundary = driver_array.boundary_condition

--- a/docs/source/examples/cpu_gpu_driver_evaluator_comparison.py
+++ b/docs/source/examples/cpu_gpu_driver_evaluator_comparison.py
@@ -103,7 +103,7 @@ def build_driver_evaluator(
             copy=True,
             dtype=precision,
         ),
-        dt=precision(interpolator.dt),
+        dt=precision(interpolator.driver_sample_period),
         t0=precision(interpolator.t0),
         wrap=interpolator.wrap,
         precision=precision,

--- a/src/cubie/AGENTS.md
+++ b/src/cubie/AGENTS.md
@@ -42,7 +42,7 @@ resolves `__version__` via `importlib.metadata.version("cubie")`.
 | `cubie_cache.py` | File-based persistence of compiled kernels: `CUBIECache*`, `CacheConfig`, `CubieCacheHandler`, `ALL_CACHE_PARAMETERS`. Built on the backend's cache bases from `cuda_simsafe` (numba-cuda `_Kernel` serialization or the MLIR compile-result scheme). |
 | `time_logger.py` | `TimeLogger` (verbosity-gated timing), `CUDAEvent` (GPU event pair with CUDASIM fallback), `TimingEvent`, `default_timelogger`. |
 | `result_codes.py` | `CUBIE_RESULT_CODES(IntFlag)` — the package-central status vocabulary OR-combined into the per-run status word — plus `decode_status_codes` for host-side decoding. |
-| `array_interpolator.py` | `ArrayInterpolator(CUDAFactory)`: builds piecewise-polynomial (spline) coefficients from sampled driver arrays and compiles `evaluate_all` (Horner evaluation of all drivers at `t`) and `evaluate_time_derivative`. Owned by `Solver` as `driver_interpolator`; defines `ArrayInterpolatorConfig`, `InterpolatorCache`. |
+| `array_interpolator.py` | `ArrayInterpolator(CUDAFactory)`: builds piecewise-polynomial (spline) coefficients from sampled driver arrays and compiles `evaluate_all` (Horner evaluation of all drivers at `t`) and `evaluate_time_derivative`. Owned by `Solver` as `driver_interpolator`; defines `ArrayInterpolatorConfig`, `InterpolatorCache`. The sample spacing is `driver_sample_period` (input-dict key and config field) — never `dt`, which is the integrator timestep. |
 | `writing_cuda_functions.md` | Working notes on CUDA device-function *optimisation* conventions (predicated commit, warp-coherent loops, …). Under discussion — consult before hand-optimising device code. |
 
 ## Subdirectories

--- a/src/cubie/array_interpolator.py
+++ b/src/cubie/array_interpolator.py
@@ -13,7 +13,7 @@ Published Classes
     >>> from numpy import float64, linspace, sin
     >>> times = linspace(0, 1, 11)
     >>> inputs = {"driver_0": sin(times)}
-    >>> inputs["dt"] = times[1] - times[0]
+    >>> inputs["driver_sample_period"] = times[1] - times[0]
     >>> interp = ArrayInterpolator(precision=float64, input_dict=inputs)
     >>> interp.num_inputs
     1
@@ -107,8 +107,8 @@ class ArrayInterpolatorConfig(CUDAFactoryConfig):
         defaults to 'not-a-knot' to match Scipy's CubicSpline.
     t0 : float
         start time of input samples
-    dt : numpy.ndarray
-        Sampling frequency.
+    driver_sample_period : float
+        Temporal spacing between consecutive driver samples.
     num_inputs : int
         Number of separate input vectors
     num_segments : int
@@ -131,7 +131,7 @@ class ArrayInterpolatorConfig(CUDAFactoryConfig):
             validators.in_({"natural", "periodic", "not-a-knot", "clamped"})
         ),
     )
-    dt: FloatArray = field(
+    driver_sample_period: float = field(
         init=False, default=1e-16, validator=getype_validator(float, 0)
     )
     t0: float = field(default=0.0, validator=getype_validator(float, 0))
@@ -155,7 +155,7 @@ class ArrayInterpolator(CUDAFactory):
     forcing terms."""
 
     config_keys = ("wrap", "order", "boundary_condition")
-    time_info = ("time", "dt", "t0")
+    time_info = ("time", "driver_sample_period", "t0")
 
     def __init__(
         self,
@@ -203,7 +203,7 @@ class ArrayInterpolator(CUDAFactory):
 
             - ``"time"``: 1D float array of sample times corresponding to
             input array values, or
-                - ``"dt"``: uniform spacing between samples, and
+                - ``"driver_sample_period"``: uniform spacing between samples, and
                 - ``"t0"``: starting time of the input samples.
             - ``[input_name]``: one-dimensional float array of samples for
             each input, where ``input_name`` is the name of the input signal
@@ -262,8 +262,14 @@ class ArrayInterpolator(CUDAFactory):
         if arrays_changed:
             self._input_array = input_array
 
-        dt, t0 = self._validate_time_inputs(time)
-        config.update({"t0": t0, "dt": dt, "num_inputs": self.num_inputs})
+        sample_period, t0 = self._validate_time_inputs(time)
+        config.update(
+            {
+                "t0": t0,
+                "driver_sample_period": sample_period,
+                "num_inputs": self.num_inputs,
+            }
+        )
 
         # Final update; invalidates cache if settings have changed.
         self._derive_segment_settings(config)
@@ -362,15 +368,17 @@ class ArrayInterpolator(CUDAFactory):
         Parameters
         ----------
         time_dict
-            Dictionary of time-related user inputs. If "dt" is provided,
-            then this will be used and "t0" will be fetched from the dict or
-            default to 0.0. If "time" is provided, dt will be calculated as the
-             difference between samples, and t0 as time_dict['time'][0].
+            Dictionary of time-related user inputs. If
+            "driver_sample_period" is provided, then this will be used
+            and "t0" will be fetched from the dict or default to 0.0.
+            If "time" is provided, the sample period will be calculated
+            as the difference between samples, and t0 as
+            time_dict['time'][0].
         Returns
         -------
         tuple (float, float)
-            dt and t0, either obtained directly from time_dict or computed
-            from a "time" array.
+            Sample period and t0, either obtained directly from
+            time_dict or computed from a "time" array.
         Raises
         ------
         ValueError
@@ -378,10 +386,15 @@ class ArrayInterpolator(CUDAFactory):
             spacing between samples is non-uniform.
         """
 
-        if ("dt" in time_dict) and ("time" in time_dict):
-            raise ValueError("Only one of dt or time should be provided.")
-        if "dt" in time_dict:
-            dt = time_dict["dt"]
+        if ("driver_sample_period" in time_dict) and (
+            "time" in time_dict
+        ):
+            raise ValueError(
+                "Only one of driver_sample_period or time should be "
+                "provided."
+            )
+        if "driver_sample_period" in time_dict:
+            sample_period = time_dict["driver_sample_period"]
             t0 = time_dict.get("t0", 0.0)
         elif "time" in time_dict:
             timeArray = time_dict["time"]
@@ -403,11 +416,14 @@ class ArrayInterpolator(CUDAFactory):
                 atol=1e-6,
             ):
                 raise ValueError("Time array must be uniformly spaced.")
-            dt = time_differences[0]
+            sample_period = time_differences[0]
         else:
-            raise ValueError("Either Time array or dt must be provided.")
+            raise ValueError(
+                "Either a time array or driver_sample_period must be "
+                "provided."
+            )
 
-        return dt, t0
+        return sample_period, t0
 
     # ---------------------------------------------------------------------- #
     # Evaluation function machinery
@@ -425,7 +441,7 @@ class ArrayInterpolator(CUDAFactory):
 
         order = self.order
         num_inputs = self.num_inputs
-        resolution = precision(self.dt)
+        resolution = precision(self.driver_sample_period)
         inv_resolution = precision(precision(1.0) / resolution)
         start_time = precision(self.t0)
         num_segments = int32(self.num_segments)
@@ -760,14 +776,14 @@ class ArrayInterpolator(CUDAFactory):
 
         interpolated = self.get_interpolated(times)
 
-        sample_times = self.t0 + self.dt * arange(
+        sample_times = self.t0 + self.driver_sample_period * arange(
             self.num_samples,
             dtype=self.precision,
         )
         sample_values = self.input_array.astype(self.precision, copy=False)
 
         if self.wrap and times.size:
-            period = self.dt * self.num_samples
+            period = self.driver_sample_period * self.num_samples
             min_eval = times.min()
             max_eval = times.max()
             repeats_before = int(
@@ -1115,6 +1131,6 @@ class ArrayInterpolator(CUDAFactory):
         return self.compile_settings.t0
 
     @property
-    def dt(self) -> float:
+    def driver_sample_period(self) -> float:
         """Return the sample spacing."""
-        return self.compile_settings.dt
+        return self.compile_settings.driver_sample_period

--- a/src/cubie/batchsolving/AGENTS.md
+++ b/src/cubie/batchsolving/AGENTS.md
@@ -140,6 +140,8 @@ concrete: `driver_coefficients_shape` is a `BatchSolverConfig` compile setting (
 closure constants), seeded at Solver construction and refreshed through `kernel.update`
 wherever the interpolator's evaluators change, so shape checks compare against the layout
 the kernel was compiled for.
+Driver dicts name their sample spacing `driver_sample_period` — `dt` is the integrator
+timestep and never reaches the interpolator.
 
 ### Testing
 `tests/batchsolving/` (`test_solver.py`, `test_BatchSolverKernel.py`, input-handler/result tests).

--- a/src/cubie/batchsolving/solver.py
+++ b/src/cubie/batchsolving/solver.py
@@ -457,7 +457,7 @@ class Solver:
             precision=precision,
             input_dict={
                 "placeholder": np_zeros(6, dtype=precision),
-                "dt": 0.1,
+                "driver_sample_period": 0.1,
             },
         )
 

--- a/src/cubie/odesystems/symbolic/parsing/AGENTS.md
+++ b/src/cubie/odesystems/symbolic/parsing/AGENTS.md
@@ -73,7 +73,7 @@ only defines the container and its derived metadata; treat its `_*` fields as `i
 state set in `__attrs_post_init__` (never set them directly).
 
 ### Driver settings
-Keys in `DRIVER_SETTING_KEYS` (`time`, `dt`, `wrap`, `order`) are configuration, not driver
+Keys in `DRIVER_SETTING_KEYS` (`time`, `driver_sample_period`, `wrap`, `order`) are configuration, not driver
 symbols; they're stripped before building driver names and reattached via
 `drivers.set_passthrough_defaults`.
 

--- a/src/cubie/odesystems/symbolic/parsing/parser.py
+++ b/src/cubie/odesystems/symbolic/parsing/parser.py
@@ -37,7 +37,7 @@ PARSE_TRANSFORMS = (T[0][0], T[3][0], T[4][0], T[8][0])
 _INDEXED_NAME_PATTERN = re.compile(r"(?P<name>[A-Za-z_]\w*)\[(?P<index>\d+)\]")
 
 TIME_SYMBOL = sp.Symbol("t", real=True)
-DRIVER_SETTING_KEYS = {"time", "dt", "wrap", "order"}
+DRIVER_SETTING_KEYS = {"time", "driver_sample_period", "wrap", "order"}
 
 
 def _detect_input_type(dxdt: Union[str, Iterable, Callable]) -> str:

--- a/src/cubie/odesystems/symbolic/symbolicODE.py
+++ b/src/cubie/odesystems/symbolic/symbolicODE.py
@@ -520,7 +520,7 @@ class SymbolicODE(BaseODE):
         """
 
         if isinstance(drivers, dict) and (
-            "time" in drivers or "dt" in drivers
+            "time" in drivers or "driver_sample_period" in drivers
         ):
             ArrayInterpolator(precision=precision, input_dict=drivers)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -684,7 +684,7 @@ def driver_settings(
         name: np.array(driver_matrix[:, idx], dtype=precision, copy=True)
         for idx, name in enumerate(driver_names)
     }
-    drivers_dict["dt"] = precision(dt_sample)
+    drivers_dict["driver_sample_period"] = precision(dt_sample)
     drivers_dict["wrap"] = solver_settings["driverspline_wrap"]
     drivers_dict["order"] = order
     drivers_dict["boundary_condition"] = solver_settings[
@@ -739,7 +739,7 @@ def cpu_driver_evaluator(
             dtype=precision,
             copy=True,
         )
-        dt_value = precision(driver_array.dt)
+        dt_value = precision(driver_array.driver_sample_period)
         t0_value = precision(driver_array.t0)
         wrap_value = bool(driver_array.wrap)
 

--- a/tests/integrators/cpu_reference/test_cpu_utils.py
+++ b/tests/integrators/cpu_reference/test_cpu_utils.py
@@ -145,7 +145,7 @@ def test_cpu_driver_evaluator_matches_gpu_time_alignment(
 
     driver_dict = {
         "t0": warmup,
-        "dt": dt,
+        "driver_sample_period": dt,
         "wrap": False,
         "order": 3,
         "driver": driver_values.astype(precision),
@@ -154,7 +154,7 @@ def test_cpu_driver_evaluator_matches_gpu_time_alignment(
     interpolator = ArrayInterpolator(precision=precision, input_dict=driver_dict)
     evaluator = DriverEvaluator(
         coefficients=interpolator.coefficients,
-        dt=precision(interpolator.dt),
+        dt=precision(interpolator.driver_sample_period),
         t0=precision(interpolator.t0),
         wrap=interpolator.wrap,
         precision=precision,

--- a/tests/test_array_interpolator.py
+++ b/tests/test_array_interpolator.py
@@ -191,7 +191,7 @@ def test_driver_del_t_matches_cubic_reference(cubic_inputs,
     query_times = np.linspace(
         cubic_inputs.t0,
         cubic_inputs.t0
-        + cubic_inputs.dt * (cubic_inputs.num_segments - 1),
+        + cubic_inputs.driver_sample_period * (cubic_inputs.num_segments - 1),
         num=17,
         dtype=cubic_inputs.precision,
     )
@@ -226,13 +226,13 @@ def test_cpu_driver_derivative_matches_gpu_reference(
     query_times = np.linspace(
         cubic_inputs.t0,
         cubic_inputs.t0
-        + cubic_inputs.dt * (cubic_inputs.num_segments - 1),
+        + cubic_inputs.driver_sample_period * (cubic_inputs.num_segments - 1),
         num=17,
         dtype=cubic_inputs.precision,
     )
     evaluator = DriverEvaluator(
         coefficients=coefficients,
-        dt=precision(cubic_inputs.dt),
+        dt=precision(cubic_inputs.driver_sample_period),
         t0=precision(cubic_inputs.t0),
         wrap=cubic_inputs.wrap,
         precision=precision,
@@ -367,7 +367,7 @@ def test_build_coefficients_matches_polynomial(quadratic_input, tolerance):
     interior = coefficients[1:-1]
     segment_starts = (
         np.arange(interior.shape[0], dtype=quadratic_input.precision)
-        * quadratic_input.dt
+        * quadratic_input.driver_sample_period
     )
     expected = np.column_stack(
         (
@@ -420,7 +420,7 @@ def test_device_interpolation_matches_cpu(
 
     input = cubic_inputs
     query_times = np.arange(input.num_samples + 2, dtype=np.int32)
-    query_times = query_times.astype(input.precision) * input.dt
+    query_times = query_times.astype(input.precision) * input.driver_sample_period
 
     coefficients = input.coefficients
     device_fn = input.evaluation_function
@@ -433,7 +433,7 @@ def test_device_interpolation_matches_cpu(
                 t,
                 coefficients,
                 input.t0,
-                input.dt,
+                input.driver_sample_period,
                 wrap=False,
                 boundary_condition=input.boundary_condition,
                 precision=precision,
@@ -460,7 +460,7 @@ def test_get_interpolated_matches_kernel_output(cubic_inputs):
 
     query_times = np.linspace(
         cubic_inputs.t0,
-        cubic_inputs.t0 + cubic_inputs.dt * (cubic_inputs.num_segments - 1),
+        cubic_inputs.t0 + cubic_inputs.driver_sample_period * (cubic_inputs.num_segments - 1),
         17,
         dtype=cubic_inputs.precision,
     )
@@ -517,7 +517,7 @@ def test_wrap_vs_clamp_evaluation(
                 t,
                 clamp_input.coefficients,
                 clamp_input.t0,
-                clamp_input.dt,
+                clamp_input.driver_sample_period,
                 wrap=False,
                 boundary_condition=clamp_input.boundary_condition,
                 precision=precision,
@@ -531,7 +531,7 @@ def test_wrap_vs_clamp_evaluation(
                 t,
                 wrap_input.coefficients,
                 wrap_input.t0,
-                wrap_input.dt,
+                wrap_input.driver_sample_period,
                 wrap=True,
                 boundary_condition=wrap_input.boundary_condition,
                 precision=precision,
@@ -583,12 +583,12 @@ def test_non_wrap_returns_zero_outside_range(quadratic_input, tolerance) -> None
     coefficients = input.coefficients
     device_fn = input.evaluation_function
     dtype = input.precision
-    end_time = input.t0 + (input.num_samples - 1) * input.dt
+    end_time = input.t0 + (input.num_samples - 1) * input.driver_sample_period
     query_times = np.array(
         [
-            input.t0 - input.dt,
-            input.t0 + 0.5 * input.dt,
-            end_time + input.dt,
+            input.t0 - input.driver_sample_period,
+            input.t0 + 0.5 * input.driver_sample_period,
+            end_time + input.driver_sample_period,
         ],
         dtype=dtype,
     )
@@ -634,7 +634,7 @@ def test_wrap_repeats_periodically(wrapping_inputs, tolerance) -> None:
     _, wrap_input = wrapping_inputs
     coefficients = wrap_input.coefficients
     device_fn = wrap_input.evaluation_function
-    period = wrap_input.num_segments * wrap_input.dt
+    period = wrap_input.num_segments * wrap_input.driver_sample_period
     dtype = wrap_input.precision
     query_times = np.array(
         [
@@ -795,7 +795,7 @@ def test_natural_boundary_supports_higher_orders(precision, tolerance) -> None:
     )
 
     coefficients = input.coefficients
-    dt = input.dt
+    dt = input.driver_sample_period
     expected_zero = []
     remaining = order - 1
     derivative = 2
@@ -854,7 +854,7 @@ def test_periodic_boundary_respects_general_order(precision, tolerance) -> None:
     )
 
     coefficients = input.coefficients
-    dt = input.dt
+    dt = input.driver_sample_period
     last_segment = input.num_segments - 1
     for derivative in range(1, order):
         left = _evaluate_derivative(coefficients, 0, 0, 0.0, derivative, dt)
@@ -921,8 +921,8 @@ def test_cubic_interpolation_matches_analytic(cubic_inputs, precision, tolerance
 
     inp = cubic_inputs
     # choose query times strictly inside the sampled range to avoid ghost/wrap handling
-    start = inp.t0 + 0.1 * inp.dt
-    end = inp.t0 + (inp.num_samples - 2) * inp.dt - 0.1 * inp.dt
+    start = inp.t0 + 0.1 * inp.driver_sample_period
+    end = inp.t0 + (inp.num_samples - 2) * inp.driver_sample_period - 0.1 * inp.driver_sample_period
     query_times = np.linspace(start, end, 25, dtype=inp.precision)
 
     observed = inp.get_interpolated(query_times)
@@ -963,7 +963,7 @@ def test_check_against_system_drivers_orders_by_declared_order(
     shuffled = {
         "d_b": samples_b,
         "d_a": samples_a,
-        "dt": precision(0.1),
+        "driver_sample_period": precision(0.1),
         "wrap": False,
     }
 
@@ -972,7 +972,7 @@ def test_check_against_system_drivers_orders_by_declared_order(
     driver_keys = [key for key in ordered if key in ("d_a", "d_b")]
     assert driver_keys == list(system.indices.driver_names)
     # Non-driver configuration/timing entries are preserved.
-    assert ordered["dt"] == precision(0.1)
+    assert ordered["driver_sample_period"] == precision(0.1)
     assert ordered["wrap"] is False
 
 
@@ -992,12 +992,12 @@ def test_interpolator_columns_track_declared_driver_order(
     forward = {
         "d_a": samples_a,
         "d_b": samples_b,
-        "dt": precision(0.1),
+        "driver_sample_period": precision(0.1),
     }
     reversed_dict = {
         "d_b": samples_b,
         "d_a": samples_a,
-        "dt": precision(0.1),
+        "driver_sample_period": precision(0.1),
     }
 
     forward_interp = ArrayInterpolator(
@@ -1038,7 +1038,7 @@ def test_construction_rejects_non_convertible_array(precision):
             precision=precision,
             input_dict={
                 "values": ["a", "b", "c"],
-                "dt": precision(0.1),
+                "driver_sample_period": precision(0.1),
             },
         )
 
@@ -1050,7 +1050,7 @@ def test_construction_rejects_multidimensional_input(precision):
             precision=precision,
             input_dict={
                 "values": np.zeros((3, 2), dtype=precision),
-                "dt": precision(0.1),
+                "driver_sample_period": precision(0.1),
             },
         )
 
@@ -1063,7 +1063,7 @@ def test_construction_rejects_mismatched_input_lengths(precision):
             input_dict={
                 "a": np.zeros(5, dtype=precision),
                 "b": np.zeros(4, dtype=precision),
-                "dt": precision(0.1),
+                "driver_sample_period": precision(0.1),
             },
         )
 
@@ -1076,7 +1076,7 @@ def test_construction_rejects_too_few_samples(precision):
             input_dict={
                 "values": np.array([1.0, 2.0], dtype=precision),
                 "order": 3,
-                "dt": precision(0.1),
+                "driver_sample_period": precision(0.1),
             },
         )
 
@@ -1086,12 +1086,12 @@ def test_construction_rejects_too_few_samples(precision):
 
 def test_construction_rejects_both_dt_and_time(precision):
     """Providing both dt and time raises ValueError."""
-    with pytest.raises(ValueError, match="Only one of dt or time"):
+    with pytest.raises(ValueError, match="Only one of driver_sample_period or time"):
         ArrayInterpolator(
             precision=precision,
             input_dict={
                 "values": np.arange(4, dtype=precision),
-                "dt": precision(0.1),
+                "driver_sample_period": precision(0.1),
                 "time": np.arange(4, dtype=precision),
             },
         )
@@ -1150,7 +1150,7 @@ def test_construction_rejects_non_uniform_time(precision):
 
 def test_construction_rejects_neither_dt_nor_time(precision):
     """Providing neither dt nor time raises ValueError."""
-    with pytest.raises(ValueError, match="Either Time array or dt"):
+    with pytest.raises(ValueError, match="time array or driver_sample_period"):
         ArrayInterpolator(
             precision=precision,
             input_dict={"values": np.arange(4, dtype=precision)},
@@ -1172,7 +1172,7 @@ def test_update_accepts_kwargs():
         precision=np.float32,
         input_dict={
             "values": np.arange(6, dtype=np.float32),
-            "dt": np.float32(0.1),
+            "driver_sample_period": np.float32(0.1),
             "order": 2,
             "wrap": False,
         },
@@ -1233,7 +1233,7 @@ def test_check_against_system_drivers_rejects_wrong_count(system, precision):
     """A driver-count mismatch raises ValueError."""
     with pytest.raises(ValueError, match="does not match number of"):
         ArrayInterpolator.check_against_system_drivers(
-            {"d_a": np.zeros(4, dtype=precision), "dt": precision(0.1)},
+            {"d_a": np.zeros(4, dtype=precision), "driver_sample_period": precision(0.1)},
             system,
         )
 
@@ -1252,7 +1252,7 @@ def test_check_against_system_drivers_rejects_wrong_symbols(
             {
                 "d_a": np.zeros(4, dtype=precision),
                 "not_a_driver": np.zeros(4, dtype=precision),
-                "dt": precision(0.1),
+                "driver_sample_period": precision(0.1),
             },
             system,
         )
@@ -1271,7 +1271,7 @@ def test_periodic_boundary_requires_wrap(precision):
             precision=precision,
             input_dict={
                 "values": np.arange(6, dtype=precision),
-                "dt": precision(0.1),
+                "driver_sample_period": precision(0.1),
                 "wrap": False,
                 "boundary_condition": "periodic",
             },
@@ -1289,7 +1289,7 @@ def test_periodic_boundary_requires_matching_endpoints(precision):
             precision=precision,
             input_dict={
                 "values": values,
-                "dt": precision(0.1),
+                "driver_sample_period": precision(0.1),
                 "wrap": True,
             },
         )


### PR DESCRIPTION
Replaces the rename chunk of #666, split out per the review there. Base of
the five-PR stack that supersedes #666
(rename -> cache policy -> immutable snapshots -> helper registry ->
solver width).

## What it does
The interpolator's sample-spacing key and config field are
`driver_sample_period` end to end: driver input dicts, the parser's
`DRIVER_SETTING_KEYS`, `ArrayInterpolatorConfig`, the interpolator
property, error messages, docs, benchmarks, and tests. `dt` names only the
integrator timestep, so a driver dict key can never collide with a solver
timestep kwarg. Breaking rename, no aliases kept (exact-keys rule).

## Verification
- Full CUDASIM suite: 3066 passed, 0 failed.
- Full real-GPU suite: 3142 passed, 0 failed.
- flake8 (E9,F63,F7,F82): clean.
- A/B performance gate vs origin/main: running; table to follow in a
  comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
