### PR TITLE
fix(fleet): a leg with no archived job log renders and prices

### DIFF
--- a/infra/fleet/README.md
+++ b/infra/fleet/README.md
@@ -167,7 +167,7 @@ embeds in each runner name (`runs-on--i-<id>--...`): the GitHub Actions
 Jobs API (step timings), each leg's `Set up job` log (RunsOn boot
 timeline, instance type/AZ, launch time), and AWS via the `cubie-fleet`
 profile — `ec2:DescribeSpotPriceHistory` (achieved spot rate),
-`cloudtrail:LookupEvents` (instance terminate time), and Cost Explorer
+`cloudtrail:LookupEvents` (instance launch and terminate), and Cost Explorer
 (`ce:GetCostAndUsage`) for the account panels. The last two are the
 read-only grants the bootstrap policy's `ReadOnly` / `CostExplorerReadOnly`
 statements add.
@@ -240,6 +240,19 @@ headers. ECharts remains CDN-hosted, but its exact bytes are pinned with
 Subresource Integrity and `crossorigin="anonymous"`; all dashboard
 JavaScript is served locally. Missing spot-price or termination telemetry
 is shown as incomplete and is never converted to a zero-cost leg.
+
+A runner that dies mid-step takes its job log with it: GitHub marks the
+job failed, leaves the running step with no end time, and answers the job
+log endpoint with 404 forever. Such a leg no longer fails the whole run
+view. Its CloudTrail `RunInstances` event supplies the instance type, AZ
+and platform the log banner would have, so it still prices, and billing
+runs from the instance launch. Its steps band extends to the job's end
+rather than to its last completed step, because the runner was still
+working. The leg is labelled `(no log)` on the timeline and step axes,
+its RunsOn queue wait stays unknown rather than zero, and the unfinished
+step contributes no duration to the per-step totals. A 404 is never
+cached, so a log archived moments after a job completes is still picked
+up.
 
 Requirements: `gh` authenticated to the repo and the `cubie-fleet` AWS
 profile; the pinned ECharts asset needs browser internet access. The AWS

--- a/infra/fleet/cost_dashboard.js
+++ b/infra/fleet/cost_dashboard.js
@@ -45,6 +45,12 @@ function mins(seconds) {
   return seconds == null ? null : seconds / 60;
 }
 
