### PR TITLE
fix(mlir): fastmath codegen knobs reach the production LTO link

### DIFF
--- a/src/cubie/_mlir_compat.py
+++ b/src/cubie/_mlir_compat.py
@@ -97,12 +97,13 @@ branch ships in the wheel, and the fma-uplift shim strips the
 math-uplift-to-fma pass from the optimization pipeline so libnvvm
 owns floating-point contraction (the fork's
 perf-drop-math-uplift-to-fma branch). The LTO-link fastmath shim
-passes the ftz/fma/prec-div/prec-sqrt codegen knobs to the
-production kernel link: final code generation for LTO-IR inputs
-happens in nvJitLink, which applies precise-math defaults unless
-the link passes the knobs, so LTO cubins lost fastmath codegen
-while the ``get_lto_ptx()`` diagnostic linker carried it (the
-fork's fix-lto-link-fastmath-knobs branch).
+passes the per-flag fma/prec-div/prec-sqrt codegen knobs (and
+ftz under full ``fast``) to the production kernel link: final
+code generation for LTO-IR inputs happens in nvJitLink, which
+applies precise-math defaults unless the link passes the knobs,
+so LTO cubins lost fastmath codegen while the ``get_lto_ptx()``
+diagnostic linker carried it (the fork's
+fix-lto-link-fastmath-knobs branch).
 Remove the corresponding shim once each lands upstream. With the
 shared-memory shim in place CuBIE requests LTO-link optimization
 explicitly; set
@@ -2799,25 +2800,33 @@ register_fma_uplift_removal_shim()
 # ``=1`` only), so the rendered option list is rewritten
 # numerically as well. Mirrors the fork's
 # fix-lto-link-fastmath-knobs branch.
+#
+# The link-stage knobs deliberately bypass the standalone-ftz wrap:
+# ftz keys off full ``fast`` only, per the native per-flag mapping.
+# Under link-time ``-ftz=1`` the f32 arithmetic just takes its
+# same-throughput .FTZ opcode forms, but the f64->f32 narrowing of
+# the loop's time accumulator gains a guard sequence — a magnitude
+# compare on the 1/32-rate f64 pipe plus predicated
+# denormal-scaling and x1.0 flush multiplies — on the per-step
+# dependency chain: +24% kernel time on the gate's explicit RK4
+# config, knob-decomposed to ftz alone (fma/prec knobs: +-0%).
+# Production LTO cubins have never flushed denormals, so no
+# accuracy contract depends on it. The NVVM-stage wrap keeps
+# numba-cuda's module-knob behaviour for the non-LTO path, where
+# flushing is free.
 
 
 def _lto_link_fastmath_knobs(fastmath):
     """Return the LTO-link codegen knobs a fastmath value implies.
 
-    Resolved at link time through the ``numba_cuda_mlir.fastmath``
-    module attribute so wrappers installed later (the standalone-ftz
-    shim) are honoured; stock wheels without that module fall back
-    to this file's copy of the knob mapping.
+    Uses this file's per-flag mapping — never the standalone-ftz
+    wrap — so link-stage ftz is implied by full ``fast`` only. The
+    guard sequences link-time ftz=1 forces around f64->f32
+    narrowing cost 24% kernel time on the gate's explicit RK4
+    config; see the section comment.
     """
 
-    try:
-        from numba_cuda_mlir import fastmath as fastmath_module
-
-        return dict(
-            fastmath_module.nvvm_fastmath_options(fastmath or False)
-        )
-    except ImportError:
-        return _fastmath_nvvm_knobs(fastmath or False)
+    return _fastmath_nvvm_knobs(fastmath or False)
 
 
 _LTO_CODEGEN_BOOLEAN_OPTIONS = ("-ftz", "-prec-div", "-prec-sqrt", "-fma")

--- a/src/cubie/_mlir_compat.py
+++ b/src/cubie/_mlir_compat.py
@@ -81,7 +81,8 @@ fix-numpy-scalar-constants, fix-nested-tuple-dynamic-getitem,
 fix-integer-mod-floordiv-lowering, fix-dynamic-shared-memory-ub,
 fix-frozen-array-device-malloc, ssa-iterative-def-search,
 selective-fastmath, fix-float-minmax-lowering, fix-pow-zero-fold,
-ftz-standalone-flag, perf-drop-math-uplift-to-fma).
+ftz-standalone-flag, perf-drop-math-uplift-to-fma,
+fix-lto-link-fastmath-knobs).
 
 The iterative SSA def-search shim removes the RecursionError that
 large flattened kernels hit inside ``reconstruct_ssa``, and the
