### PR TITLE
chore(benchmarks): ab_gate guards per-call host overhead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,10 @@ updating a PR; targeted subsets miss cross-cutting tests.
   its lowest `k` per-solve kernel times (CUDA-event, kernel-only: the fastest solves track the
   kernel's intrinsic cost); the two blocks of a pair run seconds apart and share clock state, so
   the verdict per config is the **median paired delta** against `--threshold` (default 0.50%),
-  with non-zero exit on regression. A default run takes ~3 minutes for two backends on a quiet
-  GPU. A row marked DISTRUST means the per-pair deltas disagreed. Retry the gate once, with more
+  with non-zero exit on regression. The `host_overhead` config (a constant 8 trajectories,
+  guarding the per-call host cost of `Solver.solve`) gates on its wall statistic only, in
+  absolute milliseconds against `--host-overhead-threshold` (default 0.25 ms). A default run
+  takes ~3 minutes for two backends on a quiet GPU. A row marked DISTRUST means the per-pair deltas disagreed. Retry the gate once, with more
   `--pairs`; publish the PR with the retry's table as-is, DISTRUST rows and all. Constant
   background load inflates absolute times but cancels out of the deltas. `--calibrate` measures
   the A-vs-A null for setting the threshold on a new machine;

--- a/benchmarks/ab_gate.py
+++ b/benchmarks/ab_gate.py
@@ -27,13 +27,22 @@ register deltas that leave occupancy and spill unchanged are
 reported but not gated (their runtime effect, if any, is caught by
 the timing rows).
 
-Four configs run (see ``lorenz_mean_runtime.py``): ``fixed`` and
+Five configs run (see ``lorenz_mean_runtime.py``): ``fixed`` and
 ``adaptive`` as before; ``chunked``, whose small VRAM cap forces a
 few run-axis chunks so chunk-path regressions surface in its wall
-delta; and ``wave``, sized by the gate to exactly two full waves of
+delta; ``wave``, sized by the gate to exactly two full waves of
 side A's occupancy (``wave <n_runs>`` handshake after startup) so
 any occupancy decrease on B forces a third wave and a step kernel
-regression instead of hiding behind compute saturation.
+regression instead of hiding behind compute saturation; and
+``host_overhead``, a constant eight trajectories whose
+sub-millisecond wall statistic is the per-call host cost of
+``Solver.solve``. Its wall delta gates in **absolute milliseconds**
+(``--host-overhead-threshold``) — a fixed per-call cost is a
+rounding error against the percent thresholds at the other configs'
+sizes — and it reports no kernel row, since an eight-trajectory
+kernel time is launch-dominated. Both workers run this repository's
+benchmark script (only the ``cubie`` import differs per side); a
+config announced by only one worker is skipped with a notice.
 
 Why blocks: the floor of the kernel-time distribution tracks the
 compiled kernel's intrinsic cost but wanders a few tenths of a
@@ -54,7 +63,8 @@ Usage::
 
     python benchmarks/ab_gate.py [--main REF] [--backends numba-cuda,mlir]
         [--pairs P] [--min-count K] [--threshold PCT]
-        [--wall-threshold PCT] [--n-runs N] [--chunked-runs N]
+        [--wall-threshold PCT] [--host-overhead-threshold MS]
+        [--n-runs N] [--chunked-runs N]
         [--chunked-proportion P] [--calibrate] [--keep]
 
 ``--calibrate`` points B at ``main`` too (A-vs-A); rerun it a few
@@ -242,7 +252,7 @@ def compare_meta(backend, metas, keys):
     """Print the A-vs-B compile-metrics table; return regression."""
     regressed = False
     print(f"\n[{backend}] compile metrics, A -> B")
-    print(f"{'config':<10}{'metric':<20}{'A':>12}{'B':>12}  flags")
+    print(f"{'config':<15}{'metric':<20}{'A':>12}{'B':>12}  flags")
     for key in keys:
         a, b = metas["A"][key], metas["B"][key]
         flags = []
@@ -269,7 +279,7 @@ def compare_meta(backend, metas, keys):
         for index, field in enumerate(META_FIELDS):
             suffix = "  ".join(flags) if index == 0 else ""
             print(
-                f"{key if index == 0 else '':<10}{field:<20}"
+                f"{key if index == 0 else '':<15}{field:<20}"
                 f"{a[field]:>12}{b[field]:>12}  {suffix}"
             )
     return regressed
@@ -313,11 +323,20 @@ def run_backend(backend, main_tree, b_tree, base, args):
             ready[side], metas[side] = read_startup(
                 workers[side], side)
             print(f"[{backend}] {side} ready", file=sys.stderr)
-        if ready["A"] != ready["B"]:
+        common = [key for key in ready["A"] if key in ready["B"]]
+        if not common:
             raise SystemExit(
-                f"config keys differ between sides: "
+                f"no config keys shared between sides: "
                 f"A={ready['A']} B={ready['B']}"
             )
+        for side in ("A", "B"):
+            skipped = [k for k in ready[side] if k not in common]
+            if skipped:
+                print(
+                    f"[{backend}] configs only on side {side}, "
+                    f"skipped: {', '.join(skipped)}",
+                    file=sys.stderr,
+                )
 
         # Size the wave config from side A's occupancy — "two full
         # waves at current levels" — and impose that count on both
@@ -337,7 +356,7 @@ def run_backend(backend, main_tree, b_tree, base, args):
         for side in ("A", "B"):
             line = read_reply(workers[side], "@META wave ", side)
             metas[side]["wave"] = parse_meta(line)[1]
-        keys = ready["A"] + ["wave"]
+        keys = common + ["wave"]
 
         def block(side, store=None):
             for key in keys:
@@ -375,7 +394,13 @@ def run_backend(backend, main_tree, b_tree, base, args):
     }
     for key in keys:
         k = min(args.min_count, BLOCK_SOLVES)