+// A leg whose runner died mid-step has no archived log, so its instance
+// type, spot price and queue wait are unknown rather than absent.
+function legLabel(leg) {
+  return leg.log_known === false ? `${leg.label} (no log)` : leg.label;
+}
+
 function renderSharedLegend(id, entries) {
   const legend = document.getElementById(id);
   legend.replaceChildren();
@@ -108,7 +114,7 @@ const TOKEN_HEADER = 'X-Cubie-Dashboard-Token';
 
 function renderGantt(payload) {
   const legs = payload.legs;
-  const categories = legs.map(leg => leg.label);
+  const categories = legs.map(legLabel);
   const offsets = legs.map(leg => mins(leg.offset_s));
   const makeSeries = (name, key, color) => ({
     name,
@@ -239,7 +245,7 @@ function renderSteps(payload) {
     },
     xAxis: {
       type: 'category',
-      data: legs.map(leg => leg.label),
+      data: legs.map(legLabel),
       axisLabel: {rotate: 40, fontSize: 10, interval: 0}
     },
     yAxis: {type: 'value', name: 'minutes'},
@@ -425,8 +431,13 @@ function renderRun(payload) {
       `${missing} leg${missing === 1 ? '' : 's'} missing spot price ` +
       'or termination telemetry'
     : `compute cost $${knownCost.toFixed(3)}`;
+  const logless = payload.legs.filter(leg => leg.log_known === false).length;
+  const logText = logless
+    ? ` · ${logless} leg${logless === 1 ? '' : 's'} left no archived log ` +
+      '(runner lost mid-step)'
+    : '';
   document.getElementById('runMeta').textContent =
-    `${title} · ${payload.legs.length} GPU legs · ${costText}`;
+    `${title} · ${payload.legs.length} GPU legs · ${costText}${logText}`;
   renderGantt(payload);
   renderGanttAggregate(payload);
   renderSteps(payload);

--- a/infra/fleet/cost_dashboard.js
+++ b/infra/fleet/cost_dashboard.js
@@ -45,8 +45,8 @@ function mins(seconds) {
   return seconds == null ? null : seconds / 60;
 }
 
-// A leg whose runner died mid-step has no archived log, so its instance
-// type, spot price and queue wait are unknown rather than absent.
+// A leg whose runner died mid-step has no archived log; instance type
+// and spot price are recovered from CloudTrail, but queue wait is not.
 function legLabel(leg) {
   return leg.log_known === false ? `${leg.label} (no log)` : leg.label;
 }

--- a/infra/fleet/cost_dashboard.py
+++ b/infra/fleet/cost_dashboard.py
@@ -24,7 +24,10 @@ fetch bypasses the automatic trigger, with its own five-minute limit.
 The loopback server validates Host and Origin, requires a per-process
 token for API requests, accepts paid force refreshes only by POST, and
 serves a restrictive security policy. Missing run-cost telemetry remains
-unknown throughout the API and UI rather than being coerced to zero.
+unknown throughout the API and UI rather than being coerced to zero. A
+leg whose runner died mid-step never gets an archived job log; it prices
+from its CloudTrail launch record instead, and reports its queue wait as
+unknown.
 
 Run:  python infra/fleet/cost_dashboard.py   (opens http://localhost:8787)
 Needs: gh authenticated to the repo, the cubie-fleet AWS profile.
@@ -67,6 +70,8 @@ FORCE_RATE_LIMIT = timedelta(minutes=5)
 COST_EXPLORER_HOURLY_RETENTION = timedelta(days=14)
 ZERO_COST_CONFIRMATION_AGE = timedelta(hours=48)
 CONFIRMED_OVERLAP = timedelta(hours=12)
+LOG_ARCHIVE_GRACE = timedelta(minutes=5)
+LAUNCH_LOOKBACK = timedelta(hours=1)
 MAX_DAILY_RANGE_DAYS = 3660
 MAX_HOURLY_RANGE_DAYS = 366
 USAGE_SCHEMA_VERSION = 3
@@ -85,6 +90,17 @@ _CE_LOCK = threading.Lock()
 
 
 # ------------------------------------------------------------------ shells
+class GitHubError(RuntimeError):
+    """A failed gh invocation, carrying any HTTP status it reported."""
+
+    def __init__(self, message, status=None):
+        super().__init__(message)
+        self.status = status
+
+
+_GH_STATUS = re.compile(r"HTTP (\d{3})")
+
+
 def gh(*args):
     out = subprocess.run(
         ["gh", *args],
@@ -94,7 +110,14 @@ def gh(*args):
         env=_ENV,
     )
     if out.returncode != 0:
-        raise RuntimeError(f"gh {' '.join(args)} failed:\n{out.stderr}")
+        # gh reports a REST failure as either "gh: HTTP 404" or
+        # "gh: Not Found (HTTP 404)" depending on whether the response
+        # body was JSON; both carry the status in the same form.
+        status_match = _GH_STATUS.search(out.stderr)
+        raise GitHubError(
+            f"gh {' '.join(args)} failed:\n{out.stderr}",
+            int(status_match.group(1)) if status_match else None,
+        )
     return out.stdout
 
 
@@ -660,6 +683,13 @@ def fetch_legs(run_id):
                 "instance_id": m.group(1),
                 "job_start": ts(j["started_at"]),
                 "job_end": ts(j["completed_at"]),
+                # A step GitHub reports as started but never completed
+                # is one the runner was still running when it died, so
+                # the step list stops short of the job's own end.
+                "truncated": any(
+                    s["started_at"] and not s["completed_at"]
+                    for s in j["steps"]
+                ),
                 "steps": [
                     {
                         "name": s["name"],
@@ -681,12 +711,23 @@ def fetch_legs(run_id):
 
 
 def fetch_log(job_id):
+    """Return a job's archived log, or None when GitHub has none.
+
+    A runner that dies mid-step leaves its job marked failed with no log
+    blob ever written, and the endpoint answers 404 forever. The absence
+    is never cached: a log archived moments after a job completes would
+    otherwise stay missing for the life of the process.
+    """
     cache = CACHE_DIR / "logs" / f"job-{job_id}.log"
     if cache.exists():
         return cache.read_text(encoding="utf-8", errors="replace")
-    text = gh("api", f"repos/{REPO}/actions/jobs/{job_id}/logs").replace(
-        "\r", ""
-    )
+    try:
+        text = gh("api", f"repos/{REPO}/actions/jobs/{job_id}/logs")
+    except GitHubError as exc:
+        if exc.status == 404:
+            return None
+        raise
+    text = text.replace("\r", "")
     cache.parent.mkdir(parents=True, exist_ok=True)
     cache.write_text(text, encoding="utf-8")
     return text
@@ -701,6 +742,20 @@ _PHASE = re.compile(r"│ (\d{4}-\d\d-\d\dT[\d:]+Z) │ ([a-z0-9-]+)\s+│ (\d+)
 
 
 def parse_log(text):
+    """Return the RunsOn banner and phase fields a job log carries.
+
+    With no log at all every field is unknown, including the queue wait:
+    a log that omits the instance-pending phase reports a warm instance
+    that waited zero, which a missing log cannot claim.
+    """
+    if text is None:
+        return {
+            **{key: None for key in _BANNER},
+            "job_scheduled": None,
+            "running_start": None,
+            "wait_ms": None,
+            "log_known": False,
+        }
     info = {
         k: (m.group(1) if (m := rx.search(text)) else None)
         for k, rx in _BANNER.items()
@@ -712,6 +767,7 @@ def parse_log(text):
         info["running_start"], info["wait_ms"] = by["instance-pending"]
     else:
         info["running_start"], info["wait_ms"] = None, 0
+    info["log_known"] = True
     return info
 
 
@@ -744,7 +800,36 @@ def spot_price(itype, az, at, platform):
     return price if price is not None else float(hist[-1]["SpotPrice"])
 
 
-def terminate_time(iid, after):
+def _launch_details(event, iid):
+    """Return the launch fields a RunInstances event records for iid."""
+    # A RunInstances call that failed records a null responseElements,
+    # so every level here can legitimately be absent or null.
+    detail = json.loads(event["CloudTrailEvent"])
+    response = detail.get("responseElements") or {}
+    items = (response.get("instancesSet") or {}).get("items") or []
+    for item in items:
+        if item.get("instanceId") != iid:
+            continue
+        return {
+            "instance_type": item.get("instanceType"),
+            "az": (item.get("placement") or {}).get("availabilityZone"),
+            # CloudTrail reports "windows" and omits the field for
+            # Linux, matching the RunsOn banner's Platform values.
+            "platform": item.get("platform"),
+            "launched_at": ts(event["EventTime"]),
+        }
+    return None
+
+
+def instance_history(iid, around):
+    """Return one instance's launch record and termination time.
+
+    The RunInstances event carries the instance type, availability zone
+    and platform that the RunsOn log banner also reports, so a leg whose
+    runner died before its log was archived still prices. Launch always
+    precedes the anchor, so the widened window adds no termination event
+    that the anchored window would not already have returned first.
+    """
     ok, res = aws(
         "cloudtrail",
         "lookup-events",
@@ -753,16 +838,24 @@ def terminate_time(iid, after):
         "--lookup-attributes",
         f"AttributeKey=ResourceName,AttributeValue={iid}",
         "--start-time",
-        after.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        (around - LAUNCH_LOOKBACK).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "--end-time",
-        (after + timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        (around + timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%SZ"),
     )
     if not ok:
-        return None
+        return None, None
+    launch = None
+    termination = None
     for ev in res.get("Events", []):
-        if ev["EventName"] in ("TerminateInstances", "BidEvictedEvent"):
-            return ts(ev["EventTime"])
-    return None
+        name = ev["EventName"]
+        if termination is None and name in (
+            "TerminateInstances",
+            "BidEvictedEvent",
+        ):
+            termination = ts(ev["EventTime"])
+        elif launch is None and name == "RunInstances":
+            launch = _launch_details(ev, iid)
+    return launch, termination
 
 
 # ----------------------------------------------------------------- derive
@@ -778,16 +871,37 @@ def _billing_values(run_start, termination, price):
 def _enrich_leg(leg):
     log = parse_log(fetch_log(leg["job_id"]))
     leg.update(log)
-    run_start = log["running_start"] or leg["job_start"]
-    term = terminate_time(leg["instance_id"], run_start)
+    anchor = log["running_start"] or leg["job_start"]
+    launch, term = instance_history(leg["instance_id"], anchor)
+    launch = launch or {}
+    # The log is authoritative where it exists; the launch record only
+    # ever adds identity the banner left out.
+    for field in ("instance_type", "az", "platform"):
+        leg[field] = log[field] or launch.get(field)
+    if log["log_known"]:
+        # A log without an instance-pending phase reports a warm
+        # instance, whose launch long predates this job and must not be
+        # billed to it.
+        run_start = log["running_start"] or leg["job_start"]
+    else:
+        run_start = launch.get("launched_at") or leg["job_start"]
     price = (
-        spot_price(log["instance_type"], log["az"], run_start, log["platform"])
-        if log["instance_type"] and log["az"]
+        spot_price(
+            leg["instance_type"], leg["az"], run_start, leg["platform"]
+        )
+        if leg["instance_type"] and leg["az"]
         else None
     )
     dur_h, cost = _billing_values(run_start, term, price)
     first = leg["steps"][0]["start"] if leg["steps"] else run_start
-    last = leg["steps"][-1]["end"] if leg["steps"] else leg["job_end"]
+    # Work on a truncated leg ran until the job ended; drawing that time
+    # as shutdown would attribute a live runner's last minutes to a
+    # teardown that never happened.
+    last = (
+        leg["steps"][-1]["end"]
+        if leg["steps"] and not leg["truncated"]
+        else leg["job_end"]
+    )
     merged = {}
     for s in leg["steps"]:
         nm = _step_name(s["name"])
@@ -806,10 +920,13 @@ def _enrich_leg(leg):
             if term is not None
             else None
         ),
-        "wait_s": (log["wait_ms"] or 0) / 1000,
+        "wait_s": (
+            None if log["wait_ms"] is None else log["wait_ms"] / 1000
+        ),
         "step_durs": merged,
         "termination_known": term is not None,
         "price_known": price is not None,
+        "log_known": log["log_known"],
     }
     return leg
 
@@ -829,6 +946,14 @@ def run_payload(run_id, store=None, now=None):
     legs, settled = fetch_legs(run_id)
     with ThreadPoolExecutor(max_workers=8) as ex:
         list(ex.map(_enrich_leg, legs))
+    # A log absent within moments of the job finishing is still being
+    # archived; only an older absence is the permanent one a dead runner
+    # leaves behind, and only that is safe to memoize.
+    settled = settled and all(
+        leg["_derived"]["log_known"]
+        or current - leg["job_end"] >= LOG_ARCHIVE_GRACE
+        for leg in legs
+    )
     legs.sort(key=lambda leg: leg["_derived"]["run_start"])
     t0 = min(
         (leg["job_scheduled"] or leg["_derived"]["run_start"] for leg in legs),
@@ -859,6 +984,7 @@ def run_payload(run_id, store=None, now=None):
                 "shutdown_s": d["shutdown_s"],
                 "termination_known": d["termination_known"],
                 "price_known": d["price_known"],
+                "log_known": d["log_known"],
                 "offset_s": (
                     (leg["job_scheduled"] or d["run_start"]) - t0
                 ).total_seconds(),


### PR DESCRIPTION
## What broke

Selecting run 30113911584 in the dashboard failed the whole run view with

```
error: gh api repos/cubiepy/cubie/actions/jobs/89557193132/logs failed: gh: HTTP 404
```

Job 89557193132 (`cuda (windows, 3.10, 13, numba-cuda)`) is a leg whose
runner died during `Test with pytest`. GitHub reports the job as
`completed`/`failure` with that step still `in_progress`, and the log
endpoint answers `BlobNotFound` — no log was ever archived, and none
ever will be. `fetch_log` raised that 404 out of `_enrich_leg`, so one
dead runner took all 16 legs of the run with it. Two of the thirteen
runs currently in the seven-day window are affected (30113911584 with
one such leg, 29732087244 with three).

## The fix

`fetch_log` returns `None` on 404 rather than raising, and never caches
the absence — a log archived moments after a job completes is still
picked up on the next view. A run holding a leg whose log is younger
than `LOG_ARCHIVE_GRACE` is not memoized, so only a permanently missing
log is treated as settled. `parse_log` reports every field of a missing
log as unknown, the queue wait included: a log without an
`instance-pending` phase reports a warm instance that genuinely waited
zero, which a missing log cannot claim.

## The leg still prices

Reporting the dead leg's cost as unknown would understate the run — it
is a real instance that was really billed. One CloudTrail lookup per
leg now returns the instance's `RunInstances` record alongside its
termination (same free `cloudtrail:LookupEvents` call, window widened
backwards by an hour to reach the launch). That record carries the
instance type, availability zone and platform the RunsOn log banner
would have supplied, so the leg prices from the spot history as usual,
and its billing runs from the instance launch rather than from the
later first job step.

The log stays authoritative wherever it exists; the launch record only
fills fields the banner left out, and a logged leg without an
`instance-pending` phase keeps using its job start (that instance was
warm, and its launch must not be billed to this job).

A truncated leg — one with a step GitHub reports as started and never
completed — draws its steps band to the job's end instead of to its
last completed step, because the runner was still working. The
unfinished step contributes no duration of its own, so the per-step
totals stay comparable across legs.

The UI marks the leg `(no log)` on the timeline and step axes and names
the condition in the run summary.

## Verification

No mocks: everything below is the real GitHub and AWS data.

Payload for run 30113911584 diffed leg-by-leg against the same payload
built from `origin/main` — **all 15 logged legs bit-identical**, only
the dead leg changed:

| field | before | after |
|---|---|---|
| type / az | `None` | `g4dn.xlarge` / `ap-southeast-2a` |
| price | `None` | `0.292` |
| cost | `None` | `$0.0818` |
| billed_hours | 0.2508 | 0.2803 |
| boot_s | 2.0 | 108.0 |
| steps_s | 241.0 | 900.0 |
| shutdown_s | 660.0 | 1.0 |
| wait_s | 0.0 | `null` (unknown) |

The new values reconcile exactly with CloudTrail: `RunInstances`
18:41:40Z → first step 18:43:28Z (boot 108 s) → job end 18:58:28Z
(steps 900 s) → `TerminateInstances` 18:58:29Z (shutdown 1 s, billed
16 m 49 s).

All 13 qualified runs in the seven-day window build a payload without
error, and **every leg in every run is priced**, including all four
logless legs across the two affected runs.

Served end to end (`GET /`, `/api/runs`, `/api/run?id=30113911584` →
200) and rendered in Chrome: run summary reads
`CUDA tests · 16 GPU legs · compute cost $0.886 · 1 leg left no
archived log (runner lost mid-step)`, the leg appears as
`… numba-cuda (no log)`, and the per-instance-type panel now has the
`g4dn.xlarge` column that leg alone contributes. No console errors.

`ruff check` and `flake8` clean on `cost_dashboard.py`; `node --check`
clean on `cost_dashboard.js`.

**No A/B performance gate.** The diff touches only `infra/fleet/`; no
package source changes, so the gate measures nothing here and was
waived for this PR.

**No regression test is included.** Every path here is defined by what
`gh` and `aws` return, so a unit test would have to stub those
subprocesses, and `CLAUDE.md` allows mocks and patches only with an
explicit exception from you. Say the word and I will add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
