### PR TITLE
fix: host-array solves transfer directly; writeback waits drain inline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,9 @@ updating a PR; targeted subsets miss cross-cutting tests.
   `docs`, `chore`.
 - **Agents:** every fix or feature is developed on its own branch off `main`. When the work is
   done and verified, commit, push the branch, and open a PR.
+- Capture `ab_gate.py` stdout untruncated.
 - **Performance gate (every PR):** run `python benchmarks/ab_gate.py` and paste its table into
-  the PR message, capturing stdout in full (never through `tail`/`head`). One command compares
-  A (`origin/main`, an ephemeral `git worktree`) against B
+  the PR message. One command compares A (`origin/main`, an ephemeral `git worktree`) against B
   (the working tree) on every installed CUDA backend — both `numba-cuda` and `numba-cuda-mlir`
   should be in the venv. Per backend it starts one persistent worker per side (each compiles and
   builds its grid once) and ping-pongs short solve blocks between them in ABBA order with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,8 @@ updating a PR; targeted subsets miss cross-cutting tests.
 - **Agents:** every fix or feature is developed on its own branch off `main`. When the work is
   done and verified, commit, push the branch, and open a PR.
 - **Performance gate (every PR):** run `python benchmarks/ab_gate.py` and paste its table into
-  the PR message. One command compares A (`origin/main`, an ephemeral `git worktree`) against B
+  the PR message, capturing stdout in full (never through `tail`/`head`). One command compares
+  A (`origin/main`, an ephemeral `git worktree`) against B
   (the working tree) on every installed CUDA backend — both `numba-cuda` and `numba-cuda-mlir`
   should be in the venv. Per backend it starts one persistent worker per side (each compiles and
   builds its grid once) and ping-pongs short solve blocks between them in ABBA order with

--- a/src/cubie/array_interpolator.py
+++ b/src/cubie/array_interpolator.py
@@ -45,10 +45,10 @@ from numpy import (
     arange,
     array_equal,
     asarray,
-    ascontiguousarray,
     column_stack,
     concatenate,
     diff,
+    dtype as np_dtype,
     empty,
     floating,
     full_like,
@@ -58,7 +58,7 @@ from numpy import (
 )
 from numpy.linalg import solve as np_solve
 from attrs import define, field, validators, frozen
-from cubie.cuda_simsafe import cuda, int32, numba_from_dtype as from_dtype
+from cubie.cuda_simsafe import cuda, int32
 from numpy.typing import NDArray
 
 from cubie.cuda_simsafe import CUDA_SIMULATION, cupy, selp
@@ -75,6 +75,7 @@ from cubie._utils import (
 from cubie.memory import current_cupy_stream, default_memmgr
 
 if TYPE_CHECKING:
+    from cubie.memory.mem_manager import MemoryManager
     from cubie.odesystems.symbolic.symbolicODE import SymbolicODE
 
 
@@ -159,6 +160,7 @@ class ArrayInterpolator(CUDAFactory):
         self,
         precision: PrecisionDType,
         input_dict: Dict[str, FloatArray],
+        memory_manager: "MemoryManager" = default_memmgr,
     ) -> None:
         """Initialize the array interpolator factory.
 
@@ -169,12 +171,15 @@ class ArrayInterpolator(CUDAFactory):
         input_dict : dict
             Dictionary containing input arrays and configuration. See
             :meth:`update_from_dict` for required and optional fields.
+        memory_manager : MemoryManager
+            Manager whose policy sizes the pinned coefficients buffer.
         """
         super().__init__()
         config = ArrayInterpolatorConfig(
             precision=precision,
         )
         self.setup_compile_settings(config)
+        self._memory_manager = memory_manager
         self._coefficients = None
         self._input_array = None
         self.update_from_dict(input_dict)
@@ -435,7 +440,6 @@ class ArrayInterpolator(CUDAFactory):
             Device function which evaluates input polynomials at a given time.
         """
         precision = self.precision
-        numba_precision = from_dtype(precision)
 
         order = self.order
         num_inputs = self.num_inputs
@@ -1082,7 +1086,29 @@ class ArrayInterpolator(CUDAFactory):
         solution = np_solve(matrix, rhs)
         coefficients = solution.reshape(num_segments, order + 1, num_inputs)
         coefficients = np_transpose(coefficients, (0, 2, 1))
-        return ascontiguousarray(coefficients, dtype=self.precision)
+        return self._land_coefficients(coefficients)
+
+    def _land_coefficients(self, coefficients: FloatArray) -> FloatArray:
+        """Copy coefficients into a reused pinned-or-pageable buffer."""
+        buffer = self._coefficients
+        if (
+            buffer is None
+            or buffer.shape != coefficients.shape
+            or buffer.dtype != self.precision
+        ):
+            nbytes = (
+                coefficients.size * np_dtype(self.precision).itemsize
+            )
+            memory_type = (
+                "pinned"
+                if nbytes <= self._memory_manager.pinned_max_bytes
+                else "host"
+            )
+            buffer = self._memory_manager.create_host_array(
+                coefficients.shape, self.precision, memory_type
+            )
+        buffer[...] = coefficients
+        return buffer
 
     # ---------------------------------------------------------------------- #
     # Getters and pass-through

--- a/src/cubie/batchsolving/BatchInputHandler.py
+++ b/src/cubie/batchsolving/BatchInputHandler.py
@@ -961,8 +961,8 @@ class BatchInputHandler:
         self,
         states: ndarray,
         params: ndarray,
-        states_input: object = None,
-        params_input: object = None,
+        states_input: object,
+        params_input: object,
     ) -> tuple[ndarray, ndarray]:
         """Return arrays in system precision, pinned when handler-owned.
 

--- a/src/cubie/batchsolving/BatchInputHandler.py
+++ b/src/cubie/batchsolving/BatchInputHandler.py
@@ -468,6 +468,7 @@ def _views_user_input(array: ndarray, user_input: object) -> bool:
     if not isinstance(user_input, ndarray):
         return False
     base = array
+    # Walk views back to the original array they were taken from.
     while isinstance(base, ndarray):
         if base is user_input:
             return True
@@ -1000,24 +1001,29 @@ class BatchInputHandler:
         handler-assembled arrays land in page-locked buffers below the
         memory manager's pinned ceiling.
         """
+        # Nothing to transfer: empty arrays pass through.
         if array.size == 0:
             return array
         aligned = (
             array.dtype == self.precision
             and array.flags["C_CONTIGUOUS"]
         )
+        # The caller's own array is used as-is, whatever its backing.
         if aligned and _views_user_input(array, user_input):
             return array
+        # Small arrays get pinned buffers; large ones stay pageable.
         nbytes = int(array.size) * np_dtype(self.precision).itemsize
         memory_type = (
             "pinned"
             if nbytes <= self.memory_manager.pinned_max_bytes
             else "host"
         )
+        # Assembled but already transfer-ready: no copy needed.
         if aligned and (
             memory_type == "host" or is_pinned_array(array)
         ):
             return array
+        # Copy once into a buffer of the chosen backing.
         return self.memory_manager.create_host_array(
             array.shape, self.precision, memory_type, like=array
         )

--- a/src/cubie/batchsolving/BatchInputHandler.py
+++ b/src/cubie/batchsolving/BatchInputHandler.py
@@ -161,7 +161,7 @@ from numpy import (
 
 from numpy.typing import ArrayLike
 
-from cubie.cuda_simsafe import is_device_array
+from cubie.cuda_simsafe import is_device_array, is_pinned_array
 from cubie.batchsolving.SystemInterface import SystemInterface
 from cubie.memory import default_memmgr
 from cubie.odesystems.baseODE import BaseODE
@@ -463,6 +463,18 @@ def extend_grid_to_array(
     return array
 
 
+def _views_user_input(array: ndarray, user_input: object) -> bool:
+    """Return whether ``array`` is or views a caller-supplied array."""
+    if not isinstance(user_input, ndarray):
+        return False
+    base = array
+    while isinstance(base, ndarray):
+        if base is user_input:
+            return True
+        base = base.base
+    return False
+
+
 class BatchInputHandler:
     """Process and validate solver inputs for batch runs.
 
@@ -587,7 +599,9 @@ class BatchInputHandler:
         )
 
         # Cast to system precision
-        return self._cast_to_precision(states_array, params_array)
+        return self._cast_to_precision(
+            states_array, params_array, states, params
+        )
 
     def _validate_device_array(
         self,
@@ -735,7 +749,7 @@ class BatchInputHandler:
                     f"verbatim: pass a single column to broadcast or "
                     f"a matching run count."
                 )
