### PR TITLE
chore(ci): AMI bake preps toolcache, runner agent, and driver search; age-guarded cadence

### DIFF
--- a/.github/workflows/build-windows-gpu-ami.yml
+++ b/.github/workflows/build-windows-gpu-ami.yml
@@ -64,26 +64,12 @@ jobs:
         if: steps.age.outputs.bake == 'true'
         run: packer init packer/windows-gpu.pkr.hcl
 
+      # Chase brief per-AZ spot windows; only capacity misses retry.
       - name: Build AMI
-        # Acquire a spot GPU instance, then bake. GPU spot capacity here is
-        # tight and shows up in brief, random windows (freed when some other
-        # load ends), so two nested retries chase it:
-        #  * AZ sweep (spatial): Packer pins a build to one subnet = one AZ
-        #    and capacity is per-AZ, so try each default-VPC subnet in turn.
-        #  * short fixed-interval rounds (temporal): a dry fleet fails in
-        #    ~6s, so poll frequently at a constant interval to catch a brief
-        #    window -- exponential backoff would just miss it by waiting
-        #    ever longer.
-        # Only a spot-acquisition miss (fleet yielded no instance) retries.
-        # A post-launch failure (WinRM, driver install) exits immediately
-        # with Packer's real code -- it would recur in every AZ and a
-        # Windows bake runs 30-60 min. A regional spot-quota miss
-        # (MaxSpotInstanceCountExceeded) skips the rest of that round's AZ
-        # sweep (all AZs share the quota) but still retries. Set
-        # AWS_BUILD_SUBNET_ID to pin one subnet (e.g. no default VPC).
         if: steps.age.outputs.bake == 'true'
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
+          # Set to pin one subnet (e.g. no default VPC).
           PINNED_SUBNET: ${{ vars.AWS_BUILD_SUBNET_ID }}
           MAX_ROUNDS: "40"
           RETRY_INTERVAL: "20"   # seconds between rounds; short and frequent

--- a/.github/workflows/build-windows-gpu-ami.yml
+++ b/.github/workflows/build-windows-gpu-ami.yml
@@ -7,8 +7,8 @@ on:
         type: boolean
         default: false
   schedule:
-    # Fires days 1/15/29; the age guard bakes roughly four-weekly.
-    - cron: "0 3 */14 * *"
+    # Mondays; the 25-day age guard yields exact 28-day bake cycles.
+    - cron: "0 3 * * 1"
 
 permissions:
   id-token: write   # OIDC -> AWS
@@ -27,7 +27,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_AMI_BUILDER_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      # Age-guarded ~4-weekly cadence; manual dispatches always bake.
+      # Age guard for scheduled firings; manual dispatches always bake.
       - name: Decide whether to bake
         id: age
         env:
@@ -133,6 +133,22 @@ jobs:
           done
           echo "No spot GPU capacity after $MAX_ROUNDS rounds." >&2
           exit 1
+
+      # Surface PREP-MARKER lines; warn when the agent refresh skipped.
+      - name: Report image prep results
+        if: steps.age.outputs.bake == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo '## Image prep'
+            grep -o 'PREP-MARKER.*' packer.out \
+              || echo 'no PREP-MARKER lines in packer output'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if ! grep -Eq 'PREP-MARKER runner-agent: (updated|current)' \
+              packer.out; then
+            echo "::warning::Runner agent not refreshed; AMI dispatch" \
+              "lifetime tracks the base image's agent."
+          fi
 
       - name: Deregister superseded cubie-win-gpu AMIs
         # Keep the most recent AMI; deregister older ones (and their

--- a/.github/workflows/build-windows-gpu-ami.yml
+++ b/.github/workflows/build-windows-gpu-ami.yml
@@ -1,14 +1,19 @@
 name: Build Windows GPU AMI
 on:
   workflow_dispatch:
+    inputs:
+      keep_old_amis:
+        description: Keep superseded AMIs after this bake
+        type: boolean
+        default: false
   schedule:
