### PR TITLE
chore(ci): AMI bakes a uv wheel cache for the Windows GPU legs

### DIFF
--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -296,14 +296,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # uv resolves and installs several times faster than pip, and its
-      # wheel cache rides GitHub's actions/cache service, so the
-      # multi-GB nvidia-*/cupy wheels download once per leg flavour,
-      # not once per run.
+      # Linux legs ride actions/cache; Windows legs use the baked cache.
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          enable-cache: true
+          enable-cache: ${{ matrix.os == 'linux' }}
           cache-suffix: ${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}
           cache-dependency-glob: pyproject.toml
 
@@ -316,6 +313,9 @@ jobs:
       - name: Install cubie (${{ matrix.extra }})
         shell: bash
         run: |
+          if [ "${{ matrix.os }}" = "windows" ]; then
+            export UV_CACHE_DIR='C:\uv-cache'
+          fi
           uv pip install --system -e ".[${{ matrix.extra }}]" \
             -c kernel-cache/constraints.txt
 

--- a/ci/tools/populate_uv_cache.ps1
+++ b/ci/tools/populate_uv_cache.ps1
@@ -1,0 +1,94 @@
+##  Bake-time uv wheel-cache populate for the cubie Windows GPU CI AMI.
+
+$ErrorActionPreference = 'Stop'
+
+$cacheDir = 'C:\uv-cache'
+$pyprojectPath = 'C:\Windows\Temp\pyproject.toml'
+$uvReleaseUrl =
+    'https://api.github.com/repos/astral-sh/uv/releases/latest'
+
+# (python spec, extra) pairs the Windows CUDA matrix installs.
+$combos = @(
+    @('3.10', 'dev12'), @('3.10', 'dev13'),
+    @('3.11', 'dev-mlir12'), @('3.11', 'dev-mlir13'),
+    @('3.14', 'dev12'), @('3.14', 'dev13'),
+    @('3.14', 'dev-mlir12'), @('3.14', 'dev-mlir13')
+)
+
+function Get-UvExecutable {
+    $latest = Invoke-RestMethod -Uri $uvReleaseUrl -UseBasicParsing
+    $asset = $latest.assets |
+        Where-Object { $_.name -eq 'uv-x86_64-pc-windows-msvc.zip' } |
+        Select-Object -First 1
+    if (-not $asset) {
+        throw 'No uv-x86_64-pc-windows-msvc.zip on the latest release.'
+    }
+    $zipPath = Join-Path $env:TEMP $asset.name
+    Invoke-WebRequest -Uri $asset.browser_download_url `
+        -OutFile $zipPath -UseBasicParsing
+    $binDir = Join-Path $env:TEMP 'uv-bin'
+    Expand-Archive -Path $zipPath -DestinationPath $binDir -Force
+    $exe = Get-ChildItem -Path $binDir -Recurse -Filter 'uv.exe' |
+        Select-Object -First 1
+    if (-not $exe) {
+        throw 'uv.exe missing from the uv release archive.'
+    }
+    return $exe.FullName
+}
+
+function Get-ToolcachePython {
+    param([Parameter(Mandatory = $true)][string]$Spec)
+    $dir = Get-ChildItem -Path 'C:\hostedtoolcache\windows\Python' `
+        -Directory -Filter "$Spec.*" -ErrorAction SilentlyContinue |
+        Sort-Object -Property Name |
+        Select-Object -Last 1
+    if (-not $dir) {
+        throw "Python $Spec is not in the toolcache."
+    }
+    return (Join-Path $dir.FullName 'x64\python.exe')
+}
+
+function Invoke-Uv {
+    param([Parameter(Mandatory = $true)][string]$Uv,
+          [Parameter(Mandatory = $true)][string[]]$Arguments)
+    try {
+        # uv reports progress on stderr; keep that non-terminating.
+        $ErrorActionPreference = 'Continue'
+        & $Uv @Arguments 2>&1 | ForEach-Object { "$_" } | Write-Host
+    } finally {
+        $ErrorActionPreference = 'Stop'
+    }
+    if ($LASTEXITCODE -ne 0) {
+        throw "uv $($Arguments -join ' ') exited $LASTEXITCODE."
+    }
+}
+
+if (-not (Test-Path -Path $pyprojectPath)) {
+    throw "No pyproject.toml at $pyprojectPath."
+}
+$uv = Get-UvExecutable
+$env:UV_CACHE_DIR = $cacheDir
+New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+$stagingDir = Join-Path $env:TEMP 'uv-cache-staging'
+
+foreach ($combo in $combos) {
+    $spec = $combo[0]
+    $extra = $combo[1]
+    $python = Get-ToolcachePython -Spec $spec
+    $venv = Join-Path $stagingDir "venv-$spec-$extra"
+    $elapsed = Measure-Command {
+        Invoke-Uv -Uv $uv -Arguments @('venv', $venv, '--python', $python)
+        Invoke-Uv -Uv $uv -Arguments @(
+            'pip', 'install',
+            '--python', (Join-Path $venv 'Scripts\python.exe'),
+            '-r', $pyprojectPath, '--extra', $extra
+        )
+    }
+    Remove-Item -Path $venv -Recurse -Force
+    Write-Host ("PREP-MARKER uv-cache ${spec}/${extra}: " +
+        "$([int]$elapsed.TotalSeconds)s")
+}
+
+$bytes = (Get-ChildItem -Path $cacheDir -Recurse -File |
+    Measure-Object -Property Length -Sum).Sum
+Write-Host ("PREP-MARKER uv-cache total: {0:N1} GB" -f ($bytes / 1GB))