-        host_arr = self._materialise(np_asarray(host_arr))
+        host_arr = self._materialise(np_asarray(host_arr), other)
 
         if states_is_device:
             return device_arr, host_arr
@@ -944,9 +958,13 @@ class BatchInputHandler:
         return combine_grids(states_array, params_array, kind=kind)
 
     def _cast_to_precision(
-        self, states: ndarray, params: ndarray
+        self,
+        states: ndarray,
+        params: ndarray,
+        states_input: object = None,
+        params_input: object = None,
     ) -> tuple[ndarray, ndarray]:
-        """Return arrays in system precision, pinned when materialised.
+        """Return arrays in system precision, pinned when handler-owned.
 
         Parameters
         ----------
@@ -954,26 +972,41 @@ class BatchInputHandler:
             Initial state array in (variable, run) format.
         params
             Parameter array in (variable, run) format.
+        states_input
+            The caller's original ``states`` argument.
+        params_input
+            The caller's original ``params`` argument.
 
         Returns
         -------
         tuple of ndarray and ndarray
             State and parameter arrays with ``dtype`` matching
-            ``self.precision``. An array already C-contiguous in the
-            system precision passes through untouched; one that needs
-            materialising (a dtype cast or contiguity fix) lands
-            directly in a buffer chosen by the memory manager —
-            pinned below the manager's ceiling for direct
-            asynchronous transfer, pageable above it.
+            ``self.precision``. A caller-supplied array already
+            C-contiguous in the system precision passes through
+            untouched; anything else lands in a buffer chosen by the
+            memory manager — pinned below the manager's ceiling,
+            pageable above it.
         """
         return (
-            self._materialise(states),
-            self._materialise(params),
+            self._materialise(states, states_input),
+            self._materialise(params, params_input),
         )
 
-    def _materialise(self, array: ndarray) -> ndarray:
-        """Return ``array`` in precision, copying at most once."""
-        if array.dtype == self.precision and array.flags["C_CONTIGUOUS"]:
+    def _materialise(self, array: ndarray, user_input: object) -> ndarray:
+        """Return ``array`` in precision, copying at most once.
+
+        A caller-supplied array (or a view of one) already
+        C-contiguous in the system precision passes through untouched;
+        handler-assembled arrays land in page-locked buffers below the
+        memory manager's pinned ceiling.
+        """
+        if array.size == 0:
+            return array
+        aligned = (
+            array.dtype == self.precision
+            and array.flags["C_CONTIGUOUS"]
+        )
+        if aligned and _views_user_input(array, user_input):
             return array
         nbytes = int(array.size) * np_dtype(self.precision).itemsize
         memory_type = (
@@ -981,6 +1014,10 @@ class BatchInputHandler:
             if nbytes <= self.memory_manager.pinned_max_bytes
             else "host"
         )
+        if aligned and (
+            memory_type == "host" or is_pinned_array(array)
+        ):
+            return array
         return self.memory_manager.create_host_array(
             array.shape, self.precision, memory_type, like=array
         )
@@ -1079,6 +1116,8 @@ class BatchInputHandler:
         kind: str,
     ) -> Optional[Tuple[ndarray, ndarray]]:
         """Attempt fast returns for pre-sized host array inputs."""
+        states_input = states
+        params_input = params
         states_runs = self._get_run_count(states)
         params_runs = None
         if not (self.parameters.empty and params is None):
@@ -1095,7 +1134,9 @@ class BatchInputHandler:
         if states_ok and params_ok:
             if states_runs is not None and params_runs is not None:
                 if states_runs == params_runs:
-                    return self._cast_to_precision(states, params)
+                    return self._cast_to_precision(
+                        states, params, states_input, params_input
+                    )
 
         states_small = self._is_1d_or_none(states)
         params_small = self._is_1d_or_none(params)
@@ -1111,7 +1152,9 @@ class BatchInputHandler:
             states_array, params_array = self._align_run_counts(
                 states, params_array, kind
             )
-            return self._cast_to_precision(states_array, params_array)
+            return self._cast_to_precision(
+                states_array, params_array, states_input, params_input
+            )
 
         if params_ok and states_small:
             n_runs = params_runs if params_runs is not None else 1
@@ -1124,7 +1167,9 @@ class BatchInputHandler:
             states_array, params_array = self._align_run_counts(
                 states_array, params, kind
             )
-            return self._cast_to_precision(states_array, params_array)
+            return self._cast_to_precision(
+                states_array, params_array, states_input, params_input
+            )
 
         return None
 

--- a/src/cubie/batchsolving/BatchSolverKernel.py
+++ b/src/cubie/batchsolving/BatchSolverKernel.py
@@ -307,6 +307,7 @@ class BatchSolverKernel(CUDAFactory):
                 "placeholder": np_zeros(6, dtype=precision),
                 "driver_sample_period": 0.1,
             },
+            memory_manager=self._memory_manager,
         )
 
         system_name = system.name

--- a/src/cubie/batchsolving/arrays/BaseArrayManager.py
+++ b/src/cubie/batchsolving/arrays/BaseArrayManager.py
@@ -225,12 +225,24 @@ class ManagedArray:
 
 @define(slots=False)
 class ArrayContainer(ABC):
-    """Store per-array metadata and references for CUDA managers."""
+    """Store per-array metadata and references for CUDA managers.
+
+    Field discovery is cached on first iteration.
+    """
+
+    def _managed_map(self) -> Dict[str, ManagedArray]:
+        cached = self.__dict__.get("_managed_map_cache")
+        if cached is None:
+            cached = {
+                name: value
+                for name, value in self.__dict__.items()
+                if isinstance(value, ManagedArray)
+            }
+            object.__setattr__(self, "_managed_map_cache", cached)
+        return cached
 
     def _iter_field_items(self) -> Iterator[tuple[str, ManagedArray]]:
-        for name, value in self.__dict__.items():
-            if isinstance(value, ManagedArray):
-                yield name, value
+        return iter(self._managed_map().items())
 
     def iter_managed_arrays(self) -> Iterator[tuple[str, ManagedArray]]:
         """Yield ``(label, managed)`` pairs for each array."""
@@ -240,17 +252,17 @@ class ArrayContainer(ABC):
     def array_names(self) -> List[str]:
         """Return array labels managed by this container."""
 
-        return [label for label, _ in self.iter_managed_arrays()]
+        return list(self._managed_map())
 
     def get_managed_array(self, label: str) -> ManagedArray:
         """Retrieve the metadata wrapper for ``label``."""
 
-        for managed_label, managed in self.iter_managed_arrays():
-            if managed_label == label:
-                return managed
-        raise AttributeError(
-            f"Managed array with label '{label}' does not exist."
-        )
+        managed = self._managed_map().get(label)
+        if managed is None:
+            raise AttributeError(
+                f"Managed array with label '{label}' does not exist."
+            )
+        return managed
 
     def get_array(
         self, label: str

--- a/src/cubie/batchsolving/arrays/BaseArrayManager.py
+++ b/src/cubie/batchsolving/arrays/BaseArrayManager.py
@@ -225,21 +225,21 @@ class ManagedArray:
 
 @define(slots=False)
 class ArrayContainer(ABC):
-    """Store per-array metadata and references for CUDA managers.
+    """Store per-array metadata and references for CUDA managers."""
 
-    Field discovery is cached on first iteration.
-    """
+    _managed_map_cache: Optional[Dict[str, ManagedArray]] = field(
+        default=None, init=False, eq=False, repr=False
+    )
 
     def _managed_map(self) -> Dict[str, ManagedArray]:
-        cached = self.__dict__.get("_managed_map_cache")
-        if cached is None:
-            cached = {
+        """Map array labels to ManagedArray fields, built once."""
+        if self._managed_map_cache is None:
+            self._managed_map_cache = {
                 name: value
                 for name, value in self.__dict__.items()
                 if isinstance(value, ManagedArray)
             }
-            object.__setattr__(self, "_managed_map_cache", cached)
-        return cached
+        return self._managed_map_cache
 
     def _iter_field_items(self) -> Iterator[tuple[str, ManagedArray]]:
         return iter(self._managed_map().items())

--- a/src/cubie/batchsolving/arrays/BatchInputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchInputArrays.py
@@ -208,13 +208,17 @@ class InputArrays(BaseArrayManager):
         transfer occurs, and no managed device buffer is allocated for
         them. They must already match the expected shape and dtype.
         """