-    # Days 1/15/29 (~14-day cadence) keeps the baked RunsOn agent well
-    # under GitHub's 30-day runner-dispatch cutoff.
+    # Fires days 1/15/29; the age guard bakes roughly four-weekly.
     - cron: "0 3 */14 * *"
 
 permissions:
   id-token: write   # OIDC -> AWS
   contents: read
+  issues: write     # bake-failure alert
 
 jobs:
   build-ami:
@@ -22,10 +27,41 @@ jobs:
           role-to-assume: ${{ secrets.AWS_AMI_BUILDER_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
 
+      # Age-guarded ~4-weekly cadence; manual dispatches always bake.
+      - name: Decide whether to bake
+        id: age
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "schedule" ]; then
+            echo "bake=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          newest=$(aws ec2 describe-images --owners self \
+            --filters "Name=name,Values=cubie-win-gpu-*" \
+            --query 'sort_by(Images,&CreationDate)[-1].CreationDate' \
+            --output text)
+          if [ "$newest" = "None" ]; then
+            echo "No existing AMI; baking."
+            echo "bake=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          age_days=$(( ($(date +%s) - $(date -d "$newest" +%s)) / 86400 ))
+          echo "Newest AMI is ${age_days} days old."
+          if [ "$age_days" -ge 25 ]; then
+            echo "bake=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skipping this firing."
+            echo "bake=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Packer
+        if: steps.age.outputs.bake == 'true'
         uses: hashicorp/setup-packer@v3
 
       - name: Packer init
+        if: steps.age.outputs.bake == 'true'
         run: packer init packer/windows-gpu.pkr.hcl
 
       - name: Build AMI
@@ -45,6 +81,7 @@ jobs:
         # (MaxSpotInstanceCountExceeded) skips the rest of that round's AZ
         # sweep (all AZs share the quota) but still retries. Set
         # AWS_BUILD_SUBNET_ID to pin one subnet (e.g. no default VPC).
+        if: steps.age.outputs.bake == 'true'
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           PINNED_SUBNET: ${{ vars.AWS_BUILD_SUBNET_ID }}
@@ -114,6 +151,7 @@ jobs:
       - name: Deregister superseded cubie-win-gpu AMIs
         # Keep the most recent AMI; deregister older ones (and their
         # snapshots) so snapshot storage cost does not grow unbounded.
+        if: steps.age.outputs.bake == 'true' && inputs.keep_old_amis != true
         run: |
           set -euo pipefail
           KEEP=$(aws ec2 describe-images --owners self \
@@ -133,3 +171,24 @@ jobs:
               done
             fi
           done
+
+      # Dead bakes age the fleet toward GitHub's runner-dispatch cutoff.
+      - name: Open an issue on bake failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="Windows GPU AMI bake failed"
+          body="Failed run: ${RUN_URL}. Runners stop receiving jobs once the baked agent falls 30 days behind the latest actions/runner release, so fix and re-dispatch the bake promptly."
+          number=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --state open --search "in:title \"$title\"" \
+            --json number --jq '.[0].number // empty')
+          if [ -z "$number" ]; then
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$title" --body "$body"
+          else
+            gh issue comment "$number" --repo "$GITHUB_REPOSITORY" \
+              --body "$body"
+          fi

--- a/ci/tools/prepare_ci_image.ps1
+++ b/ci/tools/prepare_ci_image.ps1
@@ -12,26 +12,37 @@ $runnerReleaseUrl =
 
 function Set-LocalOnlyDriverSearch {
     # PnP device installs use the local driver store only.
-    $keyPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion' +
+    $prefKey = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion' +
         '\DriverSearching'
-    New-Item -Path $keyPath -Force | Out-Null
-    New-ItemProperty -Path $keyPath -Name 'SearchOrderConfig' `
+    New-Item -Path $prefKey -Force | Out-Null
+    New-ItemProperty -Path $prefKey -Name 'SearchOrderConfig' `
         -PropertyType DWord -Value 0 -Force | Out-Null
-    Write-Host 'Driver search restricted to the local driver store.'
+    # The policy key wins over the preference key where both exist.
+    $polKey = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows' +
+        '\DriverSearching'
+    New-Item -Path $polKey -Force | Out-Null
+    New-ItemProperty -Path $polKey -Name 'DontSearchWindowsUpdate' `
+        -PropertyType DWord -Value 1 -Force | Out-Null
+    Write-Host 'PREP-MARKER driver-search: local-only'
 }
 
 function Get-ToolcacheRoot {
-    $default = 'C:\hostedtoolcache\windows'
-    if (Test-Path -Path $default) {
-        return $default
+    $root = 'C:\hostedtoolcache\windows'
+    if (-not (Test-Path -Path $root)) {
+        $found = Get-ChildItem -Path 'C:\' -Directory `
+            -Filter '*toolcache*' -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($found) {
+            $root = Join-Path $found.FullName 'windows'
+        }
     }
-    $found = Get-ChildItem -Path 'C:\' -Directory `
-        -Filter '*toolcache*' -ErrorAction SilentlyContinue |
-        Select-Object -First 1
-    if ($found) {
-        return (Join-Path $found.FullName 'windows')
+    # A root without pre-baked Pythons is not the runner's toolcache.
+    $probe = Get-ChildItem -Path (Join-Path $root 'Python') `
+        -Directory -ErrorAction SilentlyContinue
+    if (-not $probe) {
+        throw "No pre-baked Pythons under $root; wrong toolcache root."
     }
-    return $default
+    return $root
 }
 
 function Install-ToolcachePython {
@@ -44,7 +55,7 @@ function Install-ToolcachePython {
     $cached = Get-ChildItem -Path $pythonRoot -Directory `
         -Filter "$Spec.*" -ErrorAction SilentlyContinue
     if ($cached) {
-        Write-Host "Python $Spec already in the toolcache."
+        Write-Host "PREP-MARKER python-${Spec}: already present"
         return
     }
     # Newest stable entry that still ships a Windows build.
@@ -57,7 +68,7 @@ function Install-ToolcachePython {
         } |
         Select-Object -First 1
     if (-not $release) {
-        throw "No stable win32/x64 python-versions release matches $Spec."
+        throw "No stable win32/x64 python-versions release for $Spec."
     }
     $file = $release.files |
         Where-Object { $_.platform -eq 'win32' -and $_.arch -eq 'x64' } |
@@ -72,10 +83,18 @@ function Install-ToolcachePython {
     $env:AGENT_TOOLSDIRECTORY = $ToolsDirectory
     Push-Location $extractDir
     try {
+        # Vendored script; its non-terminating errors stay non-fatal.
+        $ErrorActionPreference = 'Continue'
         & .\setup.ps1
     } finally {
+        $ErrorActionPreference = 'Stop'
         Pop-Location
     }
+    $marker = Join-Path $pythonRoot "$($release.version)\x64.complete"
+    if (-not (Test-Path -Path $marker)) {
+        throw "Python $($release.version) install left no $marker."
+    }
+    Write-Host "PREP-MARKER python-${Spec}: installed $($release.version)"
 }
 
 function Get-RunnerDirectory {
@@ -104,16 +123,34 @@ function Get-RunnerDirectory {
                 -ErrorAction SilentlyContinue
         }
     }
+    # The listener lives in <runner root>\bin.
     $dirs = @($hits |
+        Where-Object { $_.Directory.Name -eq 'bin' } |
         ForEach-Object { $_.Directory.Parent.FullName } |
         Sort-Object -Unique)
     if ($dirs.Count -ne 1) {
-        Write-Host ("Runner agent refresh skipped: " +
-            "$($dirs.Count) candidate installs found " +
-            "($($dirs -join ', '))")
+        Write-Host ("PREP-MARKER runner-agent: skipped " +
+            "($($dirs.Count) candidate installs: $($dirs -join ', '))")
         return $null
     }
     return $dirs[0]
+}
+
+function Get-RunnerVersion {
+    param([Parameter(Mandatory = $true)][string]$Listener)
+    try {
+        # Native stderr under a Stop preference is terminating in 5.1.
+        $ErrorActionPreference = 'Continue'
+        $raw = & $Listener --version 2>$null | Select-Object -First 1
+    } catch {
+        return $null
+    } finally {
+        $ErrorActionPreference = 'Stop'
+    }
+    if ($LASTEXITCODE -ne 0 -or -not $raw) {
+        return $null
+    }
+    return "$raw".Trim()
 }
 
 function Update-RunnerAgent {
@@ -122,12 +159,23 @@ function Update-RunnerAgent {
         return
     }
     $listener = Join-Path $runnerDir 'bin\Runner.Listener.exe'
-    $current = (& $listener --version).Trim()
-    $latest = Invoke-RestMethod -Uri $runnerReleaseUrl -UseBasicParsing
+    $current = Get-RunnerVersion -Listener $listener
+    if (-not $current) {
+        Write-Host ('PREP-MARKER runner-agent: skipped ' +
+            '(version probe failed)')
+        return
+    }
+    try {
+        $latest = Invoke-RestMethod -Uri $runnerReleaseUrl `
+            -UseBasicParsing
+    } catch {
+        Write-Host ("PREP-MARKER runner-agent: skipped " +
+            "(release query failed: $_)")
+        return
+    }
     $version = $latest.tag_name.TrimStart('v')
-    Write-Host ("Runner agent at ${runnerDir}: " +
-        "installed $current, latest $version")
     if ($current -eq $version) {
+        Write-Host "PREP-MARKER runner-agent: current $current"
         return
     }
     $assetName = "actions-runner-win-x64-$version.zip"
@@ -142,11 +190,11 @@ function Update-RunnerAgent {
         -OutFile $zipPath -UseBasicParsing
     # Overlay: standard runner files are replaced, extra files kept.
     Expand-Archive -Path $zipPath -DestinationPath $runnerDir -Force
-    $updated = (& $listener --version).Trim()
+    $updated = Get-RunnerVersion -Listener $listener
     if ($updated -ne $version) {
         throw "Runner agent update failed: reports $updated."
     }
-    Write-Host "Runner agent updated to $updated."
+    Write-Host "PREP-MARKER runner-agent: updated $current -> $updated"
 }
 
 Set-LocalOnlyDriverSearch

--- a/ci/tools/prepare_ci_image.ps1
+++ b/ci/tools/prepare_ci_image.ps1
@@ -1,0 +1,162 @@
+##  Bake-time prep for the cubie Windows GPU CI AMI (run by Packer).
+
+$ErrorActionPreference = 'Stop'
+
+# Python versions the CUDA test matrix uses on Windows runners.
+$pythonVersions = @('3.10', '3.11')
+
+$pythonManifestUrl = 'https://raw.githubusercontent.com/actions/' +
+    'python-versions/main/versions-manifest.json'
+$runnerReleaseUrl =
+    'https://api.github.com/repos/actions/runner/releases/latest'
+
+function Set-LocalOnlyDriverSearch {
+    # PnP device installs use the local driver store only.
+    $keyPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion' +
+        '\DriverSearching'
+    New-Item -Path $keyPath -Force | Out-Null
+    New-ItemProperty -Path $keyPath -Name 'SearchOrderConfig' `
+        -PropertyType DWord -Value 0 -Force | Out-Null
+    Write-Host 'Driver search restricted to the local driver store.'
+}
+
+function Get-ToolcacheRoot {
+    $default = 'C:\hostedtoolcache\windows'
+    if (Test-Path -Path $default) {
+        return $default
+    }
+    $found = Get-ChildItem -Path 'C:\' -Directory `
+        -Filter '*toolcache*' -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($found) {
+        return (Join-Path $found.FullName 'windows')
+    }
+    return $default
+}
+
+function Install-ToolcachePython {
+    param(
+        [Parameter(Mandatory = $true)][string]$Spec,
+        [Parameter(Mandatory = $true)][string]$ToolsDirectory,
+        [Parameter(Mandatory = $true)]$Manifest
+    )
+    $pythonRoot = Join-Path $ToolsDirectory 'Python'
+    $cached = Get-ChildItem -Path $pythonRoot -Directory `
+        -Filter "$Spec.*" -ErrorAction SilentlyContinue
+    if ($cached) {
+        Write-Host "Python $Spec already in the toolcache."
+        return
+    }
+    # Newest stable entry that still ships a Windows build.
+    $release = $Manifest |
+        Where-Object {
+            $_.stable -and $_.version -like "$Spec.*" -and
+            ($_.files | Where-Object {
+                $_.platform -eq 'win32' -and $_.arch -eq 'x64'
+            })
+        } |
+        Select-Object -First 1
+    if (-not $release) {
+        throw "No stable win32/x64 python-versions release matches $Spec."
+    }
+    $file = $release.files |
+        Where-Object { $_.platform -eq 'win32' -and $_.arch -eq 'x64' } |
+        Select-Object -First 1
+    Write-Host "Installing Python $($release.version) into $pythonRoot"
+    $zipPath = Join-Path $env:TEMP "python-$($release.version).zip"
+    Invoke-WebRequest -Uri $file.download_url -OutFile $zipPath `
+        -UseBasicParsing
+    $extractDir = Join-Path $env:TEMP "python-$($release.version)"
+    Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+    # setup.ps1 installs the actions/setup-python toolcache layout.
+    $env:AGENT_TOOLSDIRECTORY = $ToolsDirectory
+    Push-Location $extractDir
+    try {
+        & .\setup.ps1
+    } finally {
+        Pop-Location
+    }
+}
+
+function Get-RunnerDirectory {
+    $roots = @(
+        'C:\actions-runner', 'C:\runners', 'C:\runner', 'C:\a',
+        'C:\actions', 'C:\ProgramData\RunsOn'
+    )
+    $hits = foreach ($root in $roots) {
+        if (Test-Path -Path $root) {
+            Get-ChildItem -Path $root -Recurse -Depth 3 `
+                -Filter 'Runner.Listener.exe' `
+                -ErrorAction SilentlyContinue
+        }
+    }
+    if (-not $hits) {
+        $skip = @(
+            'Windows', 'Program Files', 'Program Files (x86)',
+            'Users', 'PerfLogs', 'hostedtoolcache'
+        )
+        $shallow = Get-ChildItem -Path 'C:\' -Directory `
+            -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -notin $skip }
+        $hits = foreach ($dir in $shallow) {
+            Get-ChildItem -Path $dir.FullName -Recurse -Depth 3 `
+                -Filter 'Runner.Listener.exe' `
+                -ErrorAction SilentlyContinue
+        }
+    }
+    $dirs = @($hits |
+        ForEach-Object { $_.Directory.Parent.FullName } |
+        Sort-Object -Unique)
+    if ($dirs.Count -ne 1) {
+        Write-Host ("Runner agent refresh skipped: " +
+            "$($dirs.Count) candidate installs found " +
+            "($($dirs -join ', '))")
+        return $null
+    }
+    return $dirs[0]
+}
+
+function Update-RunnerAgent {
+    $runnerDir = Get-RunnerDirectory
+    if (-not $runnerDir) {
+        return
+    }
+    $listener = Join-Path $runnerDir 'bin\Runner.Listener.exe'
+    $current = (& $listener --version).Trim()
+    $latest = Invoke-RestMethod -Uri $runnerReleaseUrl -UseBasicParsing
+    $version = $latest.tag_name.TrimStart('v')
+    Write-Host ("Runner agent at ${runnerDir}: " +
+        "installed $current, latest $version")
+    if ($current -eq $version) {
+        return
+    }
+    $assetName = "actions-runner-win-x64-$version.zip"
+    $asset = $latest.assets |
+        Where-Object { $_.name -eq $assetName } |
+        Select-Object -First 1
+    if (-not $asset) {
+        throw "actions/runner $($latest.tag_name) has no $assetName."
+    }
+    $zipPath = Join-Path $env:TEMP $assetName
+    Invoke-WebRequest -Uri $asset.browser_download_url `
+        -OutFile $zipPath -UseBasicParsing
+    # Overlay: standard runner files are replaced, extra files kept.
+    Expand-Archive -Path $zipPath -DestinationPath $runnerDir -Force
+    $updated = (& $listener --version).Trim()
+    if ($updated -ne $version) {
+        throw "Runner agent update failed: reports $updated."
+    }
+    Write-Host "Runner agent updated to $updated."
+}
+
+Set-LocalOnlyDriverSearch
+
+$toolsDirectory = Get-ToolcacheRoot
+Write-Host "Toolcache root: $toolsDirectory"
+$manifest = Invoke-RestMethod -Uri $pythonManifestUrl -UseBasicParsing
+foreach ($spec in $pythonVersions) {
+    Install-ToolcachePython -Spec $spec `
+        -ToolsDirectory $toolsDirectory -Manifest $manifest
+}
+
+Update-RunnerAgent

--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -52,8 +52,7 @@ variable "runs_on_owner" {
   default = "135269210855"
 }
 
-# RunsOn Windows 2025 base image; already carries the RunsOn agent, so a
-# 14-day rebuild keeps the agent under GitHub's 30-day dispatch cutoff.
+# RunsOn Windows 2025 base image; already carries the RunsOn agent.
 variable "source_ami_name" {
   type    = string
   default = "runs-on-v2.2-windows25-full-x64-*"
@@ -146,6 +145,11 @@ build {
 
   provisioner "powershell" {
     scripts = ["ci/tools/install_gpu_driver.ps1"]
+  }
+
+  # Toolcache Pythons, latest runner agent, local-only driver search.
+  provisioner "powershell" {
+    scripts = ["ci/tools/prepare_ci_image.ps1"]
   }
 
   # Disable WinRM in the published AMI and reset EC2Launch so it


### PR DESCRIPTION
The Packer build runs a new prep provisioner (ci/tools/prepare_ci_image.ps1) after driver verification:

- **Local-only driver search**: both the preference key (SearchOrderConfig=0) and the overriding policy key (DontSearchWindowsUpdate=1) are set, so first-boot PnP binds of the GRID driver on a GPU family other than the bake's resolve from the local driver store without consulting Windows Update, shortening the bind the GPU sanity check waits on (measured 87-123 s per affected leg).
- **Toolcache Pythons**: 3.10 and 3.11 are installed into the hostedtoolcache at bake time, so actions/setup-python cache-hits on every Windows matrix leg (measured 43-49 s download+install per 3.10/3.11 leg today; 3.14 already cache-hits at <20 s). The resolved toolcache root must hold the base image's pre-baked Pythons and each install must leave its x64.complete marker, otherwise the bake fails.
- **Runner agent refresh**: the baked actions/runner is replaced with the latest release, so the image's dispatch lifetime counts from the bake, not from the RunsOn base image's agent (the base publishes ~monthly and its agent can be weeks old at bake time). Discovery accepts only a single listener under a bin directory; probe or release-query failures degrade to a logged skip rather than failing the bake.

The bake workflow schedules on Mondays with a 25-day AMI-age guard: three Mondays fall inside the guard window, the fourth bakes, giving exact 28-day cycles independent of month lengths, roughly halving bake spend. With the agent refreshed at bake, a 28-day cycle sits inside GitHub's 30-day agent-dispatch cutoff. Manual dispatches always bake and can keep superseded AMIs (keep_old_amis input) so a validation bake retains a rollback image. PREP-MARKER lines from the provisioner are surfaced in the job summary with a warning when the agent refresh did not happen, and bake failures open or comment on a tracking issue instead of failing silently.

No runtime code changes; the performance gate does not apply.

Co-authored by Chris' bot