### PR TITLE
chore(ci): GPU sanity check runs after environment setup

### DIFF
--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -322,8 +322,7 @@ jobs:
       - name: Lint with flake8
         run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
-      # Last GPU-free step: first-boot driver PnP-binding (Windows AMI
-      # baked on a different GPU family) overlaps the setup steps above.
+      # Last GPU-free step: first-boot driver PnP-binding overlaps setup.
       - name: GPU sanity check
         shell: bash
         run: |

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -296,27 +296,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # The Windows AMI bakes the multi-GPU GRID driver on whichever GPU
-      # family the bake's spot request landed (packer/windows-gpu.pkr.hcl);
-      # on the first boot atop a *different* family, Windows PnP binds the
-      # driver to the new hardware ID asynchronously after boot, and the
-      # runner can take the job before the bind completes. Poll for up to
-      # 3 minutes (nudging a device rescan on Windows) before declaring
-      # the GPU genuinely absent.
-      - name: GPU sanity check
-        shell: bash
-        run: |
-          for attempt in $(seq 1 36); do
-            if nvidia-smi; then
-              exit 0
-            fi
-            command -v pnputil.exe >/dev/null 2>&1 && pnputil.exe /scan-devices || true
-            echo "nvidia-smi not ready (attempt ${attempt}/36); retrying in 5s"
-            sleep 5
-          done
-          echo "GPU driver never became available" >&2
-          exit 1
-
       # uv resolves and installs several times faster than pip, and its
       # wheel cache rides GitHub's actions/cache service, so the
       # multi-GB nvidia-*/cupy wheels download once per leg flavour,
@@ -342,6 +321,22 @@ jobs:
 
       - name: Lint with flake8
         run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+
+      # Last GPU-free step: first-boot driver PnP-binding (Windows AMI
+      # baked on a different GPU family) overlaps the setup steps above.
+      - name: GPU sanity check
+        shell: bash
+        run: |
+          for attempt in $(seq 1 36); do
+            if nvidia-smi; then
+              exit 0
+            fi
+            command -v pnputil.exe >/dev/null 2>&1 && pnputil.exe /scan-devices || true
+            echo "nvidia-smi not ready (attempt ${attempt}/36); retrying in 5s"
+            sleep 5
+          done
+          echo "GPU driver never became available" >&2
+          exit 1
 
       - name: Test with pytest
         # -n logical (CLI) overrides pyproject's desktop-safe -n8 so the


### PR DESCRIPTION
The GPU sanity check is now the last GPU-free step in the cuda job, placed after setup-python, uv setup, kernel-cache download, install, and lint. On Windows runners the AMI's first boot on a GPU family other than the one it was baked on PnP-binds the driver asynchronously; running the check last lets that bind complete during environment setup instead of being polled through beforehand (measured 87-123 s of polling per affected leg in run 998, ~9 min GPU time per run). The 3-minute poll loop is unchanged and remains the failure backstop.

No runtime code changes; the performance gate does not apply.

Co-authored by Chris' bot