+        self.update_from_solver(solver_instance)
+        if self._fast_path_update(
+            initial_values, parameters, driver_coefficients
+        ):
+            return
         updates_dict = {
             "initial_values": initial_values,
             "parameters": parameters,
         }
         if driver_coefficients is not None:
             updates_dict["driver_coefficients"] = driver_coefficients
-        self.update_from_solver(solver_instance)
         device_updates = {
             name: arr
             for name, arr in updates_dict.items()
@@ -281,6 +285,38 @@ class InputArrays(BaseArrayManager):
                 self._needs_reallocation.remove(name)
             if name in self._needs_overwrite:
                 self._needs_overwrite.remove(name)
+
+    def _fast_path_update(
+        self,
+        initial_values: NDArray,
+        parameters: NDArray,
+        driver_coefficients: Optional[NDArray],
+    ) -> bool:
+        """Queue overwrites when the attached inputs are re-supplied.
+
+        Returns ``True`` when every input is the object already
+        attached, after refreshing the pinned coefficient mirror.
+        """
+        if self._device_inputs:
+            return False
+        if initial_values is not self.host.initial_values.array:
+            return False
+        if parameters is not self.host.parameters.array:
+            return False
+        overwrite = ["initial_values", "parameters"]
+        if driver_coefficients is not None:
+            if is_device_array(driver_coefficients):
+                return False
+            pinned = self._pin_driver_coefficients(driver_coefficients)
+            if pinned is not self.host.driver_coefficients.array:
+                return False
+            overwrite.append("driver_coefficients")
+        for name in overwrite:
+            if name not in self._needs_overwrite:
+                self._needs_overwrite.append(name)
+        if self._needs_reallocation:
+            self.allocate()
+        return True
 
     def _pin_driver_coefficients(self, coefficients: NDArray) -> NDArray:
         """Return driver coefficients in page-locked backing.

--- a/src/cubie/batchsolving/arrays/BatchInputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchInputArrays.py
@@ -292,23 +292,19 @@ class InputArrays(BaseArrayManager):
         parameters: NDArray,
         driver_coefficients: Optional[NDArray],
     ) -> bool:
-        """Queue overwrites when the attached inputs are re-supplied.
-
-        Returns ``True`` when every input is the object already
-        attached, after refreshing the pinned coefficient mirror.
-        """
+        """Queue overwrites when the attached inputs are re-supplied."""
         if self._device_inputs:
             return False
-        if initial_values is not self.host.initial_values.array:
+        if not self._matches_slot("initial_values", initial_values):
             return False
-        if parameters is not self.host.parameters.array:
+        if not self._matches_slot("parameters", parameters):
             return False
         overwrite = ["initial_values", "parameters"]
         if driver_coefficients is not None:
             if is_device_array(driver_coefficients):
                 return False
             pinned = self._pin_driver_coefficients(driver_coefficients)
-            if pinned is not self.host.driver_coefficients.array:
+            if not self._matches_slot("driver_coefficients", pinned):
                 return False
             overwrite.append("driver_coefficients")
         for name in overwrite:
@@ -317,6 +313,11 @@ class InputArrays(BaseArrayManager):
         if self._needs_reallocation:
             self.allocate()
         return True
+
+    def _matches_slot(self, name: str, array: NDArray) -> bool:
+        """Return whether ``array`` is the attached, dtype-current slot."""
+        slot = self.host.get_managed_array(name)
+        return array is slot.array and array.dtype == slot.dtype
 
     def _pin_driver_coefficients(self, coefficients: NDArray) -> NDArray:
         """Return driver coefficients in page-locked backing.

--- a/src/cubie/batchsolving/arrays/BatchInputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchInputArrays.py
@@ -293,23 +293,30 @@ class InputArrays(BaseArrayManager):
         driver_coefficients: Optional[NDArray],
     ) -> bool:
         """Queue overwrites when the attached inputs are re-supplied."""
+
+        # Device inputs always take the full update path.
         if self._device_inputs:
             return False
+        # Bail unless the caller re-supplied the attached arrays.
         if not self._matches_slot("initial_values", initial_values):
             return False
         if not self._matches_slot("parameters", parameters):
             return False
         overwrite = ["initial_values", "parameters"]
         if driver_coefficients is not None:
+            # A device coefficient array attaches via the full path.
             if is_device_array(driver_coefficients):
                 return False
+            # A new mirror or a new array is a real update.
             pinned = self._pin_driver_coefficients(driver_coefficients)
             if not self._matches_slot("driver_coefficients", pinned):
                 return False
             overwrite.append("driver_coefficients")
+        # Same buffers as last solve: only queue the value uploads.
         for name in overwrite:
             if name not in self._needs_overwrite:
                 self._needs_overwrite.append(name)
+        # Rebuild device buffers dropped by an invalidation.
         if self._needs_reallocation:
             self.allocate()
         return True

--- a/src/cubie/batchsolving/arrays/BatchInputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchInputArrays.py
@@ -39,7 +39,12 @@ from typing import Dict, Optional, TYPE_CHECKING
 if TYPE_CHECKING:
     from cubie.batchsolving.BatchSolverKernel import BatchSolverKernel
 
-from cubie.cuda_simsafe import cuda, CUDA_SIMULATION, is_device_array
+from cubie.cuda_simsafe import (
+    cuda,
+    CUDA_SIMULATION,
+    is_device_array,
+    is_pinned_array,
+)
 from cubie.memory.chunk_buffer_pool import ChunkBufferPool
 from cubie.memory.mem_manager import HOST_STAGING_BYTES
 from cubie.batchsolving.writeback_watcher import WritebackWatcher
@@ -160,6 +165,9 @@ class InputArrays(BaseArrayManager):
         factory=WritebackWatcher, init=False
     )
     _device_inputs: Dict[str, object] = field(factory=dict, init=False)
+    _pinned_coefficients_mirror: Optional[NDArray] = field(
+        default=None, init=False, eq=False, repr=False
+    )
 
     def __attrs_post_init__(self) -> None:
         """Ensure host and device containers use explicit memory types.
@@ -219,11 +227,16 @@ class InputArrays(BaseArrayManager):
         }
         for name in list(self._device_inputs):
             if name in host_updates:
-                # A slot returning to host input needs a managed
-                # device buffer allocated again.
+                # Back to host input: reallocate the device buffer.
                 del self._device_inputs[name]
                 if name not in self._needs_reallocation:
                     self._needs_reallocation.append(name)
+        if "driver_coefficients" in host_updates:
+            host_updates["driver_coefficients"] = (
+                self._pin_driver_coefficients(
+                    host_updates["driver_coefficients"]
+                )
+            )
         if host_updates:
             self.update_host_arrays(host_updates)
         if device_updates:
@@ -268,6 +281,31 @@ class InputArrays(BaseArrayManager):
                 self._needs_reallocation.remove(name)
             if name in self._needs_overwrite:
                 self._needs_overwrite.remove(name)
+
+    def _pin_driver_coefficients(self, coefficients: NDArray) -> NDArray:
+        """Return driver coefficients in page-locked backing.
+
+        Pageable coefficients are copied into a persistent pinned
+        mirror, reallocated when shape or dtype changes. Arrays
+        already pinned, or above the pinned ceiling, pass through
+        unchanged.
+        """
+        if CUDA_SIMULATION or is_pinned_array(coefficients):
+            return coefficients
+        if coefficients.nbytes > self._memory_manager.pinned_max_bytes:
+            return coefficients
+        mirror = self._pinned_coefficients_mirror
+        if (
+            mirror is None
+            or mirror.shape != coefficients.shape
+            or mirror.dtype != coefficients.dtype
+        ):
+            mirror = self._memory_manager.create_host_array(
+                coefficients.shape, coefficients.dtype, "pinned"
+            )
+            self._pinned_coefficients_mirror = mirror
+        mirror[...] = coefficients
+        return mirror
 
     @property
     def has_device_inputs(self) -> bool:

--- a/src/cubie/batchsolving/arrays/BatchInputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchInputArrays.py
@@ -43,7 +43,6 @@ from cubie.cuda_simsafe import (
     cuda,
     CUDA_SIMULATION,
     is_device_array,
-    is_pinned_array,
 )
 from cubie.memory.chunk_buffer_pool import ChunkBufferPool
 from cubie.memory.mem_manager import HOST_STAGING_BYTES
@@ -165,9 +164,6 @@ class InputArrays(BaseArrayManager):
         factory=WritebackWatcher, init=False
     )
     _device_inputs: Dict[str, object] = field(factory=dict, init=False)
-    _pinned_coefficients_mirror: Optional[NDArray] = field(
-        default=None, init=False, eq=False, repr=False
-    )
 
     def __attrs_post_init__(self) -> None:
         """Ensure host and device containers use explicit memory types.