--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -152,6 +152,17 @@ build {
     scripts = ["ci/tools/prepare_ci_image.ps1"]
   }
 
+  # Stage pyproject.toml for dependency resolution during the bake.
+  provisioner "file" {
+    source      = "pyproject.toml"
+    destination = "C:/Windows/Temp/pyproject.toml"
+  }
+
+  # Pre-download the CUDA test matrix's wheels into C:\uv-cache.
+  provisioner "powershell" {
+    scripts = ["ci/tools/populate_uv_cache.ps1"]
+  }
+
   # Disable WinRM in the published AMI and reset EC2Launch so it
   # re-initialises (and re-runs the RunsOn agent bootstrap) on first boot as
   # a runner. Block mirrors runs-on/runner-images-for-aws


### PR DESCRIPTION
Stacked on #694.

The Packer build stages pyproject.toml onto the instance and runs a populate provisioner after image prep: for each of the 8 (Python, extra) pairs the Windows CUDA matrix installs, uv resolves the dependency set from pyproject.toml into a throwaway venv with UV_CACHE_DIR=C:\uv-cache. That puts the multi-GB cu12/cu13 nvidia and cupy wheel sets, plus the per-Python cpXX wheels, on the image. Dependencies only — cubie itself is never installed, so the cache does not track cubie's version; wheels that drift between 28-day bakes re-download as deltas at job time, identical to a cache miss today. Per-combo timings and the final cache size are logged as PREP-MARKER lines and surface in the bake job summary.

Workflow side: Windows fleet legs export UV_CACHE_DIR=C:\uv-cache in the install step and drop the actions/cache layer (its restore and post-job save no longer buy anything there); Linux fleet legs and GitHub-hosted precompile legs keep actions/cache unchanged. The install itself is byte-identical otherwise, and the installed environments are unchanged — the cache only changes where wheels are linked from. Addresses the measured 23-56 s install plus cache restore per Windows GPU leg (~5 min GPU per run).

The uv invocation contract (uv venv --python <toolcache python>; uv pip install --python <venv> -r pyproject.toml --extra <name>) was verified locally against uv 0.11.7 with a dry-run resolve of dev-mlir12.

No runtime code changes; the performance gate does not apply.

Co-authored by Chris' bot