### PR TITLE
fix(cache): the cache lock retries on a short backoff

### DIFF
--- a/src/cubie/cubie_cache.py
+++ b/src/cubie/cubie_cache.py
@@ -64,6 +64,11 @@ default_timelogger.register_event(
 )
 
 
+# Retry bounds for the cache lock, in seconds.
+_LOCK_RETRY_MIN = 0.0005
+_LOCK_RETRY_MAX = 0.02
+
+
 class _CacheFileLock(AbstractContextManager):
     """Cross-process lock for one cache index."""
 
@@ -82,6 +87,9 @@ class _CacheFileLock(AbstractContextManager):
                 self._handle.flush()
 
             deadline = monotonic() + self._timeout
+            # Holders keep the lock for the length of one index read, so
+            # start well below that and back off towards the old wait.
+            delay = _LOCK_RETRY_MIN
             while True:
                 try:
                     self._handle.seek(0)
@@ -100,7 +108,8 @@ class _CacheFileLock(AbstractContextManager):
                         raise TimeoutError(
                             f"Timed out waiting for cache lock {self._path}."
                         ) from None
-                    sleep(0.05)
+                    sleep(delay)
+                    delay = min(delay * 2.0, _LOCK_RETRY_MAX)
         except BaseException:
             try:
                 self._handle.close()

--- a/src/cubie/cubie_cache.py
+++ b/src/cubie/cubie_cache.py
@@ -87,8 +87,6 @@ class _CacheFileLock(AbstractContextManager):
                 self._handle.flush()
 
             deadline = monotonic() + self._timeout
-            # Holders keep the lock for the length of one index read, so
-            # start well below that and back off towards the old wait.
             delay = _LOCK_RETRY_MIN
             while True:
                 try:


### PR DESCRIPTION
## What changed

`_CacheFileLock` retried on a flat `sleep(0.05)`. A holder keeps the lock for the length of one index read — 2.6 ms median — so every collision cost roughly twenty times the wait it was covering. Retries now start at 0.5 ms and double to a 20 ms ceiling, leaving the mutual exclusion and the 120 s timeout unchanged.

## Measurements

Warm GPU leg at `-n 4`, 3120 tests, `compilations_completed=0`, per-load timings from a profiling plugin, all arms reading a kernel-cache directory that had already been read at least once:

| arm | loads | total load time | median | loads >= 40 ms |
| --- | --- | --- | --- | --- |
| flat 50 ms | 475 | 3.77 s | 2.6 ms | 41, costing 2.61 s |
| backoff | 479 | 1.87 s | 2.6 ms | 3, costing 0.27 s |
| backoff | 481 | 2.80 s | 3.3 ms | 10, costing 0.78 s |

The stalls that disappear were quantised at 50, 100, 150 and 200 ms, which is the retry sleep multiplied by the number of collisions. Suite wall clock moves within this machine's noise, so no wall claim is made.

Suites: CUDASIM 3074 passed; real GPU 3120 passed across three runs on this branch.