@@ -235,12 +231,6 @@ class InputArrays(BaseArrayManager):
                 del self._device_inputs[name]
                 if name not in self._needs_reallocation:
                     self._needs_reallocation.append(name)
-        if "driver_coefficients" in host_updates:
-            host_updates["driver_coefficients"] = (
-                self._pin_driver_coefficients(
-                    host_updates["driver_coefficients"]
-                )
-            )
         if host_updates:
             self.update_host_arrays(host_updates)
         if device_updates:
@@ -304,12 +294,9 @@ class InputArrays(BaseArrayManager):
             return False
         overwrite = ["initial_values", "parameters"]
         if driver_coefficients is not None:
-            # A device coefficient array attaches via the full path.
-            if is_device_array(driver_coefficients):
-                return False
-            # A new mirror or a new array is a real update.
-            pinned = self._pin_driver_coefficients(driver_coefficients)
-            if not self._matches_slot("driver_coefficients", pinned):
+            if not self._matches_slot(
+                "driver_coefficients", driver_coefficients
+            ):
                 return False
             overwrite.append("driver_coefficients")
         # Same buffers as last solve: only queue the value uploads.
@@ -325,31 +312,6 @@ class InputArrays(BaseArrayManager):
         """Return whether ``array`` is the attached, dtype-current slot."""
         slot = self.host.get_managed_array(name)
         return array is slot.array and array.dtype == slot.dtype
-
-    def _pin_driver_coefficients(self, coefficients: NDArray) -> NDArray:
-        """Return driver coefficients in page-locked backing.
-
-        Pageable coefficients are copied into a persistent pinned
-        mirror, reallocated when shape or dtype changes. Arrays
-        already pinned, or above the pinned ceiling, pass through
-        unchanged.
-        """
-        if CUDA_SIMULATION or is_pinned_array(coefficients):
-            return coefficients
-        if coefficients.nbytes > self._memory_manager.pinned_max_bytes:
-            return coefficients
-        mirror = self._pinned_coefficients_mirror
-        if (
-            mirror is None
-            or mirror.shape != coefficients.shape
-            or mirror.dtype != coefficients.dtype
-        ):
-            mirror = self._memory_manager.create_host_array(
-                coefficients.shape, coefficients.dtype, "pinned"
-            )
-            self._pinned_coefficients_mirror = mirror
-        mirror[...] = coefficients
-        return mirror
 
     @property
     def has_device_inputs(self) -> bool:

--- a/src/cubie/batchsolving/arrays/BatchOutputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchOutputArrays.py
@@ -231,6 +231,11 @@ class OutputArrays(BaseArrayManager):
             active.add("iteration_counters")
         self._active_names = frozenset(active)
         new_arrays = self.update_from_solver(solver_instance)
+        if new_arrays is None:
+            # Sizes unchanged; reallocate only after an invalidation.
+            if self._needs_reallocation:
+                self.allocate()
+            return
         self.update_host_arrays(new_arrays, shape_only=True)
         self.allocate()
 
@@ -339,9 +344,10 @@ class OutputArrays(BaseArrayManager):
 
         Returns
         -------
-        dict[str, numpy.ndarray]
-            Host arrays with updated shapes for ``update_host_arrays``.
-            Arrays that already match are still included for consistency.
+        dict[str, numpy.ndarray] or None
+            Host arrays with updated shapes for ``update_host_arrays``,
+            or ``None`` when sizes are unchanged and the current host
+            arrays already match.
         """
         # Buffers loaned to a collected result come back for reuse
         # before sizes are compared; a live result keeps its buffers
@@ -367,10 +373,7 @@ class OutputArrays(BaseArrayManager):
             solver_instance.save_counters,
         )
         if sig == self._size_sig:
-            return {
-                name: slot.array
-                for name, slot in self.host.iter_managed_arrays()
-            }
+            return None
         self._sizes = BatchOutputSizes.from_solver(solver_instance).nonzero
         self._precision = solver_instance.precision
         self.set_array_runs(solver_instance.num_runs)

--- a/src/cubie/batchsolving/solver.py
+++ b/src/cubie/batchsolving/solver.py
@@ -532,6 +532,8 @@ class Solver:
         self.input_handler = BatchInputHandler(
             interface, memory_manager=self.kernel.memory_manager
         )
+        self._solve_info_cache = None
+        self._solve_info_key = None
 
         if set(kwargs) - recognized_kwargs:
             raise KeyError(
@@ -847,6 +849,8 @@ class Solver:
         all_unrecognized -= self.kernel.update(updates_dict, silent=True)
 
         recognised = set(updates_dict.keys()) - all_unrecognized
+        if recognised:
+            self._solve_info_cache = None
 
         if all_unrecognized:
             if not silent:
@@ -1290,8 +1294,14 @@ class Solver:
 
     @property
     def solve_info(self) -> SolveSpec:
-        """Construct a SolveSpec describing the current configuration."""
-        return SolveSpec(
+        """SolveSpec for the current settings, cached until they change."""
+        key = (self.duration, self.warmup, self.t0)
+        if (
+            self._solve_info_cache is not None
+            and self._solve_info_key == key
+        ):
+            return self._solve_info_cache
+        spec = SolveSpec(
             dt=self.dt,
             dt_min=self.dt_min,
             dt_max=self.dt_max,
@@ -1311,3 +1321,6 @@ class Solver:
             output_types=self.output_types,
             precision=self.precision,
         )
+        self._solve_info_cache = spec
+        self._solve_info_key = key
+        return spec

--- a/src/cubie/batchsolving/solver.py
+++ b/src/cubie/batchsolving/solver.py
@@ -850,7 +850,7 @@ class Solver:
 
         recognised = set(updates_dict.keys()) - all_unrecognized
         if recognised:
-            self._solve_info_cache = None
+            self._solve_info_key = None
 
         if all_unrecognized:
             if not silent:
@@ -1296,10 +1296,7 @@ class Solver:
     def solve_info(self) -> SolveSpec:
         """SolveSpec for the current settings, cached until they change."""
         key = (self.duration, self.warmup, self.t0)
-        if (
-            self._solve_info_cache is not None
-            and self._solve_info_key == key
-        ):
+        if self._solve_info_key == key:
             return self._solve_info_cache
         spec = SolveSpec(
             dt=self.dt,

--- a/src/cubie/batchsolving/solveresult.py
+++ b/src/cubie/batchsolving/solveresult.py
@@ -168,7 +168,7 @@ class SolveSpec:
     sample_summaries_every: Optional[float] = field(
         validator=opt_getype_validator(float, 0.0)
     )
-    # ndarray first: the float validator's failure message reprs it.
+    # ndarray first: a failing float validator reprs the whole array.
     atol: Optional[float] = field(
         validator=attrsval_or(
             attrsval_instance_of(ndarray), opt_gttype_validator(float, 0.0)

--- a/src/cubie/batchsolving/solveresult.py
+++ b/src/cubie/batchsolving/solveresult.py
@@ -168,14 +168,15 @@ class SolveSpec:
     sample_summaries_every: Optional[float] = field(
         validator=opt_getype_validator(float, 0.0)
     )
+    # ndarray first: the float validator's failure message reprs it.
     atol: Optional[float] = field(
         validator=attrsval_or(
-            opt_gttype_validator(float, 0.0), attrsval_instance_of(ndarray)
+            attrsval_instance_of(ndarray), opt_gttype_validator(float, 0.0)
         ),
     )
     rtol: Optional[float] = field(
         validator=attrsval_or(
-            opt_gttype_validator(float, 0.0), attrsval_instance_of(ndarray)
+            attrsval_instance_of(ndarray), opt_gttype_validator(float, 0.0)
         ),
     )
     duration: float = field(validator=gttype_validator(float, 0.0))

--- a/src/cubie/batchsolving/writeback_watcher.py
+++ b/src/cubie/batchsolving/writeback_watcher.py
@@ -35,6 +35,11 @@ from cubie.cuda_simsafe import CUDA_SIMULATION
 from cubie.memory.chunk_buffer_pool import PinnedBuffer, ChunkBufferPool
 
 
+def _timeout_error(timeout: Optional[float]) -> TimeoutError:
+    """Return the error raised when ``wait_all`` exceeds ``timeout``."""
+    return TimeoutError(f"wait_all timed out after {timeout} seconds")
+
+
 @define
 class WritebackTask:
     """Container for a pending writeback operation.
