### PR TITLE
fix(ci): bake provisioner scripts exit clean; runner version read from file metadata

### DIFF
--- a/ci/tools/populate_uv_cache.ps1
+++ b/ci/tools/populate_uv_cache.ps1
@@ -92,3 +92,6 @@ foreach ($combo in $combos) {
 $bytes = (Get-ChildItem -Path $cacheDir -Recurse -File |
     Measure-Object -Property Length -Sum).Sum
 Write-Host ("PREP-MARKER uv-cache total: {0:N1} GB" -f ($bytes / 1GB))
+
+# Packer exits with the wrapper's $LastExitCode; leave it clean.
+exit 0

--- a/ci/tools/prepare_ci_image.ps1
+++ b/ci/tools/prepare_ci_image.ps1
@@ -137,9 +137,7 @@ function Get-RunnerDirectory {
 }
 
 function Get-RunnerVersion {
-    # File metadata, not execution: ProductVersion is the release
-    # version plus '+<build sha>', and running the listener would leave
-    # a non-zero $LASTEXITCODE for Packer's `exit $LastExitCode`.
+    # Release version from file metadata; strip the '+<build sha>'.
     param([Parameter(Mandatory = $true)][string]$Listener)
     $product = (Get-Item -Path $Listener).VersionInfo.ProductVersion
     if (-not $product) {

--- a/ci/tools/prepare_ci_image.ps1
+++ b/ci/tools/prepare_ci_image.ps1
@@ -137,20 +137,15 @@ function Get-RunnerDirectory {
 }
 
 function Get-RunnerVersion {
+    # File metadata, not execution: ProductVersion is the release
+    # version plus '+<build sha>', and running the listener would leave
+    # a non-zero $LASTEXITCODE for Packer's `exit $LastExitCode`.
     param([Parameter(Mandatory = $true)][string]$Listener)
-    try {
-        # Native stderr under a Stop preference is terminating in 5.1.
-        $ErrorActionPreference = 'Continue'
-        $raw = & $Listener --version 2>$null | Select-Object -First 1
-    } catch {
-        return $null
-    } finally {
-        $ErrorActionPreference = 'Stop'
-    }
-    if ($LASTEXITCODE -ne 0 -or -not $raw) {
+    $product = (Get-Item -Path $Listener).VersionInfo.ProductVersion
+    if (-not $product) {
         return $null
     }
-    return "$raw".Trim()
+    return "$product".Split('+')[0].Trim()
 }
 
 function Update-RunnerAgent {
@@ -161,8 +156,8 @@ function Update-RunnerAgent {
     $listener = Join-Path $runnerDir 'bin\Runner.Listener.exe'
     $current = Get-RunnerVersion -Listener $listener
     if (-not $current) {
-        Write-Host ('PREP-MARKER runner-agent: skipped ' +
-            '(version probe failed)')
+        Write-Host ("PREP-MARKER runner-agent: skipped " +
+            "(no version metadata on $listener)")
         return
     }
     try {
@@ -175,7 +170,8 @@ function Update-RunnerAgent {
     }
     $version = $latest.tag_name.TrimStart('v')
     if ($current -eq $version) {
-        Write-Host "PREP-MARKER runner-agent: current $current"
+        Write-Host ("PREP-MARKER runner-agent: current $current " +
+            "($runnerDir)")
         return
     }
     $assetName = "actions-runner-win-x64-$version.zip"
@@ -194,7 +190,8 @@ function Update-RunnerAgent {
     if ($updated -ne $version) {
         throw "Runner agent update failed: reports $updated."
     }
-    Write-Host "PREP-MARKER runner-agent: updated $current -> $updated"
+    Write-Host ("PREP-MARKER runner-agent: updated " +
+        "$current -> $updated ($runnerDir)")
 }
 
 Set-LocalOnlyDriverSearch
@@ -208,3 +205,6 @@ foreach ($spec in $pythonVersions) {
 }
 
 Update-RunnerAgent
+
+# Packer exits with the wrapper's $LastExitCode; leave it clean.
+exit 0


### PR DESCRIPTION
Fixes the run 30603528511 bake failure. The provisioner errored with exit status 4294967295 immediately after the tolerated `runner-agent: skipped (version probe failed)` marker: Packer's powershell wrapper ends with `exit $LastExitCode`, and the failed `Runner.Listener.exe --version` probe left -1 there, so a failure the script deliberately absorbed still killed the build. Everything before it had succeeded on the g5 instance — driver install and verify, local-only driver search, toolcache Pythons 3.10.11 and 3.11.9.

Two changes:
- `Get-RunnerVersion` reads `ProductVersion` from the listener's file metadata (the release version precedes a `+<build sha>` suffix) instead of executing it — no process launch, no `$LASTEXITCODE` pollution, and it works regardless of why executing the listener fails on the RunsOn image. Verified locally against the actual v2.336.0 `actions-runner-win-x64` listener: probe returns exactly `2.336.0`.
- Both bake scripts (`prepare_ci_image.ps1`, `populate_uv_cache.ps1`) end with an explicit `exit 0` so absorbed native failures can never fail the provisioner via the wrapper. The wrapper semantics and the fix were reproduced locally under Windows PowerShell 5.1 (stale 255 propagates without `exit 0`, clean 0 with it).

Runner-agent markers carry the resolved runner directory for diagnosability. CI-only change; the performance gate does not apply.

Co-authored by Chris' bot