@@ -95,7 +96,13 @@ module-knob behaviour — until the fork's ftz-standalone-flag
 branch ships in the wheel, and the fma-uplift shim strips the
 math-uplift-to-fma pass from the optimization pipeline so libnvvm
 owns floating-point contraction (the fork's
-perf-drop-math-uplift-to-fma branch).
+perf-drop-math-uplift-to-fma branch). The LTO-link fastmath shim
+passes the ftz/fma/prec-div/prec-sqrt codegen knobs to the
+production kernel link: final code generation for LTO-IR inputs
+happens in nvJitLink, which applies precise-math defaults unless
+the link passes the knobs, so LTO cubins lost fastmath codegen
+while the ``get_lto_ptx()`` diagnostic linker carried it (the
+fork's fix-lto-link-fastmath-knobs branch).
 Remove the corresponding shim once each lands upstream. With the
 shared-memory shim in place CuBIE requests LTO-link optimization
 explicitly; set
@@ -2771,6 +2778,138 @@ def register_fma_uplift_removal_shim() -> None:
 
 
 register_fma_uplift_removal_shim()
+
+
+# ------------------------------------------------------------------ #
+# Fastmath knobs on the production LTO link                           #
+# ------------------------------------------------------------------ #
+# Final code generation for LTO-IR inputs happens in nvJitLink at
+# link time; the fastmath knobs handed to libnvvm only govern
+# LTO-IR generation, and nvJitLink applies its precise-math
+# defaults (ftz=0, prec-div=1, prec-sqrt=1) unless the link passes
+# ftz/fma/prec-div/prec-sqrt itself. The wheel passes them to the
+# get_lto_ptx() diagnostic linker but builds the production kernel
+# linker from _linker_config, which never carries them, so LTO
+# cubins revert to precise-math codegen. Knobs derive per flag
+# through nvvm_fastmath_options (picking up the standalone-ftz
+# wrap above) and are injected only when the link consumes LTO-IR
+# inputs — they are meaningless on a PTX-only link. cuda.core
+# renders the four knobs as ``-ftz=true``/``false``, which the
+# libnvvm parser inside nvJitLink rejects (it accepts ``=0``/
+# ``=1`` only), so the rendered option list is rewritten
+# numerically as well. Mirrors the fork's
+# fix-lto-link-fastmath-knobs branch.
+
+
+def _lto_link_fastmath_knobs(fastmath):
+    """Return the LTO-link codegen knobs a fastmath value implies.
+
+    Resolved at link time through the ``numba_cuda_mlir.fastmath``
+    module attribute so wrappers installed later (the standalone-ftz
+    shim) are honoured; stock wheels without that module fall back
+    to this file's copy of the knob mapping.
+    """
+
+    try:
+        from numba_cuda_mlir import fastmath as fastmath_module
+
+        return dict(
+            fastmath_module.nvvm_fastmath_options(fastmath or False)
+        )
+    except ImportError:
+        return _fastmath_nvvm_knobs(fastmath or False)
+
+
+_LTO_CODEGEN_BOOLEAN_OPTIONS = ("-ftz", "-prec-div", "-prec-sqrt", "-fma")
+
+
+def _render_lto_codegen_options_numeric(options):
+    """Rewrite boolean LTO codegen options to their numeric form."""
+
+    stock_prepare = options._prepare_nvjitlink_options
+
+    def prepare_numeric(as_bytes=False):
+        rendered = []
+        for opt in stock_prepare(as_bytes=False):
+            name, _, value = opt.partition("=")
+            if name in _LTO_CODEGEN_BOOLEAN_OPTIONS and value in (
+                "true",
+                "false",
+            ):
+                opt = f"{name}={1 if value == 'true' else 0}"
+            rendered.append(opt.encode() if as_bytes else opt)
+        return rendered
+
+    options._prepare_nvjitlink_options = prepare_numeric
+
+
+def register_lto_link_fastmath_shim() -> None:
+    """Pass fastmath codegen knobs to the production LTO link.
+
+    No-ops on builds whose ``_create_linker`` already derives the
+    knobs (the fork's fix-lto-link-fastmath-knobs branch, or a
+    release that merged it).
+    """
+
+    from numba_cuda_mlir.numba_cuda.cudadrv import driver as _ncm_driver
+
+    if not hasattr(_ncm_driver, "_render_lto_codegen_options_numeric"):
+        stock_get_options = _ncm_driver._Linker._get_linker_options
+
+        def get_options_numeric(self, ptx):
+            options = stock_get_options(self, ptx)
+            _render_lto_codegen_options_numeric(options)
+            return options
+
+        _ncm_driver._Linker._get_linker_options = get_options_numeric
+        _ncm_driver._render_lto_codegen_options_numeric = (
+            _render_lto_codegen_options_numeric
+        )
+
+    lower_class = _mlir_lowering.MLIRLower
+    marker = "_cubie_lto_link_fastmath"
+    if getattr(lower_class, marker, None):
+        return
+
+    source = inspect.getsource(lower_class._create_linker)
+    if "ftz" in source:
+        setattr(lower_class, marker, "upstream")
+        return
+    fragments = (
+        "**self._linker_config",
+        "lto=link_plan.compile_new_inputs_as_ltoir",
+        "optimize_unused_variables=True",
+    )
+    if any(fragment not in source for fragment in fragments):
+        raise RuntimeError(
+            "cubie._mlir_compat: numba-cuda-mlir's kernel linker "
+            "construction no longer matches the stock "
+            "implementation; update the LTO-link fastmath shim for "
+            "this release."
+        )
+
+    def _create_linker_with_fastmath(self, link_plan):
+        linker_config = dict(self._linker_config)
+        if (
+            link_plan.compile_new_inputs_as_ltoir
+            or link_plan.has_ltoir_link_items
+        ):
+            linker_config.update(
+                _lto_link_fastmath_knobs(
+                    self.targetoptions.get("fastmath")
+                )
+            )
+        return _mlir_lowering.Linker(
+            **linker_config,
+            lto=link_plan.compile_new_inputs_as_ltoir,
+            optimize_unused_variables=True,
+        )
+
+    lower_class._create_linker = _create_linker_with_fastmath
+    setattr(lower_class, marker, "shim")
+
+
+register_lto_link_fastmath_shim()
 
 
 def _lower_array_slice_getitem_empty_safe(builder, target, args, kwargs):


### PR DESCRIPTION
## What

The production LTO kernel link now passes the fastmath codegen knobs to nvJitLink. \`_mlir_compat\` gains an LTO-link fastmath shim: \`MLIRLower._create_linker\` injects per-flag \`fma\`/\`prec-div\`/\`prec-sqrt\` knobs (and \`ftz\` under full \`fast\`) whenever the link consumes LTO-IR inputs, and \`_Linker._get_linker_options\` rewrites cuda.core's boolean option rendering (\`-ftz=true\`) to the numeric form (\`-ftz=1\`) that the libnvvm parser inside nvJitLink requires. The shim feature-detects builds that already carry the fix and no-ops there; the same change lives on the fork branch \`fix-lto-link-fastmath-knobs\` of ccam80/numba-cuda-mlir.

## Why

Final code generation for LTO-IR inputs happens in nvJitLink, which applies precise-math defaults (ftz=0, prec-div=1, prec-sqrt=1) unless the link passes the knobs; the fastmath options handed to libnvvm only govern LTO-IR generation. The installed wheel passes the knobs to the \`get_lto_ptx()\` diagnostic linker but builds the production linker from \`_linker_config\`, which never carried them, so LTO cubins silently reverted to precise-math codegen (NCU comparison of ltoon/ltoff lorenz kernels showed the fastmath flags dropped under LTO).

Link-stage \`ftz\` keys off full \`fast\` only: knob decomposition on the gate's RK4 config measured link-time \`-ftz=1\` alone at +24% kernel time — the f32 arithmetic takes same-throughput .FTZ forms, but the f64→f32 narrowing of the loop time accumulator gains an f64-pipe magnitude compare plus predicated denormal-scaling and ×1.0 flush multiplies on the per-step dependency chain — while \`fma\`/\`prec\` knobs alone were performance-neutral. Production LTO cubins have never flushed denormals, so no accuracy contract depends on it.

## Performance gate

\`\`\`
mlir       fixed     kernel  A    62.720  B    62.385   -0.53%  improvement
mlir       fixed     wall    A    76.298  B    75.973   -0.54%  ok
mlir       adaptive  kernel  A    17.412  B    17.398   -0.08%  ok
mlir       adaptive  wall    A    21.708  B    21.681   -0.12%  ok
mlir       chunked   kernel  A    63.057  B    62.611   -0.38%  ok
mlir       chunked   wall    A    79.084  B    78.555   -0.67%  ok
mlir       wave      kernel  A    25.679  B    25.697   +0.01%  ok
mlir       wave      wall    A    28.395  B    28.325   -0.42%  ok

GATE: PASS (kernel threshold 0.50%, wall threshold 10.00%)
\`\`\`