### PR TITLE
feat(ci): the CPU reference compiles once, in the precompile leg

### DIFF
--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -150,6 +150,11 @@ jobs:
           # and reach every kernel launch; test verdicts are
           # irrelevant here, only compile coverage matters.
           PYTHONOPTIMIZE: "1"
+          # CPU reference compiles once here and rides in the artifact.
+          NUMBA_CACHE_DIR: ${{ github.workspace }}/kernel-cache/numba-cpu
+          NUMBA_CACHE_LOCATOR_CLASSES: tests.numba_cache_locator.PortableCacheLocator
+          NUMBA_CPU_NAME: generic
+          NUMBA_CPU_FEATURES: ""
         run: |
           set -u
           # Exit 1 is tolerated: test verdicts are meaningless on
@@ -370,6 +375,11 @@ jobs:
           # any pytest sys.path setup, so the repo root must be on
           # PYTHONPATH for `tests.precompile_plugin` to import.
           PYTHONPATH: ${{ github.workspace }}
+          # Load the CPU reference the precompile leg compiled.
+          NUMBA_CACHE_DIR: ${{ github.workspace }}/kernel-cache/numba-cpu
+          NUMBA_CACHE_LOCATOR_CLASSES: tests.numba_cache_locator.PortableCacheLocator
+          NUMBA_CPU_NAME: generic
+          NUMBA_CPU_FEATURES: ""
         run: |
           set +e
           python -m coverage run -m pytest \

--- a/tests/numba_cache_locator.py
+++ b/tests/numba_cache_locator.py
@@ -1,0 +1,30 @@
+"""Numba CPU cache locator keyed on file content, not mtime or path."""
+import hashlib
+import os
+from pathlib import Path
+
+from numba.core import config
+from numba.core.caching import UserProvidedCacheLocator
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+class PortableCacheLocator(UserProvidedCacheLocator):
+    """Cache under NUMBA_CACHE_DIR, keyed by repo path and content."""
+
+    def __init__(self, py_func, py_file):
+        super().__init__(py_func, py_file)
+        source = Path(py_file).resolve()
+        try:
+            relative = source.relative_to(_ROOT)
+        except ValueError:
+            relative = Path(source.name)
+        self._cache_path = os.path.join(
+            config.CACHE_DIR, *relative.with_suffix("").parts
+        )
+        # Line endings differ between checkouts; the content does not.
+        data = source.read_bytes().replace(b"\r\n", b"\n")
+        self._stamp = hashlib.sha256(data).hexdigest()[:16]
+
+    def get_source_stamp(self):
+        return self._stamp


### PR DESCRIPTION
## What changed

`tests/numba_cache_locator.py` replaces numba's default CPU cache locator through `NUMBA_CACHE_LOCATOR_CLASSES`. It stamps the cache with a sha256 of the source (CRLF normalised) rather than `(st_mtime, st_size)`, and places entries under `NUMBA_CACHE_DIR` keyed by repo-relative path rather than a hash of the absolute source directory. Both changes are needed for a cache to survive a fresh checkout on a different runner.

With `NUMBA_CPU_NAME=generic` and an empty `NUMBA_CPU_FEATURES` the index key's CPU components collapse from `('x86_64-pc-windows-msvc', 'alderlake', '+64bit,+adx,+aes,…')` to `('x86_64-pc-windows-msvc', 'generic', '')`. The remaining key parts numba adds are sha256 hashes of the function bytecode and closure, which are already content-based.

Both jobs set the same four variables. `NUMBA_CACHE_DIR` sits inside `kernel-cache`, which the precompile job already uploads and the GPU job already downloads, so no artifact plumbing changes.

## Measurements

GPU leg at `-n 4` on an RTX 4070 SUPER, warm kernel cache, `__pycache__` cleared before every leg so each starts from a CI-like checkout:

| leg | wall |
| --- | --- |
| compiles the reference | 35.49 s / 31.28 s |
| loads the shipped cache | 24.89 s / 25.86 s |

Roughly 8 s per leg, about 24%. Without the cache all four xdist workers compile the same functions concurrently — 5.89 s, 5.09 s, 3.97 s and 3.69 s — for a union span of 9.16 s.

Verified transfers: a second process loads what the first saved; a second pytest run reports 0 saved and 21 loaded; a `--assert=plain` run loads what a rewriting run wrote, which is the precompile-to-GPU direction; and a checkout at a different absolute path sharing only `NUMBA_CACHE_DIR` reports 0 saved and 21 loaded.

The precompile leg populates it as a byproduct: running that job's exact command with `PYTHONOPTIMIZE=1`, `--assert=plain` and the device fakes wrote 6 index and 11 data files.