-        for stat_index, stat in enumerate(("kernel", "wall")):
+        # host_overhead gates on the wall statistic only.
+        stats = (
+            ("wall",) if key == "host_overhead"
+            else ("kernel", "wall")
+        )
+        for stat in stats:
+            stat_index = 0 if stat == "kernel" else 1
             floors = {
                 side: [
                     statistics.fmean(sorted(blk[stat_index])[:k])
@@ -388,15 +413,27 @@ def run_backend(backend, main_tree, b_tree, base, args):
             # The i-th A and B blocks ran back to back (one ABBA
             # pair), so they share clock state; the median paired
             # delta cancels wander that survives in the side means.
-            deltas = [
-                100.0 * (bf - af) / af
-                for af, bf in zip(floors["A"], floors["B"])
-            ]
+            if key == "host_overhead":
+                # Paired deltas in absolute milliseconds.
+                deltas = [
+                    bf - af
+                    for af, bf in zip(floors["A"], floors["B"])
+                ]
+                threshold = args.host_overhead_threshold
+                unit = "ms"
+            else:
+                deltas = [
+                    100.0 * (bf - af) / af
+                    for af, bf in zip(floors["A"], floors["B"])
+                ]
+                threshold = thresholds[stat]
+                unit = "%"
             delta, verdict, distrust = classify_deltas(
-                deltas, thresholds[stat]
+                deltas, threshold
             )
             rows.append(
-                (backend, key, stat, a, b, delta, verdict, distrust)
+                (backend, key, stat, a, b, delta, verdict,
+                 distrust, unit)
             )
     return rows, meta_regressed
 
@@ -449,6 +486,11 @@ def main():
                              "host scatter from concurrent machine "
                              "load, so it is far coarser than "
                              "--threshold.")
+    parser.add_argument("--host-overhead-threshold", type=float,
+                        default=0.25,
+                        help="Regression threshold for the "
+                             "host_overhead config's wall delta, in "
+                             "absolute milliseconds per solve.")
     parser.add_argument("--calibrate", action="store_true",
                         help="Point B at main too (A-vs-A null).")
     parser.add_argument("--keep", action="store_true",
@@ -493,13 +535,18 @@ def main():
             regressed = regressed or meta_regressed
             print()
             for row in rows:
-                bk, key, stat, a, b, delta, verdict, distrust = row
+                (bk, key, stat, a, b, delta, verdict, distrust,
+                 unit) = row
                 regressed = regressed or verdict == "REGRESSION"
                 distrusted = distrusted or distrust
                 flag = "  DISTRUST" if distrust else ""
-                print(f"{bk:<11}{key:<10}{stat:<8}"
+                shown = (
+                    f"{delta:+7.3f}ms" if unit == "ms"
+                    else f"{delta:+6.2f}%"
+                )
+                print(f"{bk:<11}{key:<15}{stat:<8}"
                       f"A {a:9.3f}  B {b:9.3f}  "
-                      f"{delta:+6.2f}%  {verdict}{flag}")
+                      f"{shown}  {verdict}{flag}")
     finally:
         if not args.keep:
             remove_worktree(main_tree)
@@ -512,7 +559,8 @@ def main():
     )
     print(f"\nGATE: {status} "
           f"(kernel threshold {args.threshold:.2f}%, wall threshold "
-          f"{args.wall_threshold:.2f}%)")
+          f"{args.wall_threshold:.2f}%, host-overhead threshold "
+          f"{args.host_overhead_threshold:.2f} ms)")
     if distrusted:
         print("DISTRUST = the pairs split on the regression call, "
               "so that verdict is unreliable; rerun, with more "

--- a/benchmarks/lorenz_mean_runtime.py
+++ b/benchmarks/lorenz_mean_runtime.py
@@ -9,7 +9,7 @@ repeat. The first 20 post-warm-up solves are discarded — the GPU has
 not reached steady state and they run slow — and the statistic covers
 the following ``repeats`` solves.
 
-Four configs run, each printing compile metrics and two statistics:
+Five configs run, each printing compile metrics and two statistics:
 
 ``fixed``
     classical-rk4 at ``2**22`` trajectories (or the positional
@@ -40,6 +40,12 @@ Four configs run, each printing compile metrics and two statistics:
     and a step runtime increase, so occupancy regressions cannot
     hide behind compute saturation. Runs with ``duration = 10`` so
     each solve lasts tens of milliseconds.
+``host_overhead``
+    The fixed config at a constant **8 trajectories**, never scaled
+    by the positional ``n_runs``. Its kernel runs in tens of
+    microseconds, so its wall statistic is the per-call host cost
+    of ``Solver.solve`` — the floor a user pays on every solve
+    regardless of batch size.
 
 Two statistics are reported per config. The **kernel** statistic is
 the mean of the lowest ``min_count`` per-solve kernel times — the
@@ -303,6 +309,7 @@ def build_solvers(n_fixed, n_adaptive, n_chunked, chunked_proportion):
         )
 
     wave_solver = build_fixed_style_solver(lorenz_system)
+    host_overhead_solver = build_fixed_style_solver(lorenz_system)
 
     return {
         "fixed": ("fixed (classical-rk4)", fixed_solver, n_fixed, 1.0),
@@ -310,6 +317,12 @@ def build_solvers(n_fixed, n_adaptive, n_chunked, chunked_proportion):
             "adaptive (radau)",
             adaptive_solver,
             n_adaptive,
+            1.0,
+        ),
+        "host_overhead": (
+            "host overhead (classical-rk4)",
+            host_overhead_solver,
+            8,
             1.0,
         ),
         "chunked": (


### PR DESCRIPTION
A fifth gate config, `host_overhead`, runs the fixed solver at a constant 8 trajectories — never scaled by `--n-runs` — so its kernel is tens of microseconds and its wall statistic is the per-call host cost of `Solver.solve`. It gates on the wall statistic only, as the median paired delta in absolute milliseconds against `--host-overhead-threshold` (default 0.25 ms), and reports no kernel row: a fixed per-call cost is invisible to the percent thresholds at the other configs' sizes, which is how the #621 regression (~500 µs → ~5 ms per call, fixed in #690) passed the gate. The gate also skips, with a notice, any config announced by only one worker instead of aborting.

The default 0.25 ms threshold sits 2.5x above the observed null: a 2-pair smoke run measured a +0.100 ms null delta, and the full run below measures −0.113/−0.084 ms.

Performance gate (default run; both sides run pre-#690 cubie, so the `host_overhead` rows show the current ~5 ms overhead equally on A and B):

```
numba-cuda fixed          kernel  A    62.117  B    62.105   -0.04%  ok
numba-cuda fixed          wall    A    76.109  B    75.453   -0.78%  ok
numba-cuda adaptive       kernel  A    17.980  B    17.996   -0.01%  ok
numba-cuda adaptive       wall    A    22.166  B    22.193   +0.01%  ok
numba-cuda host_overhead  wall    A     4.758  B     4.699   -0.113ms  ok
numba-cuda chunked        kernel  A    62.391  B    62.380   -0.02%  ok
numba-cuda chunked        wall    A    82.438  B    81.549   -1.19%  ok
numba-cuda wave           kernel  A    25.655  B    25.665   +0.00%  ok
numba-cuda wave           wall    A    28.600  B    28.627   +0.18%  ok
mlir       fixed          kernel  A    62.454  B    62.302   +0.04%  ok
mlir       fixed          wall    A    77.131  B    76.661   -0.41%  ok
mlir       adaptive       kernel  A    17.457  B    17.410   -0.35%  ok
mlir       adaptive       wall    A    22.092  B    21.813   -1.65%  ok
mlir       host_overhead  wall    A     5.368  B     5.306   -0.084ms  ok
mlir       chunked        kernel  A    62.442  B    62.540   +0.05%  ok
mlir       chunked        wall    A    79.569  B    82.895   +3.93%  ok
mlir       wave           kernel  A    25.653  B    25.831   +0.29%  ok
mlir       wave           wall    A    28.730  B    29.151   +1.12%  ok

GATE: PASS (kernel threshold 0.50%, wall threshold 10.00%, host-overhead threshold 0.25 ms)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbPcS1bDP8eGnKqjfixE7P