@@ -217,20 +222,14 @@ class WritebackWatcher:
                     return
                 task = self._tasks.popleft() if self._tasks else None
                 if task is None:
-                    # Remaining tasks are owned by another thread;
-                    # wait for their completion or re-queue signal.
+                    # Tasks owned elsewhere: await completion signal.
                     remaining = None
                     if deadline is not None:
                         remaining = deadline - perf_counter()
                         if remaining <= 0:
-                            raise TimeoutError(
-                                f"wait_all timed out after {timeout} "
-                                "seconds"
-                            )
+                            raise _timeout_error(timeout)
                     if not self._cond.wait(timeout=remaining):
-                        raise TimeoutError(
-                            f"wait_all timed out after {timeout} seconds"
-                        )
+                        raise _timeout_error(timeout)
                     continue
             try:
                 self._finish_task(task, deadline, timeout)
@@ -257,41 +256,41 @@ class WritebackWatcher:
     def _poll_loop(self) -> None:
         """Main polling loop for the background thread."""
         while not self._stop_event.is_set():
-            with self._cond:
-                task = self._tasks.popleft() if self._tasks else None
-            if task is None:
-                sleep(self._poll_interval)
-                continue
-            if self._process_task(task):
-                with self._cond:
-                    self._pending_count -= 1
-                    self._cond.notify_all()
-            else:
-                with self._cond:
-                    self._tasks.append(task)
-                    self._cond.notify_all()
+            if not self._service_next_task():
                 sleep(self._poll_interval)
 
-        # On shutdown, complete remaining tasks synchronously to
-        # ensure all data is written.
+        # Shutdown drain: all tasks complete before the thread exits.
         while True:
             with self._cond:
                 if self._pending_count == 0:
                     return
-                task = self._tasks.popleft() if self._tasks else None
-            if task is None:
-                # A concurrent wait_all owns the remaining task(s).
+            if not self._service_next_task():
                 sleep(self._poll_interval)
