### PR TITLE
chore(ci): the kernel cache is one artefact per compute capability

### DIFF
--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -15,6 +15,11 @@ concurrency:
   group: cuda-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
+# Capabilities precompiled for the fleet's GPUs; the GPU leg refuses a
+# device outside this set.
+env:
+  PRECOMPILE_CCS: "7.5 8.6 8.9"
+
 jobs:
   # Trigger gating and commit pinning for the paid GPU matrix. Runs on
   # a free GitHub-hosted runner within seconds of the trigger: for
@@ -163,7 +168,7 @@ jobs:
           # each pass must prove a session ran by writing its junit
           # report, and the lane must end with kernels in the cache.
           # Each capability caches into its own directory.
-          for cc in 7.5 8.6 8.9; do
+          for cc in $PRECOMPILE_CCS; do
             echo "::group::precompile cc=$cc"
             export CUBIE_KERNEL_CACHE_DIR="$GITHUB_WORKSPACE/kernel-cache/cc$cc/kernels"
             set +e
@@ -360,7 +365,20 @@ jobs:
             if nvidia-smi; then
               cc=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader \
                    | head -n1 | tr -d '[:space:]')
-              echo "compute capability: ${cc:-unknown}"
+              # A kernel this leg has to compile fails the suite, so an
+              # unusable cache is settled here, not after the test run.
+              if [ -z "$cc" ]; then
+                echo "the driver reported no compute capability" >&2
+                exit 1
+              fi
+              case " $PRECOMPILE_CCS " in
+                *" $cc "*) ;;
+                *)
+                  echo "cc $cc is not precompiled (have $PRECOMPILE_CCS)" >&2
+                  exit 1
+                  ;;
+              esac
+              echo "compute capability: $cc"
               echo "cc=$cc" >> "$GITHUB_OUTPUT"
               exit 0
             fi
@@ -371,22 +389,12 @@ jobs:
           echo "GPU driver never became available" >&2
           exit 1
 
-      # An unprecompiled capability leaves the cache empty.
+      # A missing artefact fails here rather than after a full test run.
       - name: Download precompiled kernels for this GPU
-        id: kernels
-        continue-on-error: true
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: kernel-cache-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}-cc${{ steps.gpu.outputs.cc }}
           path: kernel-cache
-
-      - name: Warn on a kernel cache miss
-        if: steps.kernels.outcome != 'success'
-        shell: bash
-        env:
-          CC: ${{ steps.gpu.outputs.cc }}
-        run: |
-          echo "::warning::no precompiled kernels for cc ${CC:-unknown}; this leg compiles from scratch"
 
       - name: Test with pytest
         # -n logical (CLI) overrides pyproject's desktop-safe -n8 so the

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -131,7 +131,6 @@ jobs:
       - name: Precompile kernels per compute capability
         shell: bash
         env:
-          CUBIE_KERNEL_CACHE_DIR: ${{ github.workspace }}/kernel-cache/kernels
           CUBIE_MAX_CACHE_ENTRIES: "0"
           # Pin the backend to the lane's label. The precompile plugin
           # and cubie resolve an unset CUBIE_CUDA_BACKEND with opposite
@@ -163,8 +162,10 @@ jobs:
           # import error in cubie or the plugin) also exits 1, so
           # each pass must prove a session ran by writing its junit
           # report, and the lane must end with kernels in the cache.
+          # Each capability caches into its own directory.
           for cc in 7.5 8.6 8.9; do
             echo "::group::precompile cc=$cc"
+            export CUBIE_KERNEL_CACHE_DIR="$GITHUB_WORKSPACE/kernel-cache/cc$cc/kernels"
             set +e
             CUBIE_TARGET_CC="$cc" pytest \
               -m "not specific_algos and not sim_only" \
@@ -181,27 +182,25 @@ jobs:
               echo "pytest exited $status without running a test session for cc=$cc" >&2
               exit 1
             fi
-            echo "::endgroup::"
-          done
-          if [ -z "$(find kernel-cache/kernels -type f -print -quit 2>/dev/null)" ]; then
-            echo "precompile produced no cached kernels in kernel-cache/kernels" >&2
-            exit 1
-          fi
-          # A lane can fill the cache with peripheral kernels while
-          # every solver-run fixture dies before its launch (a broken
-          # population fake produces exactly that), so require the
-          # batch-solver integration kernel. Production index keys
-          # carry no function identity, so the check reads the stored
-          # compile payloads: the kernel's mangled symbol embeds its
-          # qualname on both backends, and the batch-solver kernel is
-          # named per algorithm/system under the stable
-          # BatchSolverKernel.build_kernel qualname path.
-          python - <<'EOF'
+            if [ -z "$(find "kernel-cache/cc$cc/kernels" -type f -print -quit 2>/dev/null)" ]; then
+              echo "precompile produced no cached kernels for cc=$cc" >&2
+              exit 1
+            fi
+            # A lane can fill the cache with peripheral kernels while
+            # every solver-run fixture dies before its launch (a broken
+            # population fake produces exactly that), so require the
+            # batch-solver integration kernel. Production index keys
+            # carry no function identity, so the check reads the stored
+            # compile payloads: the kernel's mangled symbol embeds its
+            # qualname on both backends, and the batch-solver kernel is
+            # named per algorithm/system under the stable
+            # BatchSolverKernel.build_kernel qualname path.
+            python - "kernel-cache/cc$cc/kernels" <<'EOF'
           import sys
           from pathlib import Path
 
           needle = b"build_kernel"
