### PR TITLE
test: cut wasted work from long-run tests.

### DIFF
--- a/tests/batchsolving/test_solver_teardown.py
+++ b/tests/batchsolving/test_solver_teardown.py
@@ -332,11 +332,8 @@ def test_repeated_solvers_do_not_grow_registry(
     gc.collect()
     baseline = len(manager.registry)
 
-    # Three iterations: the second is where a construction first has a
-    # predecessor to reclaim, and the third repeats that steady state
-    # once. Registry, pool and pending-teardown counts are already flat
-    # from the first iteration, so further repeats cost a build and a
-    # solve each without reaching any state the third has not.
+    # Three iterations: enough to reach and repeat steady-state
+    # reclamation.
     for _ in range(3):
         solver = Solver(
             system, algorithm="euler", dt=0.01, memory_manager=manager

--- a/tests/batchsolving/test_solver_teardown.py
+++ b/tests/batchsolving/test_solver_teardown.py
@@ -332,7 +332,12 @@ def test_repeated_solvers_do_not_grow_registry(
     gc.collect()
     baseline = len(manager.registry)
 
-    for _ in range(6):
+    # Three iterations: the second is where a construction first has a
+    # predecessor to reclaim, and the third repeats that steady state
+    # once. Registry, pool and pending-teardown counts are already flat
+    # from the first iteration, so further repeats cost a build and a
+    # solve each without reaching any state the third has not.
+    for _ in range(3):
         solver = Solver(
             system, algorithm="euler", dt=0.01, memory_manager=manager
         )

--- a/tests/odesystems/symbolic/test_neumann_convergence.py
+++ b/tests/odesystems/symbolic/test_neumann_convergence.py
@@ -127,28 +127,42 @@ def test_get_solver_helper_runs_diagnostic_for_neumann_type(system):
         )
 
 
-def _seed_kernel_cache(*target_dirs):
-    """Copy the shared kernel-cache artifact into per-test dirs.
+def _seed_kernel_cache(system_name, *target_dirs):
+    """Seed per-test cache dirs with one system's cached kernels.
 
     A per-test cache directory starts empty, so a diagnostic launch
     in the CI consumer leg would cold-compile there and trip the
-    zero-compile gate. Each directory receives a private copy of the
-    environment kernel cache: isolation between the directories is
-    preserved while their kernels load instead of compiling. Without
-    the environment cache the directories stay empty and launches
+    zero-compile gate. Each directory gets its own copy of the
+    entries for ``system_name``, so the directories stay isolated
+    while their kernels load instead of compiling. Without the
+    environment cache the directories stay empty and launches
     compile as usual.
+
+    Only that system's entries are copied. ``CUBIECache`` names every
+    file ``<system name>-<config hash>``, and the whole artifact is
+    the entire suite's kernels for every system and, on CI, every
+    compute capability: seeding all of it moved 56 MB per directory
+    locally and several times that on a CI runner, against the 44 kB
+    this test's system actually needs.
     """
     shared = os.environ.get("CUBIE_KERNEL_CACHE_DIR", "").strip()
     if not shared or not Path(shared).is_dir():
         return
+    source_root = Path(shared)
     # Lock files are live inter-process state, not cache content:
-    # another worker may hold a byte-range lock that makes the copy
-    # raise on Windows.
-    skip_locks = shutil.ignore_patterns("*.lock")
+    # another worker may hold a byte-range lock that makes reading
+    # them raise on Windows.
+    sources = [
+        path
+        for path in source_root.rglob(f"{system_name}-*")
+        if path.is_file() and path.suffix != ".lock"
+    ]
     for target in target_dirs:
-        shutil.copytree(
-            shared, target, dirs_exist_ok=True, ignore=skip_locks
-        )
+        target_root = Path(target)
+        for source in sources:
+            destination = target_root / source.relative_to(source_root)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, destination)
 
 
 @pytest.mark.parametrize(
@@ -164,7 +178,9 @@ def test_kernel_cache_policies_stay_isolated(system, tmp_path):
     """
     dir_a = tmp_path / "kernel_a"
     dir_b = tmp_path / "kernel_b"
-    _seed_kernel_cache(dir_a, dir_b, tmp_path / "kernel_a_moved")
+    _seed_kernel_cache(
+        system.name, dir_a, dir_b, tmp_path / "kernel_a_moved"
+    )
     kernel_a = BatchSolverKernel(
         system,
         algorithm_settings={"algorithm": "euler"},

--- a/tests/odesystems/symbolic/test_neumann_convergence.py
+++ b/tests/odesystems/symbolic/test_neumann_convergence.py
@@ -128,22 +128,10 @@ def test_get_solver_helper_runs_diagnostic_for_neumann_type(system):
 
 
 def _seed_kernel_cache(system_name, *target_dirs):
-    """Seed per-test cache dirs with one system's cached kernels.
+    """Copy cached kernels for *system_name* into each target dir.
 
-    A per-test cache directory starts empty, so a diagnostic launch
-    in the CI consumer leg would cold-compile there and trip the
-    zero-compile gate. Each directory gets its own copy of the
-    entries for ``system_name``, so the directories stay isolated
-    while their kernels load instead of compiling. Without the
-    environment cache the directories stay empty and launches
-    compile as usual.
-
-    Only that system's entries are copied. ``CUBIECache`` names every
-    file ``<system name>-<config hash>``, and the whole artifact is
-    the entire suite's kernels for every system and, on CI, every
-    compute capability: seeding all of it moved 56 MB per directory
-    locally and several times that on a CI runner, against the 44 kB
-    this test's system actually needs.
+    Only that system's entries are copied (matched by filename
+    prefix) so the directories stay small and isolated.
     """
     shared = os.environ.get("CUBIE_KERNEL_CACHE_DIR", "").strip()
     if not shared or not Path(shared).is_dir():

--- a/tests/odesystems/symbolic/test_sym_utils.py
+++ b/tests/odesystems/symbolic/test_sym_utils.py
@@ -1,9 +1,13 @@
+import os
+import subprocess
+import sys
 import textwrap
 import warnings
 
 import pytest
 import sympy as sp
 
+from cubie.odesystems.symbolic import sym_utils
 from cubie.odesystems.symbolic.sym_utils import (
     cse_and_stack,
     hash_system_definition,
@@ -31,34 +35,62 @@ class TestTopologicalSort:
     def test_topological_sort_order_hash_seed_independent(self):
         """Sibling assignments emit in a fixed order regardless of
         the process hash seed (generated code must be identical
-        across processes)."""
-        import subprocess
-        import sys
+        across processes).
 
+        The two seeds run concurrently, and each interpreter loads
+        ``sym_utils`` from its file instead of through ``import
+        cubie``: the package __init__ pulls in the CUDA backend and
+        the batchsolving stack (~2.4 s per interpreter) and the sort
+        order does not depend on any of it. ``sym_utils`` imports
+        nothing from its own package at runtime, so the file load
+        runs the same module; if that ever stops being true this
+        raises ImportError rather than passing quietly.
+        """
         script = (
+            "import importlib.util, sys;"
             "import sympy as sp;"
-            "from cubie.odesystems.symbolic.sym_utils import"
-            " topological_sort;"
+            "spec = importlib.util.spec_from_file_location("
+            "'sym_utils', sys.argv[1]);"
+            "module = importlib.util.module_from_spec(spec);"
+            "spec.loader.exec_module(module);"
             "a, b, c, d = sp.symbols('alpha beta gamma delta');"
-            "result = topological_sort("
+            "result = module.topological_sort("
             "[(b, a + 1), (c, a * 2), (d, a - 3),"
             " (a, sp.Integer(1))]);"
             "print([str(lhs) for lhs, _ in result])"
         )
-        orders = set()
-        for seed in ("1", "77"):
-            out = subprocess.run(
-                [sys.executable, "-c", script],
-                capture_output=True,
+        processes = [
+            subprocess.Popen(
+                [sys.executable, "-c", script, sym_utils.__file__],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                env={
-                    **__import__("os").environ,
-                    "PYTHONHASHSEED": seed,
-                },
-                check=True,
+                env={**os.environ, "PYTHONHASHSEED": seed},
             )
-            orders.add(out.stdout.strip())
-        assert len(orders) == 1
+            for seed in ("1", "77")
+        ]
+        a, b, c, d = sp.symbols("alpha beta gamma delta")
+        expected = str(
+            [
+                str(lhs)
+                for lhs, _ in topological_sort(
+                    [
+                        (b, a + 1),
+                        (c, a * 2),
+                        (d, a - 3),
+                        (a, sp.Integer(1)),
+                    ]
+                )
+            ]
+        )
+        orders = set()
+        for process in processes:
+            stdout, stderr = process.communicate()
+            assert process.returncode == 0, stderr
+            orders.add(stdout.strip())
+        # Comparing against this process's order, not just against
+        # each other, proves each subprocess actually ran the sort.
+        assert orders == {expected}
 
 
     def test_topological_sort_dict_input(self):

--- a/tests/odesystems/symbolic/test_sym_utils.py
+++ b/tests/odesystems/symbolic/test_sym_utils.py
@@ -37,14 +37,8 @@ class TestTopologicalSort:
         the process hash seed (generated code must be identical
         across processes).
 
-        The two seeds run concurrently, and each interpreter loads
-        ``sym_utils`` from its file instead of through ``import
-        cubie``: the package __init__ pulls in the CUDA backend and
-        the batchsolving stack (~2.4 s per interpreter) and the sort
-        order does not depend on any of it. ``sym_utils`` imports
-        nothing from its own package at runtime, so the file load
-        runs the same module; if that ever stops being true this
-        raises ImportError rather than passing quietly.
+        Each interpreter loads ``sym_utils`` directly from file to
+        avoid the full package import.
         """
         script = (
             "import importlib.util, sys;"

--- a/tests/test_array_interpolator.py
+++ b/tests/test_array_interpolator.py
@@ -4,6 +4,8 @@ from typing import Tuple
 
 import numpy as np
 import pytest
+from scipy.interpolate import CubicSpline
+
 from cubie.odesystems.solver_helpers import SolverHelperRequest
 from cubie.cuda_simsafe import cuda
 
@@ -712,7 +714,6 @@ def test_polynomial_samples_are_reproduced(order, precision, tolerance) -> None:
 def test_order_three_matches_scipy_reference(precision, bc, tolerance) -> None:
     """Order-three interpolation should match SciPy's cubic spline."""
 
-    scipy = pytest.importorskip("scipy.interpolate")
     rng = np.random.default_rng(1234)
     times = np.linspace(0.0, 2.0, 21, dtype=precision)
     samples = np.sin(2.3 * times) + 0.3 * np.cos(4.1 * times)
@@ -739,7 +740,7 @@ def test_order_three_matches_scipy_reference(precision, bc, tolerance) -> None:
         dt = np.diff(times)[0]
         scipy_samples = np.hstack([precision(0), samples, precision(0)])
         scipy_times = np.hstack([times[0] - dt, times, times[-1] + dt])
-    spline = scipy.CubicSpline(scipy_times, scipy_samples, bc_type=bc)
+    spline = CubicSpline(scipy_times, scipy_samples, bc_type=bc)
     scipy_values = np.asarray(spline(query), dtype=precision)
 
     np.testing.assert_allclose(

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -144,13 +144,7 @@ def test_digest_carries_schema_version():
     assert canonical_digest((1, "x")) == expected
 
 
-# The serializer module is loaded from its file rather than through
-# ``import cubie``: the package __init__ pulls in the CUDA backend and
-# the whole batchsolving stack (~2.4 s per interpreter), none of which
-# the encoding depends on. ``cubie._serialize`` imports nothing from
-# its own package, so a file load runs the same module object; if that
-# ever stops being true this raises ImportError rather than passing
-# quietly.
+# Load _serialize directly from file to avoid the full package import.
 _SUBPROCESS_SNIPPET = """
 import importlib.util
 import sys

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -8,6 +8,7 @@ import attrs
 import numpy as np
 import pytest
 
+from cubie import _serialize
 from cubie._serialize import (
     SCHEMA_VERSION,
     canonical_bytes,
@@ -143,9 +144,22 @@ def test_digest_carries_schema_version():
     assert canonical_digest((1, "x")) == expected
 
 
+# The serializer module is loaded from its file rather than through
+# ``import cubie``: the package __init__ pulls in the CUDA backend and
+# the whole batchsolving stack (~2.4 s per interpreter), none of which
+# the encoding depends on. ``cubie._serialize`` imports nothing from
+# its own package, so a file load runs the same module object; if that
+# ever stops being true this raises ImportError rather than passing
+# quietly.
 _SUBPROCESS_SNIPPET = """
+import importlib.util
+import sys
+
 import numpy as np
-from cubie._serialize import canonical_digest
+
+spec = importlib.util.spec_from_file_location("_serialize", sys.argv[1])
+serialize = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(serialize)
 value = (
     "stability-fixture",
     1,
@@ -155,20 +169,37 @@ value = (
     np.arange(4, dtype=np.float64),
     ("nested", (None, True)),
 )
-print(canonical_digest(value))
+print(serialize.canonical_digest(value))
 """
 
 
-def _digest_in_subprocess(cwd):
-    """Run the fixture digest in a fresh interpreter at ``cwd``."""
-    result = subprocess.run(
-        [sys.executable, "-c", _SUBPROCESS_SNIPPET],
-        capture_output=True,
-        text=True,
-        cwd=str(cwd),
-        check=True,
-    )
-    return result.stdout.strip()
+def _digests_in_subprocesses(cwds):
+    """Run the fixture digest in one fresh interpreter per cwd.
+
+    The interpreters run concurrently, so the test costs one
+    interpreter startup rather than one per root.
+    """
+    processes = [
+        subprocess.Popen(
+            [sys.executable, "-c", _SUBPROCESS_SNIPPET, _serialize.__file__],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=str(cwd),
+        )
+        for cwd in cwds
+    ]
+    digests = []
+    for process in processes:
+        stdout, stderr = process.communicate()
+        if process.returncode != 0:
+            raise AssertionError(
+                "digest subprocess exited {0}: {1}".format(
+                    process.returncode, stderr
+                )
+            )
+        digests.append(stdout.strip())
+    return digests
 
 
 def test_digest_stable_across_processes_and_roots(tmp_path):
@@ -182,7 +213,6 @@ def test_digest_stable_across_processes_and_roots(tmp_path):
     root_b = tmp_path / "deeper" / "checkout_b"
     root_a.mkdir(parents=True)
     root_b.mkdir(parents=True)
-    digest_a = _digest_in_subprocess(root_a)
-    digest_b = _digest_in_subprocess(root_b)
+    digest_a, digest_b = _digests_in_subprocesses((root_a, root_b))
     assert digest_a == digest_b
     assert len(digest_a) == 64


### PR DESCRIPTION
Five tests spent most of their runtime on setup incidental to what
they assert. Test files only; nothing under `src/` changes.

## `tests/odesystems/symbolic/test_sym_utils.py`

`test_topological_sort_order_hash_seed_independent` ran its two
`PYTHONHASHSEED` interpreters one after the other, and each reached
`topological_sort` through `import cubie`. The two interpreters now
start concurrently, and each loads `sym_utils` through
`importlib.util.spec_from_file_location` on the path the parent
passes. The module imports only stdlib and SymPy at runtime, so the
child executes the same module object; if that ever stops holding,
the child raises `ImportError` and the test fails.

The assertion was `len(orders) == 1`, which two empty outputs
satisfy. It now compares both children against the order the test
process computes, which does not pin a particular ordering.

## `tests/test_serialize.py`

`test_digest_stable_across_processes_and_roots` ran its two
interpreters one after the other for the same reason.
`_digest_in_subprocess` becomes `_digests_in_subprocesses`, starting
one process per root concurrently, and the snippet loads
`cubie._serialize` from the path the parent passes. That module
imports only stdlib, attrs and NumPy. A non-zero exit raises with the
child's stderr.

## `tests/batchsolving/test_solver_teardown.py`

`test_repeated_solvers_do_not_grow_registry` builds three solvers
rather than six. `MemoryManager._purge_dead_instances` drops every
dead entry in one unconditional pass with no threshold or window, and
`registry`, `_auto_pool`, `_manual_pool` and `_pending_teardowns` are
already steady after the first iteration. The second iteration is
where a construction first has a predecessor to reclaim; the third
repeats that steady state.

## `tests/test_array_interpolator.py`

`test_order_three_matches_scipy_reference` called
`pytest.importorskip("scipy.interpolate")` in the test body, so
whichever of its four parametrisations ran first absorbed the import
for the other three. SciPy is now imported at module scope. It is a
plain import: SciPy is a declared dev dependency in `pyproject.toml`,
and `src/cubie/AGENTS.md` requires a missing package to fail rather
than skip.

## `tests/odesystems/symbolic/test_neumann_convergence.py`

`_seed_kernel_cache` copied the whole `CUBIE_KERNEL_CACHE_DIR` into
each of `test_kernel_cache_policies_stay_isolated`'s three cache
directories — the entire suite's kernels, for every compute
capability the leg precompiled. It now copies only the entries for
the system under test. `CUBIECache` names every file
`<system name>-<config hash>`, so the filter is exact: 3 files and
44 kB against 536 files and 56 MB per directory locally.

The seeding exists so the test's launches load instead of
cold-compiling and tripping the zero-compile gate, and it still does:
the test reports `cache_hits=3 compilations_completed=0`.

## Timings

Warm kernel cache, `-n4`:

| test | before | after |
|---|---:|---:|
| `test_topological_sort_order_hash_seed_independent` | 6.42 s | 0.67 s |
| `test_digest_stable_across_processes_and_roots` | 6.26 s | 0.24 s |
| `test_kernel_cache_policies_stay_isolated` | 4.23 s | 0.25 s |
| `test_repeated_solvers_do_not_grow_registry` | 3.19 s | 1.54 s |
| `test_order_three_matches_scipy_reference[*]`, first to run | 2.09 s | 0.02 s |

## Verification

- Real GPU, warm cache, `-n4`: 3201 passed, `KERNEL_CACHE
  cache_hits=779 compilations_completed=0`.
- Real GPU, no cache: 3201 passed in 111.88 s.
- CUDASIM, `-m "not nocudasim and not cupy and not specific_algos"`:
  3125 passed in 18.15 s.
- `flake8 . --count --select=E9,F63,F7,F82`: 0. No new flake8 finding
  in any touched file relative to `origin/main`.

## Performance gate

`python benchmarks/ab_gate.py --pairs 8`, A = `origin/main`
(c1ec9c19), B = working tree.

```
numba-cuda fixed     kernel  A    62.430  B    62.248   -0.22%  ok
numba-cuda fixed     wall    A    76.052  B    75.803   -0.16%  ok
numba-cuda adaptive  kernel  A    17.843  B    17.846   +0.05%  ok
numba-cuda adaptive  wall    A    22.084  B    22.082   +0.44%  ok
numba-cuda chunked   kernel  A    62.711  B    62.648   +0.02%  ok
numba-cuda chunked   wall    A    78.894  B    78.920   -0.14%  ok
numba-cuda wave      kernel  A    25.754  B    25.756   -0.03%  ok
numba-cuda wave      wall    A    28.570  B    28.684   +0.69%  ok
mlir       fixed     kernel  A    62.358  B    62.431   +0.17%  ok
mlir       fixed     wall    A    76.094  B    76.171   +0.19%  ok
mlir       adaptive  kernel  A    17.232  B    17.226   +0.03%  ok
mlir       adaptive  wall    A    21.620  B    21.651   +0.30%  ok
mlir       chunked   kernel  A    62.677  B    62.610   -0.21%  ok
mlir       chunked   wall    A    79.016  B    79.117   -0.16%  ok
mlir       wave      kernel  A    25.754  B    25.834   +0.00%  ok
mlir       wave      wall    A    28.577  B    28.690   +0.53%  ok

GATE: PASS (kernel threshold 0.50%, wall threshold 10.00%)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