-                continue
-            if self._process_task(task):
-                with self._cond:
-                    self._pending_count -= 1
-                    self._cond.notify_all()
-            else:
-                with self._cond:
-                    self._tasks.append(task)
-                    self._cond.notify_all()
-                sleep(self._poll_interval)
+
+    def _service_next_task(self) -> bool:
+        """Pop one task and complete it if its event has fired.
+
+        Returns
+        -------
+        bool
+            ``True`` when a task completed. ``False`` when the deque
+            was empty or the popped task was still pending and went
+            back on the deque; the caller should sleep before
+            retrying.
+        """
+        with self._cond:
+            task = self._tasks.popleft() if self._tasks else None
+        if task is None:
+            return False
+        if self._process_task(task):
+            with self._cond:
+                self._pending_count -= 1
+                self._cond.notify_all()
+            return True
+        with self._cond:
+            self._tasks.append(task)
+            self._cond.notify_all()
+        return False
 
     def _finish_task(
         self,
@@ -322,9 +321,7 @@ class WritebackWatcher:
             else:
                 while not task.event.query():
                     if perf_counter() >= deadline:
-                        raise TimeoutError(
-                            f"wait_all timed out after {timeout} seconds"
-                        )
+                        raise _timeout_error(timeout)
                     sleep(self._poll_interval)
         self._complete_task(task)
 

--- a/src/cubie/batchsolving/writeback_watcher.py
+++ b/src/cubie/batchsolving/writeback_watcher.py
@@ -8,7 +8,8 @@ Published Classes
 
 :class:`WritebackWatcher`
     Background daemon thread that polls CUDA events and copies completed
-    pinned-buffer data to host arrays.
+    pinned-buffer data to host arrays; :meth:`wait_all` drains
+    outstanding tasks in the calling thread.
 
 See Also
 --------
@@ -18,8 +19,8 @@ See Also
     Pool managing pinned buffer allocation and reuse.
 """
 
-from queue import Queue, Empty
-from threading import Thread, Event, Lock
+from collections import deque
+from threading import Thread, Event, Condition
 from typing import Optional
 from time import sleep, perf_counter
 
@@ -69,26 +70,30 @@ class WritebackTask:
 
 
 class WritebackWatcher:
-    """Background thread for polling CUDA events and completing writebacks.
+    """Complete staged transfers when their CUDA events fire.
 
-    Monitors a queue of WritebackTask objects, polls their associated
-    CUDA events for completion, and copies data from pinned buffers
-    to host arrays when ready. Releases buffers back to pool after copy.
+    Pending :class:`WritebackTask` objects live in a shared deque. A
+    background daemon polls their events and completes ready tasks;
+    :meth:`wait_all` drains the deque in the calling thread, blocking
+    on each task's event. A task is owned by whichever thread popped
+    it; an incomplete task returns to the deque.
 
     Attributes
     ----------
-    _queue : Queue
-        Thread-safe queue of pending WritebackTask objects.
+    _tasks : deque
+        Shared deque of pending WritebackTask objects.
+    _cond : Condition
+        Guards ``_tasks`` and ``_pending_count``; signalled on every
+        completion and re-queue.
     _thread : Thread or None
         Background polling thread.
     _stop_event : Event
         Signal to terminate the polling thread.
     _poll_interval : float
-        Seconds between event polls.
+        Seconds the background thread sleeps between event polls.
     _pending_count : int
-        Number of tasks still awaiting completion.
-    _lock : Lock
-        Thread-safe access to pending count.
+        Number of submitted tasks not yet completed, including tasks
+        currently owned by a processing thread.
     """
 
     def __init__(self, poll_interval: float = 0.001) -> None:
@@ -97,14 +102,15 @@ class WritebackWatcher:
         Parameters
         ----------
         poll_interval
-            Seconds between event polls. Default 0.1ms.
+            Seconds the background thread sleeps between event polls.
+            Default 1ms.
         """
-        self._queue: Queue = Queue()
+        self._tasks: deque = deque()
+        self._cond: Condition = Condition()
         self._thread: Optional[Thread] = None
         self._stop_event: Event = Event()
         self._poll_interval: float = poll_interval
         self._pending_count: int = 0
-        self._lock: Lock = Lock()
 
     def start(self) -> None:
         """Start the background polling thread."""
@@ -115,16 +121,16 @@ class WritebackWatcher:
         self._thread.start()
 
     def _submit_task(self, task: WritebackTask) -> None:
-        """Submit a writeback task to the queue.
+        """Submit a writeback task to the shared deque.
 
         Parameters
         ----------
         task
             WritebackTask to submit.
         """
-        with self._lock:
+        with self._cond:
             self._pending_count += 1
-        self._queue.put(task)
+            self._tasks.append(task)
         # Start thread if not running
         self.start()
 
@@ -187,6 +193,11 @@ class WritebackWatcher:
     def wait_all(self, timeout: Optional[float] = None) -> None:
         """Block until all pending writebacks complete.
 
+        Drains the task deque in the calling thread, blocking on each
+        task's CUDA event. When the deque is empty but tasks are owned
+        by the background thread, waits on the condition until they
+        resolve.
+
         Parameters
         ----------
         timeout
@@ -197,18 +208,42 @@ class WritebackWatcher:
         TimeoutError
             If timeout expires before completion.
         """
-        start_time = perf_counter()
+        deadline = (
+            None if timeout is None else perf_counter() + timeout
+        )
         while True:
-            with self._lock:
+            with self._cond:
                 if self._pending_count == 0:
                     return
-            if timeout is not None:
-                elapsed = perf_counter() - start_time
-                if elapsed >= timeout:
-                    raise TimeoutError(
-                        f"wait_all timed out after {timeout} seconds"
-                    )
-            sleep(self._poll_interval)
+                task = self._tasks.popleft() if self._tasks else None
+                if task is None:
+                    # Remaining tasks are owned by another thread;
+                    # wait for their completion or re-queue signal.
+                    remaining = None
+                    if deadline is not None:
+                        remaining = deadline - perf_counter()
+                        if remaining <= 0:
+                            raise TimeoutError(
+                                f"wait_all timed out after {timeout} "
+                                "seconds"
+                            )
+                    if not self._cond.wait(timeout=remaining):
+                        raise TimeoutError(
+                            f"wait_all timed out after {timeout} seconds"
+                        )
+                    continue
+            try:
+                self._finish_task(task, deadline, timeout)
+            except BaseException:
+                # Return the unfinished task so a later wait or the
+                # shutdown drain can complete it.
+                with self._cond:
+                    self._tasks.append(task)
+                    self._cond.notify_all()
+                raise
+            with self._cond:
+                self._pending_count -= 1
+                self._cond.notify_all()
 
     def shutdown(self, timeout: Optional[float] = None) -> None:
         """Drain pending work and stop the polling thread."""
@@ -221,54 +256,92 @@ class WritebackWatcher:
 
     def _poll_loop(self) -> None:
         """Main polling loop for the background thread."""
-        # Collect tasks that are not yet complete for re-queuing
-        pending_tasks = []
-
         while not self._stop_event.is_set():
-            # Process all tasks in the pending list first
-            still_pending = []
-            for task in pending_tasks:
-                if self._process_task(task):
-                    with self._lock:
-                        self._pending_count -= 1
-                else:
-                    still_pending.append(task)
-            pending_tasks = still_pending
-
-            # Try to get new tasks from queue (non-blocking)
-            try:
-                task = self._queue.get_nowait()
-                if self._process_task(task):
-                    with self._lock:
-                        self._pending_count -= 1
-                else:
-                    pending_tasks.append(task)
-            except Empty:
-                pass
-                # No tasks available in queue; continue polling loop.
-            sleep(self._poll_interval)
-
-        # On shutdown, process remaining tasks synchronously
-        # to ensure all data is written
-        while not self._queue.empty():
-            try:
-                task = self._queue.get_nowait()
-                pending_tasks.append(task)
-            except Empty:
-                break
-
-        # Complete all pending tasks before shutdown
-        while pending_tasks:
-            still_pending = []
-            for task in pending_tasks:
-                if self._process_task(task):
-                    with self._lock:
-                        self._pending_count -= 1
-                else:
-                    still_pending.append(task)
-            pending_tasks = still_pending
-            if still_pending:
+            with self._cond:
+                task = self._tasks.popleft() if self._tasks else None
+            if task is None:
                 sleep(self._poll_interval)
+                continue
+            if self._process_task(task):
+                with self._cond:
+                    self._pending_count -= 1
+                    self._cond.notify_all()
+            else:
+                with self._cond:
+                    self._tasks.append(task)
+                    self._cond.notify_all()
+                sleep(self._poll_interval)
+
+        # On shutdown, complete remaining tasks synchronously to
+        # ensure all data is written.
+        while True:
+            with self._cond:
+                if self._pending_count == 0:
+                    return
+                task = self._tasks.popleft() if self._tasks else None
+            if task is None:
+                # A concurrent wait_all owns the remaining task(s).
+                sleep(self._poll_interval)
+                continue
+            if self._process_task(task):
+                with self._cond:
+                    self._pending_count -= 1
+                    self._cond.notify_all()
+            else:
+                with self._cond:
+                    self._tasks.append(task)
+                    self._cond.notify_all()
+                sleep(self._poll_interval)
+
+    def _finish_task(
+        self,
+        task: WritebackTask,
+        deadline: Optional[float],
+        timeout: Optional[float],
+    ) -> None:
+        """Complete one task, blocking until its event has fired.
+
+        Parameters
+        ----------
+        task
+            Task to complete.
+        deadline
+            ``perf_counter`` value after which waiting raises, or
+            ``None`` to block indefinitely on the event.
+        timeout
+            Original timeout in seconds, used in the error message.
+
+        Raises
+        ------
+        TimeoutError
+            If the deadline passes before the event fires.
+        """
+        if not CUDA_SIMULATION and task.event is not None:
+            if deadline is None:
+                task.event.synchronize()
+            else:
+                while not task.event.query():
+                    if perf_counter() >= deadline:
+                        raise TimeoutError(
+                            f"wait_all timed out after {timeout} seconds"
+                        )
+                    sleep(self._poll_interval)
+        self._complete_task(task)
+
+    def _complete_task(self, task: WritebackTask) -> None:
+        """Copy staged data to its target and release the buffer."""
+        # Copy buffer data to target array at specified slice.
+        # If data_shape provided, only copy that portion of the buffer.
+        if task.target_array is not None:
+            if task.data_shape is not None:
+                buffer_slice = tuple(
+                    slice(0, s) for s in task.data_shape
+                )
+                task.target_array[:] = task.buffer.array[buffer_slice]
+            else:
+                task.target_array[:] = task.buffer.array
+        # Release buffer back to pool
+        task.buffer_pool.release(task.buffer)
 
     def _process_task(self, task: WritebackTask) -> bool:
         """Process a single writeback task.
@@ -291,18 +364,7 @@ class WritebackWatcher:
             is_complete = task.event.query()
 
         if is_complete:
-            # Copy buffer data to target array at specified slice
-            # If data_shape provided, only copy that portion of the buffer
-            if task.target_array is not None:
-                if task.data_shape is not None:
-                    buffer_slice = tuple(
-                        slice(0, s) for s in task.data_shape
-                    )
-                    task.target_array[:] = task.buffer.array[buffer_slice]
-                else:
-                    task.target_array[:] = task.buffer.array
-            # Release buffer back to pool
-            task.buffer_pool.release(task.buffer)
+            self._complete_task(task)
             return True
 
         return False

--- a/src/cubie/batchsolving/writeback_watcher.py
+++ b/src/cubie/batchsolving/writeback_watcher.py
@@ -220,6 +220,7 @@ class WritebackWatcher:
             with self._cond:
                 if self._pending_count == 0:
                     return
+                # Claim a task; this thread now owns completing it.
                 task = self._tasks.popleft() if self._tasks else None
                 if task is None:
                     # Tasks owned elsewhere: await completion signal.
@@ -255,6 +256,8 @@ class WritebackWatcher:
 
     def _poll_loop(self) -> None:
         """Main polling loop for the background thread."""
+
+        # Sleep only when nothing was ready to complete.
         while not self._stop_event.is_set():
             if not self._service_next_task():
                 sleep(self._poll_interval)
@@ -287,6 +290,7 @@ class WritebackWatcher:
                 self._pending_count -= 1
                 self._cond.notify_all()
             return True
+        # Event not fired yet: put the task back for another pass.
         with self._cond:
             self._tasks.append(task)
             self._cond.notify_all()
@@ -319,6 +323,7 @@ class WritebackWatcher:
             if deadline is None:
                 task.event.synchronize()
             else:
+                # CUDA events have no timed wait: poll to the deadline.
                 while not task.event.query():
                     if perf_counter() >= deadline:
                         raise _timeout_error(timeout)

--- a/tests/batchsolving/arrays/test_batchinputarrays.py
+++ b/tests/batchsolving/arrays/test_batchinputarrays.py
@@ -155,6 +155,32 @@ def test_update_fast_path_requeues_attached_inputs(
     assert_array_equal(ia.driver_coefficients, drivers)
 
 
+def test_update_fast_path_rejects_stale_slot_dtype(
+    solverkernel_mutable, system, precision
+):
+    """A slot dtype change defeats the attached-input fast path."""
+    sk = solverkernel_mutable
+    ia = sk.input_arrays
+    n_states = system.sizes.states
+    n_params = system.sizes.parameters
+    inits = np.ones((n_states, 1), dtype=precision)
+    params = np.full((n_params, 1), 2.0, dtype=precision)
+    ia.update(sk, inits, params, None)
+    attached_inits = ia.host.initial_values.array
+    assert attached_inits is inits
+
+    stale = (
+        np.float64 if np.dtype(precision) == np.float32 else np.float32
+    )
+    ia.host.initial_values.dtype = stale
+    ia.update(sk, attached_inits, params, None)
+
+    replaced = ia.host.initial_values.array
+    assert replaced is not attached_inits
+    assert replaced.dtype == stale
+    assert_array_equal(replaced, attached_inits)
+
+
 # ── Forwarding properties (items 9-14) ──────────────────── #
 
 

--- a/tests/batchsolving/arrays/test_batchinputarrays.py
+++ b/tests/batchsolving/arrays/test_batchinputarrays.py
@@ -123,6 +123,38 @@ def test_update_includes_driver_coefficients(
     assert_array_equal(ia.driver_coefficients, drivers)
 
 
+def test_update_fast_path_requeues_attached_inputs(
+    solverkernel_mutable, system, precision
+):
+    """Re-supplying the attached arrays queues overwrites only."""
+    sk = solverkernel_mutable
+    ia = sk.input_arrays
+    n_states = system.sizes.states
+    n_params = system.sizes.parameters
+    n_drivers = system.sizes.drivers
+    inits = np.ones((n_states, 1), dtype=precision)
+    params = np.full((n_params, 1), 2.0, dtype=precision)
+    drivers = np.ones((4, n_drivers, 1), dtype=precision) * 3.0
+    ia.update(sk, inits, params, drivers)
+    attached_inits = ia.host.initial_values.array
+    attached_params = ia.host.parameters.array
+    attached_drivers = ia.host.driver_coefficients.array
+    ia._needs_overwrite = []
+
+    inits[:] = 7.0
+    drivers[:] = 9.0
+    ia.update(sk, attached_inits, attached_params, drivers)
+
+    assert ia.host.initial_values.array is attached_inits
+    assert ia.host.parameters.array is attached_params
+    assert ia.host.driver_coefficients.array is attached_drivers
+    assert set(ia._needs_overwrite) == {
+        "initial_values", "parameters", "driver_coefficients"
+    }
+    assert_array_equal(ia.initial_values, inits)
+    assert_array_equal(ia.driver_coefficients, drivers)
+
+
 # ── Forwarding properties (items 9-14) ──────────────────── #
 
 

--- a/tests/batchsolving/arrays/test_batchoutputarrays.py
+++ b/tests/batchsolving/arrays/test_batchoutputarrays.py
@@ -282,7 +282,7 @@ class TestOutputArrays:
         )
 
     def test_update_from_solver_fast_path(self, output_arrays_manager, solver):
-        """Test that update_from_solver reuses arrays when shape/dtype match."""
+        """Unchanged sizes return None and keep the attached arrays."""
         # First call allocates arrays
         output_arrays_manager.update(solver)
 
@@ -291,13 +291,20 @@ class TestOutputArrays:
         original_observables = output_arrays_manager.host.observables.array
         original_status_codes = output_arrays_manager.host.status_codes.array
 
-        # Second call with same solver should reuse arrays
+        # Second call with same solver signals no rebuild is needed
         new_arrays = output_arrays_manager.update_from_solver(solver)
 
+        assert new_arrays is None
         # Arrays should be the same objects (not reallocated)
-        assert new_arrays["state"] is original_state
-        assert new_arrays["observables"] is original_observables
-        assert new_arrays["status_codes"] is original_status_codes
+        assert output_arrays_manager.host.state.array is original_state
+        assert (
+            output_arrays_manager.host.observables.array
+            is original_observables
+        )
+        assert (
+            output_arrays_manager.host.status_codes.array
+            is original_status_codes
+        )
 
     def test_initialise_method(
         self, output_arrays_manager, solver, test_memory_manager

--- a/tests/batchsolving/test_batch_input_handler.py
+++ b/tests/batchsolving/test_batch_input_handler.py
@@ -1060,16 +1060,23 @@ def test_fast_return_params_ok_states_provided_1d_broadcasts(
 # ── _materialise: verbatim pass-through and pinned landing ─ #
 
 
-def test_materialise_passes_matching_arrays_through(input_handler):
-    """A C-contiguous correct-precision array is returned verbatim."""
+def test_materialise_passes_matching_user_arrays_through(input_handler):
+    """A caller's C-contiguous correct-precision array returns verbatim."""
     arr = np.ones((3, 4), dtype=input_handler.precision)
-    assert input_handler._materialise(arr) is arr
+    assert input_handler._materialise(arr, arr) is arr
+
+
+def test_materialise_passes_views_of_user_arrays_through(input_handler):
+    """A contiguous view of the caller's array returns verbatim."""
+    arr = np.ones((4, 4), dtype=input_handler.precision)
+    view = arr[:3]
+    assert input_handler._materialise(view, arr) is view
 
 
 def test_materialise_casts_into_precision_buffer(input_handler):
     """A mismatched dtype lands once in a contiguous precision buffer."""
     src = np.arange(12, dtype=np.int64).reshape(3, 4)
-    out = input_handler._materialise(src)
+    out = input_handler._materialise(src, src)
     assert out is not src
     assert out.dtype == input_handler.precision
     assert out.flags["C_CONTIGUOUS"]
@@ -1079,7 +1086,7 @@ def test_materialise_casts_into_precision_buffer(input_handler):
 def test_materialise_fixes_contiguity(input_handler):
     """A strided view lands once in a contiguous buffer."""
     src = np.ones((3, 8), dtype=input_handler.precision)[:, ::2]
-    out = input_handler._materialise(src)
+    out = input_handler._materialise(src, src)
     assert out is not src
     assert out.flags["C_CONTIGUOUS"]
     assert out.shape == src.shape
@@ -1089,5 +1096,29 @@ def test_materialise_fixes_contiguity(input_handler):
 def test_materialise_lands_pinned_below_ceiling(input_handler):
     """Materialised inputs below the ceiling are page-locked."""
     src = np.ones((3, 8), dtype=input_handler.precision)[:, ::2]
-    out = input_handler._materialise(src)
+    out = input_handler._materialise(src, src)
     assert is_pinned_array(out)
+
+
+@pytest.mark.nocudasim
+def test_materialise_pins_handler_assembled_arrays(input_handler):
+    """An assembled array in-precision and contiguous lands pinned."""
+    assembled = np.ones((3, 8), dtype=input_handler.precision)
+    out = input_handler._materialise(assembled, None)
+    assert out is not assembled
+    assert is_pinned_array(out)
+    assert_array_equal(out, assembled)
+
+
+@pytest.mark.nocudasim
+def test_call_dict_inputs_return_pinned_grids(input_handler, system):
+    """Grids assembled from dict inputs land in pinned buffers."""
+    state_names = list(system.initial_values.names)
+    param_names = list(system.parameters.names)
+    inits, params = input_handler(
+        states={state_names[0]: [0.5, 1.5]},
+        params={param_names[0]: [0.1, 0.2]},
+        kind="verbatim",
+    )
+    assert is_pinned_array(inits)
+    assert is_pinned_array(params)

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -233,9 +233,24 @@ def test_solve_info_property(
 
     assert hasattr(solve_info, "summarised_observables")
 
-    # The solver is session-scoped: hand it back at the duration
-    # every later test on this worker expects.
+    # Hand the session-scoped solver back at its previous duration.
     solver.kernel.duration = previous_duration
+
+
+def test_solve_info_cached(solver_mutable):
+    """solve_info reuses its SolveSpec until settings or times change."""
+    solver = solver_mutable
+    solver.kernel.duration = 1.0
+    first = solver.solve_info
+    assert solver.solve_info is first
+
+    solver.kernel.duration = 2.0
+    changed_duration = solver.solve_info
+    assert changed_duration is not first
+    assert changed_duration.duration == solver.duration
+
+    solver.update({"save_every": solver.save_every})
+    assert solver.solve_info is not changed_duration
 
 
 def test_solve_basic(

--- a/tests/batchsolving/test_writeback_watcher.py
+++ b/tests/batchsolving/test_writeback_watcher.py
@@ -104,7 +104,7 @@ def test_watcher_init_defaults():
     assert w._pending_count == 0
     assert w._thread is None
     assert not w._stop_event.is_set()
-    assert w._queue.empty()
+    assert not w._tasks
 
 
 def test_watcher_init_custom_poll_interval():
@@ -212,6 +212,25 @@ def test_wait_all_raises_timeout_error():
     w._pending_count = 1
     with pytest.raises(TimeoutError, match="wait_all timed out"):
         w.wait_all(timeout=0.05)
+
+
+def test_wait_all_drains_inline_without_thread():
+    """wait_all completes queued tasks in the calling thread."""
+    w = WritebackWatcher()
+    buf = _make_pinned_buffer(fill=7.0)
+    target = np.zeros((4, 3), dtype=np.float32)
+    pool = _make_pool()
+    task = WritebackTask(
+        event=None, buffer=buf, target_array=target,
+        buffer_pool=pool, array_name="state",
+    )
+    # Enqueue without submit() so no background thread starts.
+    w._tasks.append(task)
+    w._pending_count = 1
+    w.wait_all(timeout=1.0)
+    assert w._pending_count == 0
+    assert w._thread is None
+    np.testing.assert_array_equal(target, 7.0)
 
 
 # ── shutdown (items 15, 16, 17) ───────────────────────────────── #
@@ -394,12 +413,10 @@ def test_poll_loop_drain_requeues_still_pending_task_on_shutdown():
         event=event, buffer=buf, target_array=target,
         buffer_pool=pool, array_name="state",
     )
-    w._queue.put(task)
+    w._tasks.append(task)
     w._pending_count = 1
     w._stop_event.set()
-    # Task is very likely still pending on the first drain pass given
-    # the busy kernel above; the drain loop must retry until it
-    # completes.
+    # The drain loop retries until the busy kernel's event completes.
     w._poll_loop()
     np.testing.assert_array_equal(target, 44.0)
 
@@ -436,13 +453,13 @@ def test_poll_loop_drains_queue_directly_on_shutdown():
         event=None, buffer=buf, target_array=target,
         buffer_pool=pool, array_name="state",
     )
-    w._queue.put(task)
+    w._tasks.append(task)
     w._pending_count = 1
     w._stop_event.set()
     # No thread involved: call the loop body directly and synchronously.
     w._poll_loop()
     np.testing.assert_array_equal(target, 21.0)
-    assert w._queue.empty()
+    assert not w._tasks
 
 
 def test_multiple_tasks_all_complete():

--- a/tests/test_array_interpolator.py
+++ b/tests/test_array_interpolator.py
@@ -7,7 +7,7 @@ import pytest
 from scipy.interpolate import CubicSpline
 
 from cubie.odesystems.solver_helpers import SolverHelperRequest
-from cubie.cuda_simsafe import cuda
+from cubie.cuda_simsafe import cuda, is_pinned_array
 
 from cubie.array_interpolator import ArrayInterpolator
 from cubie.odesystems.symbolic.symbolicODE import SymbolicODE
@@ -1358,3 +1358,49 @@ def test_update_from_dict_applies_config_change_with_equal_arrays(
     assert interp.coefficients_shape[2] == 4
     assert interp.coefficients.shape == interp.coefficients_shape
 
+
+
+# ── Coefficient buffer backing and reuse ─────────────────── #
+
+
+def test_coefficients_buffer_reused_for_value_updates(precision):
+    """Same-shape value updates land in the same coefficients array."""
+    times = np.arange(0.0, 6.0, 1.0, dtype=precision)
+    input_dict = {"values": times**2, "time": times, "order": 2,
+                  "wrap": False}
+    interp = ArrayInterpolator(precision=precision, input_dict=input_dict)
+    first = interp.coefficients
+
+    changed = dict(input_dict)
+    changed["values"] = times**2 + 1.0
+    interp.update_from_dict(changed)
+
+    assert interp.coefficients is first
+    assert interp.coefficients.shape == interp.coefficients_shape
+
+
+def test_coefficients_buffer_reallocated_on_shape_change(precision):
+    """A segment-count change produces a new coefficients array."""
+    times = np.arange(0.0, 6.0, 1.0, dtype=precision)
+    input_dict = {"values": times**2, "time": times, "order": 2,
+                  "wrap": False}
+    interp = ArrayInterpolator(precision=precision, input_dict=input_dict)
+    first = interp.coefficients
+
+    longer = np.arange(0.0, 9.0, 1.0, dtype=precision)
+    interp.update_from_dict(
+        {"values": longer**2, "time": longer, "order": 2, "wrap": False}
+    )
+
+    assert interp.coefficients is not first
+    assert interp.coefficients.shape == interp.coefficients_shape
+
+
+@pytest.mark.nocudasim
+def test_coefficients_land_pinned_below_ceiling(precision):
+    """Coefficients are page-locked for direct async transfer."""
+    times = np.arange(0.0, 6.0, 1.0, dtype=precision)
+    input_dict = {"values": times**2, "time": times, "order": 2,
+                  "wrap": False}
+    interp = ArrayInterpolator(precision=precision, input_dict=input_dict)
+    assert is_pinned_array(interp.coefficients)


### PR DESCRIPTION
Per-solve host overhead on short host-to-host solves is back at the ~500us mark. On the Lorenz benchmark problem (n=8, classical-rk4, host arrays in and out), 200 warm solves measure min 432us / median 460us (mlir) and min 457us / median 488us (numba-cuda); before this change the same harness measured min 3560us / median 5722us. Introduced by #621, whose intended fast path did not hold on the host->host route.

Restoring the fast path:

- **Assembled grids land pinned.** `BatchInputHandler._materialise` now distinguishes caller-supplied arrays (verbatim pass-through, unchanged) from handler-assembled grids (dict inputs, defaults, casts, combinatorial products), which land in page-locked buffers below the memory manager's pinned ceiling. Assembled grids are always in-precision and C-contiguous, so the old dtype/contiguity test passed them through pageable and every solve staged all inputs through the pinned pool with a CUDA event per block.
- **Driver coefficients are born transfer-ready.** `ArrayInterpolator` takes the solver's memory manager and lands computed coefficients in a persistent buffer — pinned below the manager's ceiling, pageable above it — reused while shape and precision are unchanged. Repeat solves re-attach the same object, and `InputArrays` treats coefficients like every other host input; a recompute writes the new values into the same buffer.
- **`WritebackWatcher.wait_all` drains inline.** Pending tasks live in a shared deque guarded by a condition; `wait_all` pops tasks in the calling thread and blocks on each task's CUDA event. Previously the waiter slept in 1ms increments while the daemon thread (also on a 1ms tick) processed tasks whose events had already fired — several milliseconds of pure sleep per solve, paid after the stream was already synchronized. The daemon still recycles staging buffers during chunked runs; its polling loop and shutdown drain share one pop/process/requeue step.
- `SolveSpec.atol`/`rtol` validate `instance_of(ndarray)` before the float validator: with array tolerances, `or_` formatted the float validator's failure message — a full array repr — twice per solve.

Trimming the repeat-solve bookkeeping that remained:

- `SolveSpec` is cached on the Solver and rebuilt only after a settings update or a duration/warmup/t0 change; invalidation clears the cache key.
- `OutputArrays.update` returns early when the size signature is unchanged and the slots hold matching buffers; device buffers still reallocate after an invalidation.
- `InputArrays.update` takes a fast path when the supplied arrays are the objects already attached in the slot dtype: overwrites queue (values still upload every solve) without attach checks or allocation bookkeeping. An array whose slot dtype changed after an invalidation takes the slow path and is cast before the transfer.
- `ArrayContainer` caches managed-array field discovery in an attrs field, making per-label lookups dict hits instead of `__dict__` scans.

AGENTS.md directs agents to capture `ab_gate.py` stdout untruncated.

Full CUDASIM suite (3081 passed) and full real-GPU suite (3130 passed).

Performance gate on the final head: **PASS** — every row ok or improvement on both backends, no contested rows. The `host_overhead` config from #691 measures this PR directly: per-call host cost drops **4.759 -> 0.628 ms** (numba-cuda) and **4.560 -> 0.811 ms** (mlir):

```
numba-cuda fixed          kernel  A    62.110  B    62.148   +0.09%  ok
numba-cuda fixed          wall    A    75.968  B    72.221   -5.05%  ok
numba-cuda adaptive       kernel  A    17.983  B    17.981   -0.12%  ok
numba-cuda adaptive       wall    A    22.332  B    21.088   -5.58%  ok
numba-cuda host_overhead  wall    A     4.759  B     0.628   -4.144ms  improvement
numba-cuda chunked        kernel  A    62.386  B    62.424   +0.03%  ok
numba-cuda chunked        wall    A    78.521  B    77.132   -1.85%  ok
numba-cuda wave           kernel  A    25.669  B    25.570   -0.39%  ok
numba-cuda wave           wall    A    28.974  B    28.044   -2.96%  ok
mlir       fixed          kernel  A    62.277  B    62.297   -0.03%  ok
mlir       fixed          wall    A    76.288  B    75.933   -0.51%  ok
mlir       adaptive       kernel  A    17.449  B    17.381   -0.49%  ok
mlir       adaptive       wall    A    21.828  B    21.381   -1.94%  ok
mlir       host_overhead  wall    A     4.560  B     0.811   -3.714ms  improvement
mlir       chunked        kernel  A    62.458  B    62.625   +0.27%  ok
mlir       chunked        wall    A    78.262  B    77.577   -1.01%  ok
mlir       wave           kernel  A    25.698  B    25.768   +0.36%  ok
mlir       wave           wall    A    29.028  B    28.629   -1.40%  ok

GATE: PASS (kernel threshold 0.50%, wall threshold 10.00%, host-overhead threshold 0.25 ms)
```

Compile metrics (registers, spills, shared, occupancy) are identical A vs B — no device code changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbPcS1bDP8eGnKqjfixE7P
