### PR TITLE
fix(batchsolving): extend_grid_to_array tiles defaults across runs

### DIFF
--- a/src/cubie/batchsolving/BatchInputHandler.py
+++ b/src/cubie/batchsolving/BatchInputHandler.py
@@ -156,7 +156,6 @@ from numpy import (
     empty as np_empty,
     vstack as np_vstack,
     atleast_1d as np_atleast_1d,
-    column_stack as np_column_stack,
 )
 
 from numpy.typing import ArrayLike
@@ -457,7 +456,7 @@ def extend_grid_to_array(
         # Scatter grid rows to their variable indices; grid rows follow
         # the caller's key order, which need not match declared order.
         n_runs = grid.shape[1]
-        array = np_column_stack([default_values] * n_runs)
+        array = np_tile(default_values[:, np_newaxis], (1, n_runs))
         array[indices, :] = grid
 
     return array


### PR DESCRIPTION
`extend_grid_to_array` builds the default-value array with `np.tile` of the defaults column and scatters the swept rows in place. Assembly cost is one C-level copy at any run count; the previous `np.column_stack([default_values] * n_runs)` materialised one Python list slot and one 2D-view ndarray per run (~200 bytes/run of object overhead), which raised `MemoryError` at 2^29 runs and consumed ~25 GiB transient at 2^27. 16.7M-run assembly now completes in 37 ms.

Full suites: CUDASIM 3081 passed, real GPU 3130 passed.

Performance gate (retry per DISTRUST protocol, `--pairs 8`):

```
A = origin/main (87aeff2a)   B = fix/extend-grid-tile (working tree)   backends: numba-cuda, mlir   (8 block pairs x 15 solves/block/side)

numba-cuda fixed          kernel  A   157.203  B   172.723   +0.03%  ok  DISTRUST
numba-cuda fixed          wall    A   171.539  B   182.857   -2.48%  ok
numba-cuda adaptive       kernel  A    46.518  B    45.818   -0.77%  improvement  DISTRUST
numba-cuda adaptive       wall    A    51.043  B    49.172   -3.91%  ok
numba-cuda host_overhead  wall    A     1.147  B     0.958   -0.200ms  ok
numba-cuda chunked        kernel  A   174.328  B   176.452   +0.80%  REGRESSION  DISTRUST
numba-cuda chunked        wall    A   189.715  B   191.756   +0.67%  ok
numba-cuda wave           kernel  A    70.489  B    71.779   +2.46%  REGRESSION  DISTRUST
numba-cuda wave           wall    A    72.600  B    73.868   +2.13%  ok

mlir       fixed          kernel  A   204.447  B   202.501   -0.44%  ok
mlir       fixed          wall    A   218.262  B   216.336   -0.38%  ok
mlir       adaptive       kernel  A    51.552  B    51.573   -0.12%  ok
mlir       adaptive       wall    A    55.925  B    55.747   -0.27%  ok
mlir       host_overhead  wall    A     1.290  B     1.133   -0.112ms  ok
mlir       chunked        kernel  A   198.945  B   204.723   -0.45%  ok
mlir       chunked        wall    A   214.315  B   219.839   -0.52%  ok
mlir       wave           kernel  A    81.406  B    81.243   -0.21%  ok
mlir       wave           wall    A    83.851  B    83.810   -0.15%  ok

GATE: REGRESSION (kernel threshold 0.50%, wall threshold 10.00%, host-overhead threshold 0.25 ms)
```

Compile metrics are identical A→B on both backends (registers, spills, shared, occupancy, chunking). Both numba-cuda REGRESSION rows carry DISTRUST (the per-pair deltas split), and the numba-cuda leg's absolute A-side times moved 157↔203 ms between the first run and the retry; the mlir leg is uniformly within ±0.5%.

Co-authored by Chris' bot
