### PR TITLE
fix(ci): WinRM connect timeouts retry on a fresh instance, capped at two

### DIFF
--- a/.github/workflows/build-windows-gpu-ami.yml
+++ b/.github/workflows/build-windows-gpu-ami.yml
@@ -94,6 +94,7 @@ jobs:
           # yields no instance (step_run_spot_instance.go); every AWS
           # capacity phrasing is wrapped by it, so match the wrapper.
           FLEET_MISS_RE='Error waiting for fleet request|InsufficientInstanceCapacity|no Spot capacity available|capacity-not-available|insufficient .*capacity'
+          winrm_misses=0
           echo "Candidate subnets (one per AZ): $SUBNETS"
           for round in $(seq 1 "$MAX_ROUNDS"); do
             echo "===== spot-acquisition round $round/$MAX_ROUNDS ====="
@@ -119,6 +120,14 @@ jobs:
               if grep -Eq "$FLEET_MISS_RE" packer.out; then
                 echo "Subnet $SN: no spot capacity now (rc=$rc);" \
                      "trying the next AZ."
+                continue
+              fi
+              # A healthy boot can still miss WinRM; two fresh tries.
+              if grep -q "Timeout waiting for WinRM" packer.out \
+                  && [ "$winrm_misses" -lt 2 ]; then
+                winrm_misses=$((winrm_misses + 1))
+                echo "Subnet $SN: WinRM never came up" \
+                     "(miss ${winrm_misses}/2); trying a fresh instance."
                 continue
               fi
               echo "Subnet $SN: Packer failed after launch / for a" \

--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -78,7 +78,7 @@ source "amazon-ebs" "windows_gpu" {
   winrm_username = "Administrator"
   winrm_use_ssl  = true
   winrm_insecure = true
-  winrm_timeout  = "30m"
+  winrm_timeout  = "12m"
 
   aws_polling {
     delay_seconds = 30


### PR DESCRIPTION
Run 30769708847 lost 30 idle minutes to a boot where Windows came up (password retrieved in ~2 min) but WinRM never accepted a connection — same base AMI and user-data that connected in 77 s three days earlier, so the class is transient (WinRM-enable user-data boot race, or runner egress IP shifting after the security group pinned it). The acquisition loop treated it as a non-capacity failure and gave up.

Two changes:
- The loop recognises `Timeout waiting for WinRM` in the packer output and retries on a fresh instance, with its own counter capped at two misses per run so a systematically broken image still fails fast instead of looping. Counter logic verified locally (two retries, third falls through to the non-capacity exit).
- `winrm_timeout` drops 30m → 12m: healthy connects take 1-4 minutes, so a dead one now costs 12 idle spot-minutes instead of 30. The worst case with both changes (two dead instances then a good one) is bounded at ~24 extra minutes, less than one of today's single silent timeouts.

CI-only change; the performance gate does not apply.

Co-authored by Chris' bot