-          for nbc in Path("kernel-cache/kernels").rglob("*.nbc"):
+          for nbc in Path(sys.argv[1]).rglob("*.nbc"):
               if needle in nbc.read_bytes():
                   sys.exit(0)
           print(
@@ -211,12 +210,36 @@ jobs:
           )
           sys.exit(1)
           EOF
+            du -sh "kernel-cache/cc$cc/kernels" || true
+            echo "::endgroup::"
+          done
 
-      - name: Upload kernel cache
+      # constraints.txt and the CPU reference do not vary by capability.
+      - name: Upload lane environment
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: kernel-cache-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}
-          path: kernel-cache
+          name: kernel-env-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}
+          path: |
+            kernel-cache/constraints.txt
+            kernel-cache/numba-cpu
+
+      - name: Upload kernel cache (cc7.5)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kernel-cache-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}-cc7.5
+          path: kernel-cache/cc7.5
+
+      - name: Upload kernel cache (cc8.6)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kernel-cache-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}-cc8.6
+          path: kernel-cache/cc8.6
+
+      - name: Upload kernel cache (cc8.9)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kernel-cache-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}-cc8.9
+          path: kernel-cache/cc8.9
 
   cuda:
     needs: [gate, precompile]
@@ -309,10 +332,11 @@ jobs:
           cache-suffix: ${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}
           cache-dependency-glob: pyproject.toml
 
-      - name: Download precompiled kernel cache
+      # Needed before install; the kernels wait for the GPU's capability.
+      - name: Download lane environment
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kernel-cache-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}
+          name: kernel-env-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}
           path: kernel-cache
 
       - name: Install cubie (${{ matrix.extra }})
@@ -329,10 +353,15 @@ jobs:
 
       # Last GPU-free step: first-boot driver PnP-binding overlaps setup.
       - name: GPU sanity check
+        id: gpu
         shell: bash
         run: |
           for attempt in $(seq 1 36); do
             if nvidia-smi; then
+              cc=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader \
+                   | head -n1 | tr -d '[:space:]')
+              echo "compute capability: ${cc:-unknown}"
+              echo "cc=$cc" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             command -v pnputil.exe >/dev/null 2>&1 && pnputil.exe /scan-devices || true
@@ -341,6 +370,23 @@ jobs:
           done
           echo "GPU driver never became available" >&2
           exit 1
+
+      # An unprecompiled capability leaves the cache empty.
+      - name: Download precompiled kernels for this GPU
+        id: kernels
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kernel-cache-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}-cc${{ steps.gpu.outputs.cc }}
+          path: kernel-cache
+
+      - name: Warn on a kernel cache miss
+        if: steps.kernels.outcome != 'success'
+        shell: bash
+        env:
+          CC: ${{ steps.gpu.outputs.cc }}
+        run: |
+          echo "::warning::no precompiled kernels for cc ${CC:-unknown}; this leg compiles from scratch"
 
       - name: Test with pytest
         # -n logical (CLI) overrides pyproject's desktop-safe -n8 so the


### PR DESCRIPTION
## What changed

`precompile` gives each capability its own cache directory and uploads it as `kernel-cache-<lane>-cc<cc>`. The "cache is non-empty" and "cache holds a batch-solver kernel" guards move inside the loop so each capability is checked on its own, and each pass prints its cache size.

`constraints.txt` and the CPU reference do not vary by capability, so they upload separately as `kernel-env-<lane>`. The GPU leg downloads that before installing, since the install is constrained by it.

The GPU leg then reads the device capability from `nvidia-smi --query-gpu=compute_cap` in the sanity check and downloads only the kernels compiled for it. The sanity check keeps its position as the last GPU-free step, so first-boot driver PnP binding still overlaps environment setup.

`tests/precompile_plugin.py` fails the session if any kernel compiles, so a leg that cannot load its cache is red regardless. It is settled before the test run instead: the sanity check rejects a driver that reports no compute capability and one outside `PRECOMPILE_CCS`, and the kernel download does not tolerate a missing artefact. `PRECOMPILE_CCS` is the single list the precompile loop iterates and the GPU leg checks against.

## Why the payload splits

From the `kernel-cache-linux-py3.11-cuda12-mlir` artefact of run 30652234815: 107.7 MB unpacked, 897 `.nbc` payloads under 102 index stems. 100 of those stems hold exactly three variants totalling 42.4 MB, split 14.2 / 14.1 / 14.1 MB across the three. All 100 have three byte-distinct payloads, and in every one the second and third match in size while the first differs — the shape expected of cc 7.5 against 8.6 and 8.9. Each GPU leg loads one of the three.

The `Download precompiled kernel cache` step averaged 16.2 s across the 16 `cuda` legs of that run, 260 s of the 4219 s billed.

The per-capability sizes are not asserted here: a local precompile did not reproduce CI's cache volume (0.8 MB against CI's 22.7 MB for the same backend), so the split is measured from CI's own artefact rather than from a local run. The `du -sh` each pass now prints reports the real per-capability sizes in the first run's log.

The capability gate was exercised by running the extracted sanity-check script against a stubbed `nvidia-smi`: 8.9 and 7.5 pass, 9.0 exits 1 naming the precompiled set, an empty reading exits 1.

Suites: CUDASIM 3090 passed, real GPU 3139 passed.
