### PR TITLE
fix: a missing device and a failed writeback no longer stall a solve

### DIFF
--- a/src/cubie/batchsolving/arrays/AGENTS.md
+++ b/src/cubie/batchsolving/arrays/AGENTS.md
@@ -107,8 +107,10 @@ Output tasks also copy staged data into the result arrays. Shutdown drains all
 tasks before it clears the pool.
 
 Every acquired buffer must reach a release. A failing writeback copy is stored
-on the watcher and re-raised by `wait_all` once the queue drains. A stager that
-raises before handing its buffer over releases it itself.
+on the watcher and re-raised by `wait_all` once the queue drains. A stager
+that raises drains the stream, then releases its buffer. An event whose query
+raises retires its task, frees the buffer, and stores the error for
+`wait_all`.
 
 ### Container mechanics
 Containers use `@define(slots=False)` and discover their arrays by scanning `__dict__` for

--- a/src/cubie/batchsolving/arrays/AGENTS.md
+++ b/src/cubie/batchsolving/arrays/AGENTS.md
@@ -106,6 +106,10 @@ Transfer watchers release pinned buffers after their CUDA event completes.
 Output tasks also copy staged data into the result arrays. Shutdown drains all
 tasks before it clears the pool.
 
+Every acquired buffer must reach a release. A failing writeback copy is stored
+on the watcher and re-raised by `wait_all` once the queue drains. A stager that
+raises before handing its buffer over releases it itself.
+
 ### Container mechanics
 Containers use `@define(slots=False)` and discover their arrays by scanning `__dict__` for
 `ManagedArray` instances (`_iter_field_items`), so fields are picked up dynamically. `attach`

--- a/src/cubie/batchsolving/arrays/BatchInputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchInputArrays.py
@@ -531,20 +531,29 @@ class InputArrays(BaseArrayManager):
             buffer = self._buffer_pool.acquire(
                 array_name, device_block.shape, dtype
             )
-            trim = tuple(slice(0, extent) for extent in host_block.shape)
-            buffer.array[trim] = host_block
-            self.to_device([buffer.array], [device_block], stream=stream)
-            if CUDA_SIMULATION:
-                self._buffer_pool.release(buffer)
-            else:
-                event = cuda.event()
-                event.record(stream)
-                self._transfer_watcher.submit_release(
-                    event,
-                    buffer,
-                    self._buffer_pool,
-                    array_name,
+            # Ours to release until the watcher takes it.
+            try:
+                trim = tuple(
+                    slice(0, extent) for extent in host_block.shape
                 )
+                buffer.array[trim] = host_block
+                self.to_device(
+                    [buffer.array], [device_block], stream=stream
+                )
+                if CUDA_SIMULATION:
+                    self._buffer_pool.release(buffer)
+                else:
+                    event = cuda.event()
+                    event.record(stream)
+                    self._transfer_watcher.submit_release(
+                        event,
+                        buffer,
+                        self._buffer_pool,
+                        array_name,
+                    )
+            except BaseException:
+                self._buffer_pool.release(buffer)
+                raise
 
     def wait_pending(self, timeout: Optional[float] = None) -> None:
         """Wait for pending staging-buffer releases."""

--- a/src/cubie/batchsolving/arrays/BatchInputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchInputArrays.py
@@ -552,7 +552,12 @@ class InputArrays(BaseArrayManager):
                         array_name,
                     )
             except BaseException:
-                self._buffer_pool.release(buffer)
+                # Drain any queued copy before the buffer is reusable.
+                try:
+                    if stream is not None:
+                        stream.synchronize()
+                finally:
+                    self._buffer_pool.release(buffer)
                 raise
 
     def wait_pending(self, timeout: Optional[float] = None) -> None:

--- a/src/cubie/batchsolving/arrays/BatchOutputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchOutputArrays.py
@@ -528,7 +528,12 @@ class OutputArrays(BaseArrayManager):
                         data_shape=host_block.shape,
                     )
             except BaseException:
-                self._buffer_pool.release(buffer)
+                # Drain any queued copy before the buffer is reusable.
+                try:
+                    if stream is not None:
+                        stream.synchronize()
+                finally:
+                    self._buffer_pool.release(buffer)
                 raise
 
     def wait_pending(self, timeout: Optional[float] = None) -> None:

--- a/src/cubie/batchsolving/arrays/BatchOutputArrays.py
+++ b/src/cubie/batchsolving/arrays/BatchOutputArrays.py
@@ -505,24 +505,31 @@ class OutputArrays(BaseArrayManager):
             buffer = self._buffer_pool.acquire(
                 array_name, device_block.shape, dtype
             )
-            self.from_device([device_block], [buffer.array], stream=stream)
-            if CUDA_SIMULATION:
-                trim = tuple(
-                    slice(0, extent) for extent in host_block.shape
+            # Ours to release until the watcher takes it.
+            try:
+                self.from_device(
+                    [device_block], [buffer.array], stream=stream
                 )
-                host_block[...] = buffer.array[trim]
+                if CUDA_SIMULATION:
+                    trim = tuple(
+                        slice(0, extent) for extent in host_block.shape
+                    )
+                    host_block[...] = buffer.array[trim]
+                    self._buffer_pool.release(buffer)
+                else:
+                    event = cuda.event()
+                    event.record(stream)
+                    self._watcher.submit(
+                        event=event,
+                        buffer=buffer,
+                        target_array=host_block,
+                        buffer_pool=self._buffer_pool,
+                        array_name=array_name,
+                        data_shape=host_block.shape,
+                    )
+            except BaseException:
                 self._buffer_pool.release(buffer)
-            else:
-                event = cuda.event()
-                event.record(stream)
-                self._watcher.submit(
-                    event=event,
-                    buffer=buffer,
-                    target_array=host_block,
-                    buffer_pool=self._buffer_pool,
-                    array_name=array_name,
-                    data_shape=host_block.shape,
-                )
+                raise
 
     def wait_pending(self, timeout: Optional[float] = None) -> None:
         """Wait for all pending async writebacks to complete.

--- a/src/cubie/batchsolving/writeback_watcher.py
+++ b/src/cubie/batchsolving/writeback_watcher.py
@@ -99,7 +99,7 @@ class WritebackWatcher:
     _pending_count : int
         Number of submitted tasks not yet completed, including tasks
         currently owned by a processing thread.
-    _error : BaseException or None
+    _error : Exception or None
         First error hit completing a task; re-raised by `wait_all`.
     """
 
@@ -118,7 +118,7 @@ class WritebackWatcher:
         self._stop_event: Event = Event()
         self._poll_interval: float = poll_interval
         self._pending_count: int = 0
-        self._error: Optional[BaseException] = None
+        self._error: Optional[Exception] = None
 
     def start(self) -> None:
         """Start the background polling thread."""
@@ -216,7 +216,7 @@ class WritebackWatcher:
         ------
         TimeoutError
             If timeout expires before completion.
-        BaseException
+        Exception
             The first error hit completing a task, once drained.
         """
         deadline = (
@@ -297,9 +297,11 @@ class WritebackWatcher:
             return False
         try:
             complete = self._process_task(task)
-        except BaseException as error:
-            # Unqueryable event: retire the task and store the error.
+        except Exception as error:
+            # Unqueryable event: the context is broken and runs no
+            # DMA, so retire the task and free its buffer.
             self._record_error(error)
+            task.buffer_pool.release(task.buffer)
             with self._cond:
                 self._pending_count -= 1
                 self._cond.notify_all()
@@ -366,13 +368,13 @@ class WritebackWatcher:
                     task.target_array[:] = task.buffer.array[buffer_slice]
                 else:
                     task.target_array[:] = task.buffer.array
-        except BaseException as error:
+        except Exception as error:
             self._record_error(error)
         finally:
             # Release buffer back to pool
             task.buffer_pool.release(task.buffer)
 
-    def _record_error(self, error: BaseException) -> None:
+    def _record_error(self, error: Exception) -> None:
         """Keep the first completion error for ``wait_all``."""
         with self._cond:
             if self._error is None:

--- a/src/cubie/batchsolving/writeback_watcher.py
+++ b/src/cubie/batchsolving/writeback_watcher.py
@@ -99,6 +99,8 @@ class WritebackWatcher:
     _pending_count : int
         Number of submitted tasks not yet completed, including tasks
         currently owned by a processing thread.
+    _error : BaseException or None
+        First error hit completing a task; re-raised by `wait_all`.
     """
 
     def __init__(self, poll_interval: float = 0.001) -> None:
@@ -116,6 +118,7 @@ class WritebackWatcher:
         self._stop_event: Event = Event()
         self._poll_interval: float = poll_interval
         self._pending_count: int = 0
+        self._error: Optional[BaseException] = None
 
     def start(self) -> None:
         """Start the background polling thread."""
@@ -128,16 +131,17 @@ class WritebackWatcher:
     def _submit_task(self, task: WritebackTask) -> None:
         """Submit a writeback task to the shared deque.
 
+        The thread starts before the task is queued.
+
         Parameters
         ----------
         task
             WritebackTask to submit.
         """
+        self.start()
         with self._cond:
             self._pending_count += 1
             self._tasks.append(task)
-        # Start thread if not running
-        self.start()
 
     def submit(
         self,
@@ -212,6 +216,8 @@ class WritebackWatcher:
         ------
         TimeoutError
             If timeout expires before completion.
+        BaseException
+            The first error hit completing a task, once drained.
         """
         deadline = (
             None if timeout is None else perf_counter() + timeout
@@ -219,6 +225,10 @@ class WritebackWatcher:
         while True:
             with self._cond:
                 if self._pending_count == 0:
+                    error = self._error
+                    self._error = None
+                    if error is not None:
+                        raise error
                     return
                 # Claim a task; this thread now owns completing it.
                 task = self._tasks.popleft() if self._tasks else None
@@ -285,7 +295,16 @@ class WritebackWatcher:
             task = self._tasks.popleft() if self._tasks else None
         if task is None:
             return False
-        if self._process_task(task):
+        try:
+            complete = self._process_task(task)
+        except BaseException as error:
+            # Unqueryable event: retire the task and store the error.
+            self._record_error(error)
+            with self._cond:
+                self._pending_count -= 1
+                self._cond.notify_all()
+            return True
+        if complete:
             with self._cond:
                 self._pending_count -= 1
                 self._cond.notify_all()
@@ -331,19 +350,33 @@ class WritebackWatcher:
         self._complete_task(task)
 
     def _complete_task(self, task: WritebackTask) -> None:
-        """Copy staged data to its target and release the buffer."""
-        # Copy buffer data to target array at specified slice.
-        # If data_shape provided, only copy that portion of the buffer.
-        if task.target_array is not None:
-            if task.data_shape is not None:
-                buffer_slice = tuple(
-                    slice(0, s) for s in task.data_shape
-                )
-                task.target_array[:] = task.buffer.array[buffer_slice]
-            else:
-                task.target_array[:] = task.buffer.array
-        # Release buffer back to pool
-        task.buffer_pool.release(task.buffer)
+        """Copy staged data to its target and release the buffer.
+
+        A failing copy is stored for `wait_all`, never raised here.
+        """
+        try:
+            # Copy buffer data to target array at specified slice.
+            # If data_shape provided, only copy that portion of the
+            # buffer.
+            if task.target_array is not None:
+                if task.data_shape is not None:
+                    buffer_slice = tuple(
+                        slice(0, s) for s in task.data_shape
+                    )
+                    task.target_array[:] = task.buffer.array[buffer_slice]
+                else:
+                    task.target_array[:] = task.buffer.array
+        except BaseException as error:
+            self._record_error(error)
+        finally:
+            # Release buffer back to pool
+            task.buffer_pool.release(task.buffer)
+
+    def _record_error(self, error: BaseException) -> None:
+        """Keep the first completion error for ``wait_all``."""
+        with self._cond:
+            if self._error is None:
+                self._error = error
 
     def _process_task(self, task: WritebackTask) -> bool:
         """Process a single writeback task.

--- a/src/cubie/cuda_simsafe.py
+++ b/src/cubie/cuda_simsafe.py
@@ -120,6 +120,9 @@ if IS_MLIR:
         _CacheLocator,
         IndexDataCacheFile,
     )
+    from numba_cuda_mlir.numba_cuda.cudadrv.error import (  # noqa: F401
+        CudaSupportError,
+    )
 
     # The MLIR backend accepts a boolean cuda.jit inline argument;
     # numba-cuda takes the string form and deprecates the boolean.
@@ -132,6 +135,9 @@ else:
         _CacheLocator,
         CacheImpl,
         IndexDataCacheFile,
+    )
+    from numba.cuda.cudadrv.error import (  # noqa: F401
+        CudaSupportError,
     )
 
     INLINE_ALWAYS = "always"

--- a/src/cubie/memory/AGENTS.md
+++ b/src/cubie/memory/AGENTS.md
@@ -35,15 +35,25 @@ simulator never touches CuPy — it keeps its own numpy-backed fakes. Supporting
 - Two limit modes (`_mode`, default `"passive"`): `"passive"` computes caps but doesn't enforce (returns raw free VRAM); `"active"` enforces per-instance caps. Switch via `set_limit_mode()`.
 
 ### No device
-- `totalmem` is read from the device at construction and is **not** a
+- `totalmem` is read from the device by `probe_device()` and is **not** a
   constructor argument.
 - Construction succeeds without a device: `totalmem` and `pinned_max_bytes`
   stay `None` and the probe's error is stored.
-- `pinned_budget_bytes`, `allocate_pinned_array`, `choose_host_memory_type`
-  and `set_manual_proportion` then raise `NoCudaDeviceError` chained to that
+- `pinned_budget_bytes`, `allocate_pinned_array` and
+  `choose_host_memory_type` then raise `NoCudaDeviceError` chained to that
   error.
-- `register` still works; the cap it cannot size stays `None`, and every
-  active-mode cap reader probes the device first.
+- Registration and proportion changes carry an unsized cap rather than
+  raising, manual and auto alike: `_cap_bytes` is the only place a proportion
+  becomes bytes, and it answers `None` with no device. They must not raise —
+  `register`, `set_manual_proportion` and `set_manual_limit_mode` move the
+  instance between pools before the cap is computed, so a raise there would
+  leave it in neither. Every active-mode reader of those caps probes the
+  device first. (`register` also needs a group stream, so a process with no
+  driver at all fails in `stream_groups`, before any of this.)
+- `probe_device()` also runs on demand, re-reading the device and resizing
+  every registered cap. Call it when a device becomes usable after the manager
+  was built; the precompile plugin does, having patched `get_memory_info`
+  after `import cubie`.
 - Give an absent device no stand-in size. A placeholder survives arithmetic
   and reads downstream as a real budget.
 

--- a/src/cubie/memory/AGENTS.md
+++ b/src/cubie/memory/AGENTS.md
@@ -36,20 +36,18 @@ simulator never touches CuPy — it keeps its own numpy-backed fakes. Supporting
 
 ### No device
 - `totalmem` is read from the device by `probe_device()`; it is **not** a
-  constructor argument.
-- With no device, construction still succeeds: `totalmem` and
-  `pinned_max_bytes` stay `None` and the probe's error is stored.
-- `pinned_budget_bytes`, `allocate_pinned_array` and `choose_host_memory_type`
-  raise `NoCudaDeviceError` chained to that error.
-- `register`, `set_manual_proportion` and `set_manual_limit_mode` do not
-  raise for a missing device. `_cap_bytes` is the only place a proportion
-  becomes bytes; it answers `None`. Active-mode readers of a cap probe the
-  device first. `register` needs a group stream, so a driverless process
-  fails in `stream_groups`.
-- Call `probe_device()` when a device becomes usable after the manager was
-  built: it re-reads the size and resizes every registered cap. The precompile
-  plugin does, having patched `get_memory_info` after `import cubie`.
-- An absent device gets no stand-in size.
+  constructor argument. A device-absence failure (`CudaSupportError`, the
+  unpacking `ValueError`) stores its error and leaves `totalmem` and
+  `pinned_max_bytes` `None`; any other probe failure propagates.
+- Sizing decisions (`pinned_budget_bytes`, `allocate_pinned_array`,
+  `get_available_memory`, `get_chunk_parameters`, a pinned choice in
+  `choose_host_memory_type`) reprobe an unsized manager, then raise
+  `NoCudaDeviceError` chained to the probe's error. Disk and pageable
+  backing choices need no device.
+- `register` needs a group stream, so a driverless process fails in
+  `stream_groups`. `_cap_bytes` is the only place a proportion becomes
+  bytes. The precompile plugin patches `get_memory_info` after
+  `import cubie` and calls `probe_device()` before registrations.
 
 ### Deregistration & teardown
 - Registry allocations keep device arrays alive until deregistration.
@@ -71,7 +69,7 @@ simulator never touches CuPy — it keeps its own numpy-backed fakes. Supporting
 ### Host backing policy
 - `choose_host_memory_type(nbytes, host_spill_threshold, allow_pinned)`: memmap above the
   threshold (`None` = 80% of RAM), pinned up to `pinned_max_bytes` (default: total VRAM),
-  else pageable. Raises `NoCudaDeviceError` with no device (see **No device**).
+  else pageable. Only a reachable pinned choice needs a device (see **No device**).
 - The pinned ceiling is cumulative: `allocate_pinned_array` reserves
   against `min(pinned_max_bytes, HOST_SPILL_FRACTION × total RAM)` in
   an atomic ledger of live plus pool-retained bytes. Ambient RAM use

--- a/src/cubie/memory/AGENTS.md
+++ b/src/cubie/memory/AGENTS.md
@@ -20,9 +20,9 @@ simulator never touches CuPy — it keeps its own numpy-backed fakes. Supporting
 ## Key Files
 | File | Description |
 |------|-------------|
-| `__init__.py` | Installs the CuPy async EMM (`install_async_emm()`, before any CUDA context exists), instantiates `default_memmgr = MemoryManager()`; re-exports `MemoryManager`, `current_cupy_stream`, `CuPyAsyncNumbaManager`. |
+| `__init__.py` | Installs the CuPy async EMM (`install_async_emm()`, before any CUDA context exists), instantiates `default_memmgr = MemoryManager()`; re-exports `MemoryManager`, `NoCudaDeviceError`, `current_cupy_stream`, `CuPyAsyncNumbaManager`. |
 | `cupy_emm.py` | `CuPyAsyncNumbaManager` — Numba EMM plugin drawing device memory from `cupy.cuda.MemoryAsyncPool`; `install_async_emm()`. |
-| `mem_manager.py` | `MemoryManager` (central allocator); `InstanceMemorySettings` (per-instance registry entry); `ALL_MEMORY_MANAGER_PARAMETERS`; `MIN_AUTOPOOL_SIZE`; `current_cupy_stream` (Numba→CuPy stream forwarding). |
+| `mem_manager.py` | `MemoryManager` (central allocator); `NoCudaDeviceError`; `InstanceMemorySettings` (per-instance registry entry); `ALL_MEMORY_MANAGER_PARAMETERS`; `MIN_AUTOPOOL_SIZE`; `current_cupy_stream` (Numba→CuPy stream forwarding). |
 | `array_requests.py` | `ArrayRequest` (shape/dtype/placement spec) and `ArrayResponse` (allocated arrays + chunk metadata). |
 | `stream_groups.py` | `StreamGroups` — maps instance ids to named groups, each backed by a CUDA stream. |
 | `chunk_buffer_pool.py` | `PinnedBuffer` + `ChunkBufferPool` — reusable pinned staging buffers. Not exported from `__init__.py`. |
@@ -33,6 +33,19 @@ simulator never touches CuPy — it keeps its own numpy-backed fakes. Supporting
 - `register(instance, proportion=None, invalidate_cache_hook=…, allocation_ready_hook=…, stream_group="default")` once per object. `proportion=None` → auto pool (equal share of remaining VRAM); a float → manual pool. `MIN_AUTOPOOL_SIZE = 0.05` reserves 5% for the auto pool; a manual proportion that would crowd it below 5% raises `ValueError` if auto instances exist (else warns).
 - The registry is keyed by `id(instance)`. Keep a live reference to every registered object — GC frees the id and a new object can silently claim the slot.
 - Two limit modes (`_mode`, default `"passive"`): `"passive"` computes caps but doesn't enforce (returns raw free VRAM); `"active"` enforces per-instance caps. Switch via `set_limit_mode()`.
+
+### No device
+- `totalmem` is read from the device at construction and is **not** a
+  constructor argument.
+- Construction succeeds without a device: `totalmem` and `pinned_max_bytes`
+  stay `None` and the probe's error is stored.
+- `pinned_budget_bytes`, `allocate_pinned_array`, `choose_host_memory_type`
+  and `set_manual_proportion` then raise `NoCudaDeviceError` chained to that
+  error.
+- `register` still works; the cap it cannot size stays `None`, and every
+  active-mode cap reader probes the device first.
+- Give an absent device no stand-in size. A placeholder survives arithmetic
+  and reads downstream as a real budget.
 
 ### Deregistration & teardown
 - Registry allocations keep device arrays alive until deregistration.
@@ -54,7 +67,7 @@ simulator never touches CuPy — it keeps its own numpy-backed fakes. Supporting
 ### Host backing policy
 - `choose_host_memory_type(nbytes, host_spill_threshold, allow_pinned)`: memmap above the
   threshold (`None` = 80% of RAM), pinned up to `pinned_max_bytes` (default: total VRAM),
-  else pageable.
+  else pageable. Raises `NoCudaDeviceError` with no device (see **No device**).
 - The pinned ceiling is cumulative: `allocate_pinned_array` reserves
   against `min(pinned_max_bytes, HOST_SPILL_FRACTION × total RAM)` in
   an atomic ledger of live plus pool-retained bytes. Ambient RAM use

--- a/src/cubie/memory/AGENTS.md
+++ b/src/cubie/memory/AGENTS.md
@@ -35,27 +35,23 @@ simulator never touches CuPy — it keeps its own numpy-backed fakes. Supporting
 - Two limit modes (`_mode`, default `"passive"`): `"passive"` computes caps but doesn't enforce (returns raw free VRAM); `"active"` enforces per-instance caps. Switch via `set_limit_mode()`.
 
 ### No device
-- `totalmem` is read from the device by `probe_device()` and is **not** a
+- `totalmem` is read from the device by `probe_device()`; it is **not** a
   constructor argument.
-- Construction succeeds without a device: `totalmem` and `pinned_max_bytes`
-  stay `None` and the probe's error is stored.
-- `pinned_budget_bytes`, `allocate_pinned_array` and
-  `choose_host_memory_type` then raise `NoCudaDeviceError` chained to that
-  error.
-- Registration and proportion changes carry an unsized cap rather than
-  raising, manual and auto alike: `_cap_bytes` is the only place a proportion
-  becomes bytes, and it answers `None` with no device. They must not raise —
-  `register`, `set_manual_proportion` and `set_manual_limit_mode` move the
-  instance between pools before the cap is computed, so a raise there would
-  leave it in neither. Every active-mode reader of those caps probes the
-  device first. (`register` also needs a group stream, so a process with no
-  driver at all fails in `stream_groups`, before any of this.)
-- `probe_device()` also runs on demand, re-reading the device and resizing
-  every registered cap. Call it when a device becomes usable after the manager
-  was built; the precompile plugin does, having patched `get_memory_info`
-  after `import cubie`.
-- Give an absent device no stand-in size. A placeholder survives arithmetic
-  and reads downstream as a real budget.
+- With no device, construction still succeeds: `totalmem` and
+  `pinned_max_bytes` stay `None` and the probe's error is stored.
+- `pinned_budget_bytes`, `allocate_pinned_array` and `choose_host_memory_type`
+  raise `NoCudaDeviceError` chained to that error.
+- `register`, `set_manual_proportion` and `set_manual_limit_mode` never raise
+  for a missing device — they move the instance between pools before the cap
+  is sized. `_cap_bytes` is the only place a proportion becomes bytes and it
+  answers `None`. Active-mode readers of a cap probe the device first.
+  `register` still needs a group stream, so a driverless process fails in
+  `stream_groups`.
+- Call `probe_device()` when a device becomes usable after the manager was
+  built: it re-reads the size and resizes every registered cap. The precompile
+  plugin does, having patched `get_memory_info` after `import cubie`.
+- Give an absent device no stand-in size; `None` propagates, a placeholder
+  reads downstream as a real budget.
 
 ### Deregistration & teardown
 - Registry allocations keep device arrays alive until deregistration.

--- a/src/cubie/memory/AGENTS.md
+++ b/src/cubie/memory/AGENTS.md
@@ -41,17 +41,15 @@ simulator never touches CuPy — it keeps its own numpy-backed fakes. Supporting
   `pinned_max_bytes` stay `None` and the probe's error is stored.
 - `pinned_budget_bytes`, `allocate_pinned_array` and `choose_host_memory_type`
   raise `NoCudaDeviceError` chained to that error.
-- `register`, `set_manual_proportion` and `set_manual_limit_mode` never raise
-  for a missing device — they move the instance between pools before the cap
-  is sized. `_cap_bytes` is the only place a proportion becomes bytes and it
-  answers `None`. Active-mode readers of a cap probe the device first.
-  `register` still needs a group stream, so a driverless process fails in
-  `stream_groups`.
+- `register`, `set_manual_proportion` and `set_manual_limit_mode` do not
+  raise for a missing device. `_cap_bytes` is the only place a proportion
+  becomes bytes; it answers `None`. Active-mode readers of a cap probe the
+  device first. `register` needs a group stream, so a driverless process
+  fails in `stream_groups`.
 - Call `probe_device()` when a device becomes usable after the manager was
   built: it re-reads the size and resizes every registered cap. The precompile
   plugin does, having patched `get_memory_info` after `import cubie`.
-- Give an absent device no stand-in size; `None` propagates, a placeholder
-  reads downstream as a real budget.
+- An absent device gets no stand-in size.
 
 ### Deregistration & teardown
 - Registry allocations keep device arrays alive until deregistration.

--- a/src/cubie/memory/__init__.py
+++ b/src/cubie/memory/__init__.py
@@ -17,10 +17,16 @@ The main components are:
 - :class:`current_cupy_stream`: Context manager for CuPy stream integration
 
 The default memory manager instance is available as `default_memmgr`.
+Without a device it builds anyway and raises `NoCudaDeviceError` from
+any sizing decision.
 """
 
 from cubie.memory.cupy_emm import CuPyAsyncNumbaManager, install_async_emm
-from cubie.memory.mem_manager import MemoryManager, current_cupy_stream
+from cubie.memory.mem_manager import (
+    MemoryManager,
+    NoCudaDeviceError,
+    current_cupy_stream,
+)
 
 # Install the CuPy async pool as Numba's EMM before the first CUDA context is
 # created (below, when the manager queries device memory).
@@ -33,4 +39,5 @@ __all__ = [
     "CuPyAsyncNumbaManager",
     "default_memmgr",
     "MemoryManager",
+    "NoCudaDeviceError",
 ]

--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -82,6 +82,7 @@ from math import prod
 
 from cubie.cuda_simsafe import (
     CUDA_SIMULATION,
+    CudaSupportError,
     Stream,
     cupy,
     current_mem_info,
@@ -120,6 +121,15 @@ bounding the pinned footprint of a chunked or spilled solve.
 
 class NoCudaDeviceError(RuntimeError):
     """Raised by a sizing decision when no device is available."""
+
+
+def _is_no_device_error(error: Exception) -> bool:
+    """Return whether ``error`` signals an absent CUDA device."""
+    if isinstance(error, CudaSupportError):
+        return True
+    return isinstance(error, ValueError) and str(error).startswith(
+        "not enough values to unpack"
+    )
 
 
 if sys.platform == "win32":
@@ -588,10 +598,9 @@ class MemoryManager:
     proportions while passive mode mirrors standard allocation
     behaviour using chunking only when necessary.
 
-    Construction succeeds without a device: registrations carry
-    ``None`` caps and the decisions needing a byte figure raise
-    :class:`NoCudaDeviceError`. :meth:`probe_device` re-reads the
-    device.
+    Construction succeeds without a device: the manager stays
+    unsized and every decision needing a byte figure reprobes, then
+    raises :class:`NoCudaDeviceError` if no device answers.
 
     See Also
     --------
@@ -660,13 +669,22 @@ class MemoryManager:
         self.probe_device()
 
     def probe_device(self) -> None:
-        """Read the device's size and resize every registered cap.
+        """Read the device's memory size.
 
-        A failed read stores its error and leaves the sizes ``None``.
+        An absent device stores its error and leaves the sizes
+        ``None``.
+
+        Raises
+        ------
+        Exception
+            The probe's own error, when it does not signal an absent
+            device.
         """
         try:
             _, total = self.get_memory_info()
         except Exception as error:
+            if not _is_no_device_error(error):
+                raise
             self._device_probe_error = error
             total = None
         else:
@@ -674,8 +692,6 @@ class MemoryManager:
         self.totalmem = total
         if self.pinned_max_bytes is None and total is not None:
             self.pinned_max_bytes = total
-        for settings in self.registry.values():
-            settings.cap = self._cap_bytes(settings.proportion)
 
     def _cap_bytes(self, proportion: float) -> Optional[int]:
         """Bytes for ``proportion`` of VRAM; ``None`` with no device."""
@@ -684,13 +700,15 @@ class MemoryManager:
         return int(proportion * self.totalmem)
 
     def _require_device(self) -> None:
-        """Guard a sizing decision on the last device probe.
+        """Reprobe an unsized manager, then require a device size.
 
         Raises
         ------
         NoCudaDeviceError
             If the device probe failed, chained to its error.
         """
+        if self.totalmem is None:
+            self.probe_device()
         if self.totalmem is not None:
             return
         raise NoCudaDeviceError(
@@ -1474,15 +1492,18 @@ class MemoryManager:
         Raises
         ------
         NoCudaDeviceError
-            If the last device probe failed.
+            If a pinned choice is reachable but no device answers
+            the probe.
         """
-        self._require_device()
         threshold = host_spill_threshold
         if threshold is None:
             threshold = int(total_system_ram() * HOST_SPILL_FRACTION)
         if nbytes > threshold:
             return "memmap"
-        if allow_pinned and nbytes <= self.pinned_max_bytes:
+        if not allow_pinned:
+            return "host"
+        self._require_device()
+        if nbytes <= self.pinned_max_bytes:
             return "pinned"
         return "host"
 
@@ -1538,7 +1559,13 @@ class MemoryManager:
         --------
         UserWarning
             If group has used more than 95% of allocated memory.
+
+        Raises
+        ------
+        NoCudaDeviceError
+            If no device answers the probe.
         """
+        self._require_device()
         free, total = self.get_memory_info()
         instances = self.stream_groups.get_instances_in_group(group)
         if self._mode == "passive":
@@ -2036,7 +2063,13 @@ class MemoryManager:
         --------
         UserWarning
             If request exceeds available VRAM by more than 20x.
+
+        Raises
+        ------
+        NoCudaDeviceError
+            If no device answers the probe.
         """
+        self._require_device()
         free, _ = self.get_memory_info()
         available_memory = self.get_available_memory(stream_group)
         cap_headroom = None

--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -588,8 +588,11 @@ class MemoryManager:
     proportions while passive mode mirrors standard allocation
     behaviour using chunking only when necessary.
 
-    Construction succeeds without a device. Sizing decisions then
-    raise :class:`NoCudaDeviceError` from the probe's own error.
+    Construction succeeds without a device. Registration and
+    proportion changes then carry unsized caps rather than raising,
+    while the decisions that need a byte figure raise
+    :class:`NoCudaDeviceError` from the probe's own error.
+    :meth:`probe_device` re-reads a device that arrives late.
 
     See Also
     --------
@@ -654,18 +657,42 @@ class MemoryManager:
 
     def __attrs_post_init__(self) -> None:
         """Read device memory, leaving sizes unset without a device."""
+        self.registry = {}
+        self.probe_device()
+
+    def probe_device(self) -> None:
+        """Read the device's memory size, or store why it could not.
+
+        Runs at construction. Call it again once a device that was
+        unreachable then becomes usable: every registered cap is
+        resized from its proportion, so the manager ends the call
+        either fully sized or holding no size at all.
+        """
         try:
             _, total = self.get_memory_info()
         except Exception as error:
             self._device_probe_error = error
             total = None
+        else:
+            self._device_probe_error = None
         self.totalmem = total
         if self.pinned_max_bytes is None and total is not None:
             self.pinned_max_bytes = total
-        self.registry = {}
+        for settings in self.registry.values():
+            settings.cap = self._cap_bytes(settings.proportion)
+
+    def _cap_bytes(self, proportion: float) -> Optional[int]:
+        """Bytes for ``proportion`` of VRAM; ``None`` with no device.
+
+        An absent device gets no stand-in size: a placeholder would
+        survive the arithmetic and read downstream as a real cap.
+        """
+        if self.totalmem is None:
+            return None
+        return int(proportion * self.totalmem)
 
     def _require_device(self) -> None:
-        """Guard a sizing decision on the construction-time probe.
+        """Guard a sizing decision on the last device probe.
 
         Raises
         ------
@@ -996,8 +1023,6 @@ class MemoryManager:
         ValueError
             If manual proportion would exceed total available memory or leave
             insufficient memory for auto-allocated processes.
-        NoCudaDeviceError
-            If the device probe failed when this manager was built.
 
         Warnings
         --------
@@ -1029,10 +1054,9 @@ class MemoryManager:
                     "Manual proportion leaves less than 5% of memory for "
                     "auto allocation if management mode == 'active'."
                 )
-        self._require_device()
         self._manual_pool.append(instance_id)
         self.registry[instance_id].proportion = proportion
-        self.registry[instance_id].cap = int(proportion * self.totalmem)
+        self.registry[instance_id].cap = self._cap_bytes(proportion)
 
         self._rebalance_auto_pool()
 
@@ -1220,10 +1244,7 @@ class MemoryManager:
         if len(self._auto_pool) == 0:
             return
         each_proportion = available_proportion / len(self._auto_pool)
-        # No device: no size to take a share of, so no cap.
-        cap = None
-        if self.totalmem is not None:
-            cap = int(each_proportion * self.totalmem)
+        cap = self._cap_bytes(each_proportion)
         for instance_id in self._auto_pool:
             self.registry[instance_id].proportion = each_proportion
             self.registry[instance_id].cap = cap
@@ -1277,7 +1298,13 @@ class MemoryManager:
 
     @property
     def pinned_budget_bytes(self) -> int:
-        """``pinned_max_bytes`` capped at the spill fraction of RAM."""
+        """``pinned_max_bytes`` capped at the spill fraction of RAM.
+
+        Raises
+        ------
+        NoCudaDeviceError
+            If the last device probe failed, leaving no size to cap.
+        """
         self._require_device()
         ram_cap = int(HOST_SPILL_FRACTION * total_system_ram())
         return min(self.pinned_max_bytes, ram_cap)
@@ -1343,6 +1370,12 @@ class MemoryManager:
         numpy.ndarray or None
             The pinned array, or ``None`` when the budget or the
             driver refuses.
+
+        Raises
+        ------
+        NoCudaDeviceError
+            If the last device probe failed, leaving no budget to
+            reserve against.
         """
         nbytes = int(prod(shape)) * np_dtype(dtype).itemsize
         if not self._reserve_pinned_bytes(nbytes, force=force):
@@ -1450,7 +1483,8 @@ class MemoryManager:
         Raises
         ------
         NoCudaDeviceError
-            If the device probe failed when this manager was built.
+            If the last device probe failed, leaving no pinned
+            ceiling to compare against.
         """
         self._require_device()
         threshold = host_spill_threshold

--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -577,8 +577,8 @@ class MemoryManager:
     Attributes
     ----------
     totalmem
-        Total GPU memory in bytes, read from the device at
-        construction, or ``None`` when no device answered.
+        Total GPU memory in bytes as of the last
+        :meth:`probe_device`, or ``None`` when no device answered.
 
     Notes
     -----
@@ -694,8 +694,8 @@ class MemoryManager:
         if self.totalmem is not None:
             return
         raise NoCudaDeviceError(
-            "the memory manager found no CUDA device when it was "
-            "built, so it cannot size an allocation"
+            "the memory manager found no CUDA device, so it cannot "
+            "size an allocation"
         ) from self._device_probe_error
 
     def register(

--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -118,6 +118,10 @@ bounding the pinned footprint of a chunked or spilled solve.
 """
 
 
+class NoCudaDeviceError(RuntimeError):
+    """Raised by a sizing decision when no device is available."""
+
+
 if sys.platform == "win32":
     class _MemoryStatusEx(ctypes.Structure):
         """Layout of the Win32 ``MEMORYSTATUSEX`` structure."""
@@ -564,14 +568,17 @@ class MemoryManager:
 
     Parameters
     ----------
-    totalmem
-        Total GPU memory in bytes. Determined automatically when
-        omitted.
     registry
         Registry mapping instance identifiers to their memory
         settings.
     stream_groups
         Manager for organising instances into stream groups.
+
+    Attributes
+    ----------
+    totalmem
+        Total GPU memory in bytes, read from the device at
+        construction, or ``None`` when no device answered.
 
     Notes
     -----
@@ -580,6 +587,9 @@ class MemoryManager:
     and chunking information. Active mode enforces per-instance VRAM
     proportions while passive mode mirrors standard allocation
     behaviour using chunking only when necessary.
+
+    Construction succeeds without a device. Sizing decisions then
+    raise :class:`NoCudaDeviceError` from the probe's own error.
 
     See Also
     --------
@@ -591,8 +601,11 @@ class MemoryManager:
         Manages CUDA stream groups.
     """
 
-    totalmem: int = field(
-        default=None, validator=attrsval_optional(attrsval_instance_of(int))
+    # Device-read, never caller-supplied.
+    totalmem: Optional[int] = field(
+        default=None,
+        init=False,
+        validator=attrsval_optional(attrsval_instance_of(int)),
     )
     registry: dict[int, InstanceMemorySettings] = field(
         default=attrsFactory(dict),
@@ -623,8 +636,8 @@ class MemoryManager:
     # watcher's own thread — so finalizers must not deregister (or
     # join threads) directly; they append here instead.
     _pending_teardowns: list = field(factory=list, init=False)
-    # Cumulative pinned ceiling; None resolves to total VRAM at
-    # construction, after which the field holds an integer.
+    # Cumulative pinned ceiling; None resolves to total VRAM, and
+    # stays None with no device.
     pinned_max_bytes: Optional[int] = field(
         default=None,
         validator=opt_getype_validator(int, 0),
@@ -634,29 +647,37 @@ class MemoryManager:
     _pinned_lock: Lock = field(factory=Lock, init=False)
     _pinned_live_bytes: int = field(default=0, init=False)
     _pinned_retained_bytes: int = field(default=0, init=False)
+    # Cause for the NoCudaDeviceError a sizing decision raises.
+    _device_probe_error: Optional[BaseException] = field(
+        default=None, init=False
+    )
 
     def __attrs_post_init__(self) -> None:
-        """Initialise the manager with current GPU memory information."""
+        """Read device memory, leaving sizes unset without a device."""
         try:
-            free, total = self.get_memory_info()
-        except ValueError as e:
-            if e.args[0].startswith("not enough values to unpack"):
-                warn(
-                    "memory manager was initialised in a cuda-less "
-                    "environment - memory manager will allow import but not"
-                    "provide any memory (1 byte)"
-                )
-                total = 1
-        except Exception as e:
-            warn(
-                f"Unexpected exception {e} encountered while instantiating "
-                "memory manager"
-            )
-            total = 1
+            _, total = self.get_memory_info()
+        except Exception as error:
+            self._device_probe_error = error
+            total = None
         self.totalmem = total
-        if self.pinned_max_bytes is None:
+        if self.pinned_max_bytes is None and total is not None:
             self.pinned_max_bytes = total
         self.registry = {}
+
+    def _require_device(self) -> None:
+        """Guard a sizing decision on the construction-time probe.
+
+        Raises
+        ------
+        NoCudaDeviceError
+            If the device probe failed, chained to its error.
+        """
+        if self.totalmem is not None:
+            return
+        raise NoCudaDeviceError(
+            "the memory manager found no CUDA device when it was "
+            "built, so it cannot size an allocation"
+        ) from self._device_probe_error
 
     def register(
         self,
@@ -975,6 +996,8 @@ class MemoryManager:
         ValueError
             If manual proportion would exceed total available memory or leave
             insufficient memory for auto-allocated processes.
+        NoCudaDeviceError
+            If the device probe failed when this manager was built.
 
         Warnings
         --------
@@ -1006,6 +1029,7 @@ class MemoryManager:
                     "Manual proportion leaves less than 5% of memory for "
                     "auto allocation if management mode == 'active'."
                 )
+        self._require_device()
         self._manual_pool.append(instance_id)
         self.registry[instance_id].proportion = proportion
         self.registry[instance_id].cap = int(proportion * self.totalmem)
@@ -1196,7 +1220,10 @@ class MemoryManager:
         if len(self._auto_pool) == 0:
             return
         each_proportion = available_proportion / len(self._auto_pool)
-        cap = int(each_proportion * self.totalmem)
+        # No device: no size to take a share of, so no cap.
+        cap = None
+        if self.totalmem is not None:
+            cap = int(each_proportion * self.totalmem)
         for instance_id in self._auto_pool:
             self.registry[instance_id].proportion = each_proportion
             self.registry[instance_id].cap = cap
@@ -1251,6 +1278,7 @@ class MemoryManager:
     @property
     def pinned_budget_bytes(self) -> int:
         """``pinned_max_bytes`` capped at the spill fraction of RAM."""
+        self._require_device()
         ram_cap = int(HOST_SPILL_FRACTION * total_system_ram())
         return min(self.pinned_max_bytes, ram_cap)
 
@@ -1418,7 +1446,13 @@ class MemoryManager:
         -------
         str
             ``"pinned"``, ``"host"``, or ``"memmap"``.
+
+        Raises
+        ------
+        NoCudaDeviceError
+            If the device probe failed when this manager was built.
         """
+        self._require_device()
         threshold = host_spill_threshold
         if threshold is None:
             threshold = int(total_system_ram() * HOST_SPILL_FRACTION)

--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -588,11 +588,10 @@ class MemoryManager:
     proportions while passive mode mirrors standard allocation
     behaviour using chunking only when necessary.
 
-    Construction succeeds without a device. Registration and
-    proportion changes then carry unsized caps rather than raising,
-    while the decisions that need a byte figure raise
-    :class:`NoCudaDeviceError` from the probe's own error.
-    :meth:`probe_device` re-reads a device that arrives late.
+    Construction succeeds without a device: registrations carry
+    ``None`` caps and the decisions needing a byte figure raise
+    :class:`NoCudaDeviceError`. :meth:`probe_device` re-reads the
+    device.
 
     See Also
     --------
@@ -661,12 +660,9 @@ class MemoryManager:
         self.probe_device()
 
     def probe_device(self) -> None:
-        """Read the device's memory size, or store why it could not.
+        """Read the device's size and resize every registered cap.
 
-        Runs at construction. Call it again once a device that was
-        unreachable then becomes usable: every registered cap is
-        resized from its proportion, so the manager ends the call
-        either fully sized or holding no size at all.
+        A failed read stores its error and leaves the sizes ``None``.
         """
         try:
             _, total = self.get_memory_info()
@@ -682,11 +678,7 @@ class MemoryManager:
             settings.cap = self._cap_bytes(settings.proportion)
 
     def _cap_bytes(self, proportion: float) -> Optional[int]:
-        """Bytes for ``proportion`` of VRAM; ``None`` with no device.
-
-        An absent device gets no stand-in size: a placeholder would
-        survive the arithmetic and read downstream as a real cap.
-        """
+        """Bytes for ``proportion`` of VRAM; ``None`` with no device."""
         if self.totalmem is None:
             return None
         return int(proportion * self.totalmem)
@@ -1303,7 +1295,7 @@ class MemoryManager:
         Raises
         ------
         NoCudaDeviceError
-            If the last device probe failed, leaving no size to cap.
+            If the last device probe failed.
         """
         self._require_device()
         ram_cap = int(HOST_SPILL_FRACTION * total_system_ram())
@@ -1374,8 +1366,7 @@ class MemoryManager:
         Raises
         ------
         NoCudaDeviceError
-            If the last device probe failed, leaving no budget to
-            reserve against.
+            If the last device probe failed.
         """
         nbytes = int(prod(shape)) * np_dtype(dtype).itemsize
         if not self._reserve_pinned_bytes(nbytes, force=force):
@@ -1483,8 +1474,7 @@ class MemoryManager:
         Raises
         ------
         NoCudaDeviceError
-            If the last device probe failed, leaving no pinned
-            ceiling to compare against.
+            If the last device probe failed.
         """
         self._require_device()
         threshold = host_spill_threshold

--- a/tests/_inventory.json
+++ b/tests/_inventory.json
@@ -20494,7 +20494,7 @@
       "file": "memory/mem_manager.py",
       "section": "`__attrs_post_init__`",
       "num": 29,
-      "text": "Sets totalmem=1 on ValueError (cuda-less env), warns",
+      "text": "Leaves totalmem None and stores the error on a device-absence failure (CudaSupportError or unpacking ValueError)",
       "tags": [
         "error"
       ]
@@ -20503,8 +20503,10 @@
       "file": "memory/mem_manager.py",
       "section": "`__attrs_post_init__`",
       "num": 30,
-      "text": "Sets totalmem=1 on unexpected Exception, warns",
-      "tags": []
+      "text": "Re-raises any probe failure that does not signal device absence",
+      "tags": [
+        "error"
+      ]
     },
     {
       "file": "memory/mem_manager.py",

--- a/tests/batchsolving/arrays/test_batchinputarrays.py
+++ b/tests/batchsolving/arrays/test_batchinputarrays.py
@@ -282,3 +282,24 @@ def test_reset_clears_pool_and_buffers(solverkernel_mutable):
     # super().reset() clears host/device and tracking lists
     assert ia._needs_reallocation == []
     assert ia._needs_overwrite == []
+
+
+# ── Staging failure ─────────────────────────────────────── #
+
+class _FailingTransferInputArrays(InputArrays):
+    """Input arrays whose device copy raises during staging."""
+
+    def to_device(self, from_arrays, to_arrays, stream=None):
+        raise RuntimeError("transfer failed")
+
+
+def test_stage_array_releases_the_buffer_when_the_copy_fails(solverkernel):
+    """A failed staging copy returns its buffer to the pool."""
+    arrays = _FailingTransferInputArrays.from_solver(solverkernel)
+    host = np.zeros((4, 2), dtype=solverkernel.precision)
+    device = np.zeros((4, 2), dtype=solverkernel.precision)
+    with pytest.raises(RuntimeError, match="transfer failed"):
+        arrays._stage_array("initial_values", host, device, None)
+    pooled = arrays._buffer_pool._buffers["initial_values"]
+    assert pooled
+    assert all(not buffer.in_use for buffer in pooled)

--- a/tests/batchsolving/arrays/test_batchoutputarrays.py
+++ b/tests/batchsolving/arrays/test_batchoutputarrays.py
@@ -533,3 +533,33 @@ class TestOutputArraysSpecialCases:
         assert output_arrays_manager.observables is not None
         assert output_arrays_manager.state_summaries is not None
         assert output_arrays_manager.observable_summaries is not None
+
+
+# ── Staging failure ─────────────────────────────────────────── #
+
+class _FailingTransferOutputArrays(OutputArrays):
+    """Output arrays whose device copy raises during staging."""
+
+    def from_device(self, from_arrays, to_arrays, stream=None):
+        raise RuntimeError("transfer failed")
+
+
+def test_stage_output_releases_the_buffer_when_the_copy_fails(
+    precision, solver, output_test_settings, test_memory_manager
+):
+    """A failed staging copy returns its buffer to the pool."""
+    solver.kernel.duration = 1.0
+    arrays = _FailingTransferOutputArrays(
+        sizes=BatchOutputSizes.from_solver(solver),
+        precision=precision,
+        stream_group=output_test_settings["stream_group"],
+        memory_proportion=output_test_settings["memory_proportion"],
+        memory_manager=test_memory_manager,
+    )
+    device = np.zeros((4, 2), dtype=precision)
+    host = np.zeros((4, 2), dtype=precision)
+    with pytest.raises(RuntimeError, match="transfer failed"):
+        arrays._stage_array("state", device, host, None)
+    pooled = arrays._buffer_pool._buffers["state"]
+    assert pooled
+    assert all(not buffer.in_use for buffer in pooled)

--- a/tests/batchsolving/test_writeback_watcher.py
+++ b/tests/batchsolving/test_writeback_watcher.py
@@ -478,3 +478,96 @@ def test_multiple_tasks_all_complete():
     for target, val in targets:
         np.testing.assert_array_equal(target, val)
     w.shutdown()
+
+
+# ── Failing completion ────────────────────────────────────────── #
+
+class _FailingTarget(np.ndarray):
+    """Host target whose writes raise, standing in for bad I/O."""
+
+    def __setitem__(self, key, value):
+        raise OSError("[Errno 28] No space left on device")
+
+
+def _failing_target(shape=(2,)):
+    """Return a zeroed array that raises on assignment."""
+    return np.zeros(shape, dtype=np.float32).view(_FailingTarget)
+
+
+def test_failed_copy_releases_the_buffer():
+    """A raising target still returns its buffer to the pool."""
+    w = WritebackWatcher()
+    pool = _make_pool()
+    buf = _make_pinned_buffer(shape=(2,))
+    buf.in_use = True
+    w.submit(event=None, buffer=buf, target_array=_failing_target(),
+             buffer_pool=pool, array_name="state")
+    with pytest.raises(OSError):
+        w.wait_all(timeout=5.0)
+    assert buf.in_use is False
+    w.shutdown(timeout=5.0)
+
+
+def test_failing_task_is_retired_by_the_poll_loop():
+    """Serviced on the polling side, a failed task does not escape."""
+    w = WritebackWatcher()
+    pool = _make_pool()
+    buf = _make_pinned_buffer(shape=(2,))
+    buf.in_use = True
+    task = WritebackTask(
+        event=None, buffer=buf, target_array=_failing_target(),
+        buffer_pool=pool, array_name="state",
+    )
+    w._tasks.append(task)
+    w._pending_count = 1
+
+    assert w._service_next_task() is True
+    assert w._pending_count == 0
+    assert not w._tasks
+    assert buf.in_use is False
+    assert isinstance(w._error, OSError)
+
+
+def test_watcher_completes_later_tasks_after_a_failure():
+    """A failed copy does not stop the tasks queued behind it."""
+    w = WritebackWatcher()
+    pool = _make_pool()
+    w.submit(event=None, buffer=_make_pinned_buffer(shape=(2,)),
+             target_array=_failing_target(),
+             buffer_pool=pool, array_name="state")
+    target = np.zeros((2,), dtype=np.float32)
+    w.submit(event=None, buffer=_make_pinned_buffer(shape=(2,), fill=7.0),
+             target_array=target, buffer_pool=pool, array_name="state")
+    with pytest.raises(OSError):
+        w.wait_all(timeout=5.0)
+    np.testing.assert_array_equal(target, 7.0)
+    w.shutdown(timeout=5.0)
+
+
+def test_failed_copy_leaves_no_pending_task():
+    """A failed task is retired, so later waits still drain."""
+    w = WritebackWatcher()
+    pool = _make_pool()
+    w.submit(event=None, buffer=_make_pinned_buffer(shape=(2,)),
+             target_array=_failing_target(),
+             buffer_pool=pool, array_name="state")
+    with pytest.raises(OSError):
+        w.wait_all(timeout=5.0)
+    assert w._pending_count == 0
+    assert not w._tasks
+    w.wait_all(timeout=5.0)
+    w.shutdown(timeout=5.0)
+
+
+def test_wait_all_raises_the_first_error_once():
+    """The stored error surfaces on one wait, not on the next."""
+    w = WritebackWatcher()
+    pool = _make_pool()
+    w.submit(event=None, buffer=_make_pinned_buffer(shape=(2,)),
+             target_array=_failing_target(),
+             buffer_pool=pool, array_name="state")
+    with pytest.raises(OSError, match="No space left"):
+        w.wait_all(timeout=5.0)
+    assert w._error is None
+    w.wait_all(timeout=5.0)
+    w.shutdown(timeout=5.0)

--- a/tests/batchsolving/test_writeback_watcher.py
+++ b/tests/batchsolving/test_writeback_watcher.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from time import perf_counter, sleep
+
 import numpy as np
 import pytest
 
@@ -482,92 +484,73 @@ def test_multiple_tasks_all_complete():
 
 # ── Failing completion ────────────────────────────────────────── #
 
-class _FailingTarget(np.ndarray):
-    """Host target whose writes raise, standing in for bad I/O."""
-
-    def __setitem__(self, key, value):
-        raise OSError("[Errno 28] No space left on device")
-
 
 def _failing_target(shape=(2,)):
-    """Return a zeroed array that raises on assignment."""
-    return np.zeros(shape, dtype=np.float32).view(_FailingTarget)
+    """Return a read-only array whose writes raise, like bad I/O."""
+    target = np.zeros(shape, dtype=np.float32)
+    target.setflags(write=False)
+    return target
 
 
-def test_failed_copy_releases_the_buffer():
-    """A raising target still returns its buffer to the pool."""
+def test_wait_all_surfaces_a_failed_copy_once():
+    """A failed copy surfaces once and later tasks still complete."""
     w = WritebackWatcher()
     pool = _make_pool()
-    buf = _make_pinned_buffer(shape=(2,))
-    buf.in_use = True
-    w.submit(event=None, buffer=buf, target_array=_failing_target(),
+    failing_buf = pool.acquire("state", (2,), np.float32)
+    good_buf = pool.acquire("state", (2,), np.float32)
+    good_buf.array[:] = 7.0
+    target = np.zeros((2,), dtype=np.float32)
+    w.submit(event=None, buffer=failing_buf,
+             target_array=_failing_target(),
              buffer_pool=pool, array_name="state")
-    with pytest.raises(OSError):
+    w.submit(event=None, buffer=good_buf, target_array=target,
+             buffer_pool=pool, array_name="state")
+    with pytest.raises(ValueError, match="read-only"):
         w.wait_all(timeout=5.0)
-    assert buf.in_use is False
+    np.testing.assert_array_equal(target, 7.0)
+    assert failing_buf.in_use is False
+    assert good_buf.in_use is False
+    w.wait_all(timeout=5.0)
     w.shutdown(timeout=5.0)
 
 
-def test_failing_task_is_retired_by_the_poll_loop():
-    """Serviced on the polling side, a failed task does not escape."""
+def test_poll_loop_retires_a_failed_copy():
+    """The polling thread retires a failed copy without a wait."""
     w = WritebackWatcher()
     pool = _make_pool()
-    buf = _make_pinned_buffer(shape=(2,))
-    buf.in_use = True
+    buf = pool.acquire("state", (2,), np.float32)
+    w.submit(event=None, buffer=buf, target_array=_failing_target(),
+             buffer_pool=pool, array_name="state")
+    deadline = perf_counter() + 5.0
+    while buf.in_use and perf_counter() < deadline:
+        sleep(0.001)
+    assert buf.in_use is False
+    with pytest.raises(ValueError, match="read-only"):
+        w.wait_all(timeout=5.0)
+    w.shutdown(timeout=5.0)
+
+
+class _UnqueryableEvent:
+    """Event whose query raises, like a poisoned CUDA context."""
+
+    def query(self):
+        raise RuntimeError("context is poisoned")
+
+
+@pytest.mark.nocudasim
+def test_unqueryable_event_retires_task_and_frees_buffer():
+    """A raising event query retires its task and frees the buffer."""
+    w = WritebackWatcher()
+    pool = _make_pool()
+    buf = pool.acquire("state", (2,), np.float32)
     task = WritebackTask(
-        event=None, buffer=buf, target_array=_failing_target(),
+        event=_UnqueryableEvent(), buffer=buf,
+        target_array=np.zeros((2,), dtype=np.float32),
         buffer_pool=pool, array_name="state",
     )
     w._tasks.append(task)
     w._pending_count = 1
-
     assert w._service_next_task() is True
-    assert w._pending_count == 0
-    assert not w._tasks
     assert buf.in_use is False
-    assert isinstance(w._error, OSError)
-
-
-def test_watcher_completes_later_tasks_after_a_failure():
-    """A failed copy does not stop the tasks queued behind it."""
-    w = WritebackWatcher()
-    pool = _make_pool()
-    w.submit(event=None, buffer=_make_pinned_buffer(shape=(2,)),
-             target_array=_failing_target(),
-             buffer_pool=pool, array_name="state")
-    target = np.zeros((2,), dtype=np.float32)
-    w.submit(event=None, buffer=_make_pinned_buffer(shape=(2,), fill=7.0),
-             target_array=target, buffer_pool=pool, array_name="state")
-    with pytest.raises(OSError):
+    with pytest.raises(RuntimeError, match="poisoned"):
         w.wait_all(timeout=5.0)
-    np.testing.assert_array_equal(target, 7.0)
-    w.shutdown(timeout=5.0)
-
-
-def test_failed_copy_leaves_no_pending_task():
-    """A failed task is retired, so later waits still drain."""
-    w = WritebackWatcher()
-    pool = _make_pool()
-    w.submit(event=None, buffer=_make_pinned_buffer(shape=(2,)),
-             target_array=_failing_target(),
-             buffer_pool=pool, array_name="state")
-    with pytest.raises(OSError):
-        w.wait_all(timeout=5.0)
-    assert w._pending_count == 0
-    assert not w._tasks
-    w.wait_all(timeout=5.0)
-    w.shutdown(timeout=5.0)
-
-
-def test_wait_all_raises_the_first_error_once():
-    """The stored error surfaces on one wait, not on the next."""
-    w = WritebackWatcher()
-    pool = _make_pool()
-    w.submit(event=None, buffer=_make_pinned_buffer(shape=(2,)),
-             target_array=_failing_target(),
-             buffer_pool=pool, array_name="state")
-    with pytest.raises(OSError, match="No space left"):
-        w.wait_all(timeout=5.0)
-    assert w._error is None
-    w.wait_all(timeout=5.0)
-    w.shutdown(timeout=5.0)

--- a/tests/batchsolving/test_writeback_watcher.py
+++ b/tests/batchsolving/test_writeback_watcher.py
@@ -14,6 +14,7 @@ from cubie.batchsolving.writeback_watcher import (
 from cubie.cuda_simsafe import cuda
 
 from cubie.cuda_simsafe import CUDA_SIMULATION
+from cubie.memory import MemoryManager
 from cubie.memory.chunk_buffer_pool import ChunkBufferPool, PinnedBuffer
 
 
@@ -46,8 +47,8 @@ def _record_busy_event():
 
 
 def _make_pool():
-    """Return a fresh ChunkBufferPool."""
-    return ChunkBufferPool()
+    """Return a ChunkBufferPool with its own pinned budget."""
+    return ChunkBufferPool(memory_manager=MemoryManager())
 
 
 def _make_pinned_buffer(shape=(4, 3), dtype=np.float32, fill=1.0):

--- a/tests/memory/test_chunk_buffer_pool.py
+++ b/tests/memory/test_chunk_buffer_pool.py
@@ -66,30 +66,6 @@ def test_acquire_allocates_new_when_all_in_use(mgr):
     assert buf1.buffer_id != buf2.buffer_id
 
 
-def test_acquire_blocks_when_the_pinned_budget_refuses(mgr):
-    """With headroom open, a budget too small to grow waits."""
-    mgr.pinned_max_bytes = 40
-    pool = _UnthrottledPool(memory_manager=mgr)
-    first = pool.acquire("state", (10,), np.float32)
-    acquired = []
-    started = threading.Event()
-
-    def worker():
-        started.set()
-        acquired.append(pool.acquire("state", (10,), np.float32))
-
-    thread = threading.Thread(target=worker, daemon=True)
-    thread.start()
-    started.wait(timeout=2.0)
-    thread.join(timeout=0.2)
-    assert thread.is_alive()
-
-    pool.release(first)
-    thread.join(timeout=2.0)
-    assert not thread.is_alive()
-    assert acquired[0] is first
-
-
 def test_acquire_allocates_new_for_different_shape(mgr):
     """acquire allocates new buffer when shape differs."""
     pool = ChunkBufferPool(memory_manager=mgr)
@@ -190,17 +166,8 @@ class _UnthrottledPool(ChunkBufferPool):
         return True
 
 
-def test_acquire_grows_first_buffer_even_without_headroom(mgr):
-    """A label with nothing in flight always gets one buffer."""
-    pool = _ThrottledPool(memory_manager=mgr)
-    buf = pool.acquire("state", (10,), np.float32)
-    assert buf.in_use is True
-
-
-def test_acquire_blocks_until_release_when_headroom_exhausted(mgr):
-    """With headroom exhausted, acquire waits for an in-flight
-    buffer to be released rather than growing the pool."""
-    pool = _ThrottledPool(memory_manager=mgr)
+def _assert_second_acquire_waits_for_release(pool):
+    """Check a second matching acquire waits instead of growing."""
     first = pool.acquire("state", (10,), np.float32)
     acquired = []
     started = threading.Event()
@@ -220,3 +187,31 @@ def test_acquire_blocks_until_release_when_headroom_exhausted(mgr):
     thread.join(timeout=2.0)
     assert not thread.is_alive()
     assert acquired[0] is first
+
+
+def test_acquire_grows_first_buffer_even_without_headroom(mgr):
+    """A label with nothing in flight always gets one buffer."""
+    pool = _ThrottledPool(memory_manager=mgr)
+    buf = pool.acquire("state", (10,), np.float32)
+    assert buf.in_use is True
+
+
+def test_acquire_blocks_until_release_when_headroom_exhausted(mgr):
+    """With headroom exhausted, acquire waits for an in-flight
+    buffer to be released rather than growing the pool."""
+    _assert_second_acquire_waits_for_release(
+        _ThrottledPool(memory_manager=mgr)
+    )
+
+
+def test_acquire_blocks_until_release_when_the_budget_refuses(mgr):
+    """With headroom open, a budget with no room for a second
+    buffer waits on the same release.
+
+    This is the refusal a device-less manager used to reach with a
+    one-byte budget, with nothing in flight to wake the waiter.
+    """
+    mgr.pinned_max_bytes = 40
+    _assert_second_acquire_waits_for_release(
+        _UnthrottledPool(memory_manager=mgr)
+    )

--- a/tests/memory/test_chunk_buffer_pool.py
+++ b/tests/memory/test_chunk_buffer_pool.py
@@ -1,7 +1,6 @@
 """Tests for cubie.memory.chunk_buffer_pool.
 
-Pools are built on the ``mgr`` fixture, whose fixed device size keeps
-growth charged to a known pinned budget.
+Pools are built on the ``mgr`` fixture for a fixed pinned budget.
 """
 
 from __future__ import annotations
@@ -54,12 +53,7 @@ def test_acquire_reuses_released_buffer(mgr):
 
 
 def test_acquire_allocates_new_when_all_in_use(mgr):
-    """acquire grows the pool when in-use buffers block reuse.
-
-    Growth is forced open so the assertion does not depend on the
-    machine's free RAM at test time; the headroom-exhausted branch
-    is exercised by the blocking tests below.
-    """
+    """acquire grows the pool when in-use buffers block reuse."""
     pool = _UnthrottledPool(memory_manager=mgr)
     buf1 = pool.acquire("x", (10,), np.float32)
     buf2 = pool.acquire("x", (10,), np.float32)
@@ -197,20 +191,14 @@ def test_acquire_grows_first_buffer_even_without_headroom(mgr):
 
 
 def test_acquire_blocks_until_release_when_headroom_exhausted(mgr):
-    """With headroom exhausted, acquire waits for an in-flight
-    buffer to be released rather than growing the pool."""
+    """Headroom exhausted: acquire waits for a release."""
     _assert_second_acquire_waits_for_release(
         _ThrottledPool(memory_manager=mgr)
     )
 
 
 def test_acquire_blocks_until_release_when_the_budget_refuses(mgr):
-    """With headroom open, a budget with no room for a second
-    buffer waits on the same release.
-
-    This is the refusal a device-less manager used to reach with a
-    one-byte budget, with nothing in flight to wake the waiter.
-    """
+    """Budget with no room for a second buffer: acquire waits."""
     mgr.pinned_max_bytes = 40
     _assert_second_acquire_waits_for_release(
         _UnthrottledPool(memory_manager=mgr)

--- a/tests/memory/test_chunk_buffer_pool.py
+++ b/tests/memory/test_chunk_buffer_pool.py
@@ -1,4 +1,8 @@
-"""Tests for cubie.memory.chunk_buffer_pool."""
+"""Tests for cubie.memory.chunk_buffer_pool.
+
+Pools are built on the ``mgr`` fixture, whose fixed device size keeps
+growth charged to a known pinned budget.
+"""
 
 from __future__ import annotations
 
@@ -29,18 +33,18 @@ def test_pinned_buffer_in_use_override():
 
 # ── acquire ───────────────────────────────────────────────────── #
 
-def test_acquire_returns_buffer_with_correct_shape_dtype():
+def test_acquire_returns_buffer_with_correct_shape_dtype(mgr):
     """acquire returns a PinnedBuffer matching requested shape and dtype."""
-    pool = ChunkBufferPool()
+    pool = ChunkBufferPool(memory_manager=mgr)
     buf = pool.acquire("state", (100, 4), np.float32)
     assert buf.array.shape == (100, 4)
     assert buf.array.dtype == np.float32
     assert buf.in_use is True
 
 
-def test_acquire_reuses_released_buffer():
+def test_acquire_reuses_released_buffer(mgr):
     """acquire reuses a released buffer with matching shape/dtype."""
-    pool = ChunkBufferPool()
+    pool = ChunkBufferPool(memory_manager=mgr)
     buf1 = pool.acquire("state", (50, 3), np.float32)
     bid = buf1.buffer_id
     pool.release(buf1)
@@ -49,40 +53,64 @@ def test_acquire_reuses_released_buffer():
     assert buf2 is buf1
 
 
-def test_acquire_allocates_new_when_all_in_use():
+def test_acquire_allocates_new_when_all_in_use(mgr):
     """acquire grows the pool when in-use buffers block reuse.
 
     Growth is forced open so the assertion does not depend on the
     machine's free RAM at test time; the headroom-exhausted branch
     is exercised by the blocking tests below.
     """
-    pool = _UnthrottledPool()
+    pool = _UnthrottledPool(memory_manager=mgr)
     buf1 = pool.acquire("x", (10,), np.float32)
     buf2 = pool.acquire("x", (10,), np.float32)
     assert buf1.buffer_id != buf2.buffer_id
 
 
-def test_acquire_allocates_new_for_different_shape():
+def test_acquire_blocks_when_the_pinned_budget_refuses(mgr):
+    """With headroom open, a budget too small to grow waits."""
+    mgr.pinned_max_bytes = 40
+    pool = _UnthrottledPool(memory_manager=mgr)
+    first = pool.acquire("state", (10,), np.float32)
+    acquired = []
+    started = threading.Event()
+
+    def worker():
+        started.set()
+        acquired.append(pool.acquire("state", (10,), np.float32))
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    started.wait(timeout=2.0)
+    thread.join(timeout=0.2)
+    assert thread.is_alive()
+
+    pool.release(first)
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()
+    assert acquired[0] is first
+
+
+def test_acquire_allocates_new_for_different_shape(mgr):
     """acquire allocates new buffer when shape differs."""
-    pool = ChunkBufferPool()
+    pool = ChunkBufferPool(memory_manager=mgr)
     buf1 = pool.acquire("x", (10,), np.float32)
     pool.release(buf1)
     buf2 = pool.acquire("x", (20,), np.float32)
     assert buf1.buffer_id != buf2.buffer_id
 
 
-def test_acquire_allocates_new_for_different_dtype():
+def test_acquire_allocates_new_for_different_dtype(mgr):
     """acquire allocates new buffer when dtype differs."""
-    pool = ChunkBufferPool()
+    pool = ChunkBufferPool(memory_manager=mgr)
     buf1 = pool.acquire("x", (10,), np.float32)
     pool.release(buf1)
     buf2 = pool.acquire("x", (10,), np.float64)
     assert buf1.buffer_id != buf2.buffer_id
 
 
-def test_acquire_creates_new_array_name_entry():
+def test_acquire_creates_new_array_name_entry(mgr):
     """First acquire for a name creates a new entry in _buffers."""
-    pool = ChunkBufferPool()
+    pool = ChunkBufferPool(memory_manager=mgr)
     pool.acquire("new_name", (5,), np.float32)
     assert "new_name" in pool._buffers
     assert len(pool._buffers["new_name"]) == 1
@@ -90,9 +118,9 @@ def test_acquire_creates_new_array_name_entry():
 
 # ── release ───────────────────────────────────────────────────── #
 
-def test_release_marks_not_in_use():
+def test_release_marks_not_in_use(mgr):
     """release sets buffer.in_use to False."""
-    pool = ChunkBufferPool()
+    pool = ChunkBufferPool(memory_manager=mgr)
     buf = pool.acquire("x", (10,), np.float32)
     assert buf.in_use is True
     pool.release(buf)
@@ -101,9 +129,9 @@ def test_release_marks_not_in_use():
 
 # ── clear ─────────────────────────────────────────────────────── #
 
-def test_clear_empties_pool_and_resets_id():
+def test_clear_empties_pool_and_resets_id(mgr):
     """clear removes all buffers and resets _next_id to 0."""
-    pool = ChunkBufferPool()
+    pool = ChunkBufferPool(memory_manager=mgr)
     pool.acquire("a", (10,), np.float32)
     pool.acquire("b", (20,), np.float64)
     pool.clear()
@@ -113,9 +141,9 @@ def test_clear_empties_pool_and_resets_id():
 
 # ── _allocate_buffer ──────────────────────────────────────────── #
 
-def test_allocate_buffer_increments_id():
+def test_allocate_buffer_increments_id(mgr):
     """Each allocated buffer gets an incrementing buffer_id."""
-    pool = ChunkBufferPool()
+    pool = ChunkBufferPool(memory_manager=mgr)
     ids = []
     for i in range(5):
         buf = pool.acquire(f"arr_{i}", (3,), np.float32)
@@ -125,9 +153,9 @@ def test_allocate_buffer_increments_id():
 
 # ── Thread safety ─────────────────────────────────────────────── #
 
-def test_thread_safe_concurrent_acquire_release():
+def test_thread_safe_concurrent_acquire_release(mgr):
     """Concurrent acquire/release does not raise or corrupt state."""
-    pool = ChunkBufferPool()
+    pool = ChunkBufferPool(memory_manager=mgr)
     errors = []
 
     def worker(tid):
@@ -162,17 +190,17 @@ class _UnthrottledPool(ChunkBufferPool):
         return True
 
 
-def test_acquire_grows_first_buffer_even_without_headroom():
+def test_acquire_grows_first_buffer_even_without_headroom(mgr):
     """A label with nothing in flight always gets one buffer."""
-    pool = _ThrottledPool()
+    pool = _ThrottledPool(memory_manager=mgr)
     buf = pool.acquire("state", (10,), np.float32)
     assert buf.in_use is True
 
 
-def test_acquire_blocks_until_release_when_headroom_exhausted():
+def test_acquire_blocks_until_release_when_headroom_exhausted(mgr):
     """With headroom exhausted, acquire waits for an in-flight
     buffer to be released rather than growing the pool."""
-    pool = _ThrottledPool()
+    pool = _ThrottledPool(memory_manager=mgr)
     first = pool.acquire("state", (10,), np.float32)
     acquired = []
     started = threading.Event()

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -1478,18 +1478,62 @@ def test_sizing_raises_from_the_stored_probe_error():
 
 
 def test_registration_survives_without_a_device():
-    """Registration works device-free; its unsized cap is None."""
+    """Registration works device-free; its unsized cap is None.
+
+    Both pools behave the same way: a proportion is policy, and only
+    the byte cap needs a device size. A raise here would land after
+    the caller had already moved the instance out of a pool.
+    """
 
     class NoCudaMemoryManager(MemoryManager):
         def get_memory_info(self):
             raise ValueError("no device here")
 
     mgr = NoCudaMemoryManager()
-    client = MemoryClient()
-    mgr.register(client)
-    assert mgr.registry[id(client)].cap is None
-    with pytest.raises(NoCudaDeviceError):
-        mgr.set_manual_proportion(client, 0.5)
+    auto_client = MemoryClient()
+    manual_client = MemoryClient()
+    mgr.register(auto_client)
+    mgr.register(manual_client, proportion=0.25)
+    assert mgr.registry[id(auto_client)].cap is None
+    assert mgr.registry[id(manual_client)].cap is None
+    assert mgr.registry[id(manual_client)].proportion == 0.25
+
+    mgr.set_manual_proportion(auto_client, 0.5)
+    assert mgr._auto_pool == []
+    assert id(auto_client) in mgr._manual_pool
+    assert mgr.registry[id(auto_client)].cap is None
+    assert mgr.registry[id(auto_client)].proportion == 0.5
+
+
+def test_probe_device_sizes_a_manager_built_without_one():
+    """A late device resizes every registered cap.
+
+    The precompile plugin patches ``get_memory_info`` after cubie
+    imports, so the shared manager probes again to pick it up.
+    """
+    total = 24 * 1024**3
+    devices = []
+
+    class LateDeviceMemoryManager(MemoryManager):
+        def get_memory_info(self):
+            if not devices:
+                raise ValueError("no device here")
+            return total // 2, total
+
+    mgr = LateDeviceMemoryManager()
+    auto_client = MemoryClient()
+    manual_client = MemoryClient()
+    mgr.register(auto_client)
+    mgr.register(manual_client, proportion=0.25)
+
+    devices.append("device")
+    mgr.probe_device()
+
+    assert mgr.totalmem == total
+    assert mgr.pinned_max_bytes == total
+    assert mgr._device_probe_error is None
+    assert mgr.registry[id(manual_client)].cap == int(0.25 * total)
+    assert mgr.registry[id(auto_client)].cap == int(0.75 * total)
 
 
 def test_register_proportion_out_of_range(mgr, memory_client):

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -18,6 +18,7 @@ from cubie.memory.cupy_emm import CuPyAsyncNumbaManager
 from cubie.memory.mem_manager import (
     HOST_SPILL_FRACTION,
     MemoryManager,
+    NoCudaDeviceError,
     ArrayRequest,
     ArrayResponse,
     InstanceMemorySettings,
@@ -1446,21 +1447,49 @@ def test_instance_memory_settings_free_missing_key_warns():
 
 
 def test_attrs_post_init_cuda_less_environment():
-    """Test the manager falls back to totalmem=1 in a cuda-less env.
-
-    __attrs_post_init__ interprets a ValueError from get_memory_info
-    whose message starts with "not enough values to unpack" as
-    evidence there is no CUDA context to query, warns, and sets
-    totalmem to a placeholder of 1 byte instead of raising.
-    """
+    """A failed probe builds a manager holding no size."""
 
     class NoCudaMemoryManager(MemoryManager):
         def get_memory_info(self):
             raise ValueError("not enough values to unpack (expected 2, got 0)")
 
-    with pytest.warns(UserWarning, match="cuda-less"):
-        mgr = NoCudaMemoryManager()
-    assert mgr.totalmem == 1
+    mgr = NoCudaMemoryManager()
+    assert mgr.totalmem is None
+    assert mgr.pinned_max_bytes is None
+
+
+def test_sizing_raises_from_the_stored_probe_error():
+    """Every sizing decision re-raises the driver's own error."""
+
+    probe_error = ValueError("no device here")
+
+    class NoCudaMemoryManager(MemoryManager):
+        def get_memory_info(self):
+            raise probe_error
+
+    mgr = NoCudaMemoryManager()
+    with pytest.raises(NoCudaDeviceError) as excinfo:
+        mgr.pinned_budget_bytes
+    assert excinfo.value.__cause__ is probe_error
+    with pytest.raises(NoCudaDeviceError):
+        mgr.choose_host_memory_type(1024)
+    with pytest.raises(NoCudaDeviceError):
+        mgr.allocate_pinned_array((8,), np.float64)
+
+
+def test_registration_survives_without_a_device():
+    """Registration works device-free; its unsized cap is None."""
+
+    class NoCudaMemoryManager(MemoryManager):
+        def get_memory_info(self):
+            raise ValueError("no device here")
+
+    mgr = NoCudaMemoryManager()
+    client = MemoryClient()
+    mgr.register(client)
+    assert mgr.registry[id(client)].cap is None
+    with pytest.raises(NoCudaDeviceError):
+        mgr.set_manual_proportion(client, 0.5)
 
 
 def test_register_proportion_out_of_range(mgr, memory_client):
@@ -1657,16 +1686,23 @@ def test_replace_with_chunked_size():
 
 
 def test_attrs_post_init_unexpected_exception():
-    """Test __attrs_post_init__ falls back to totalmem=1 and warns on
-    an unexpected exception from get_memory_info."""
+    """Any probe failure holds no size and keeps its own error."""
 
     class BrokenMemoryManager(MemoryManager):
         def get_memory_info(self):
             raise RuntimeError("boom")
 
-    with pytest.warns(UserWarning, match="Unexpected exception"):
-        mgr = BrokenMemoryManager()
-    assert mgr.totalmem == 1
+    mgr = BrokenMemoryManager()
+    assert mgr.totalmem is None
+    with pytest.raises(NoCudaDeviceError) as excinfo:
+        mgr.pinned_budget_bytes
+    assert str(excinfo.value.__cause__) == "boom"
+
+
+def test_totalmem_is_not_a_constructor_argument():
+    """A caller cannot claim a device size the device did not report."""
+    with pytest.raises(TypeError):
+        MemoryManager(totalmem=1024)
 
 
 def test_set_auto_limit_mode_noop_when_already_auto(mgr, memory_client):

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -8,6 +8,7 @@ import pytest
 from cubie.cuda_simsafe import cuda
 
 from cubie.cuda_simsafe import (
+    CudaSupportError,
     DeviceNDArray,
     Stream,
     empty_pinned,
@@ -1461,7 +1462,7 @@ def test_attrs_post_init_cuda_less_environment():
 def test_sizing_raises_from_the_stored_probe_error():
     """Every sizing decision re-raises the driver's own error."""
 
-    probe_error = ValueError("no device here")
+    probe_error = CudaSupportError("Error at driver init")
 
     class NoCudaMemoryManager(MemoryManager):
         def get_memory_info(self):
@@ -1475,47 +1476,23 @@ def test_sizing_raises_from_the_stored_probe_error():
         mgr.choose_host_memory_type(1024)
     with pytest.raises(NoCudaDeviceError):
         mgr.allocate_pinned_array((8,), np.float64)
-
-
-def test_registration_survives_without_a_device():
-    """Registration works device-free; both pools get a None cap."""
-
-    class NoCudaMemoryManager(MemoryManager):
-        def get_memory_info(self):
-            raise ValueError("no device here")
-
-    mgr = NoCudaMemoryManager()
-    auto_client = MemoryClient()
-    manual_client = MemoryClient()
-    mgr.register(auto_client)
-    mgr.register(manual_client, proportion=0.25)
-    assert mgr.registry[id(auto_client)].cap is None
-    assert mgr.registry[id(manual_client)].cap is None
-    assert mgr.registry[id(manual_client)].proportion == 0.25
-
-    mgr.set_manual_proportion(auto_client, 0.5)
-    assert mgr._auto_pool == []
-    assert id(auto_client) in mgr._manual_pool
-    assert mgr.registry[id(auto_client)].cap is None
-    assert mgr.registry[id(auto_client)].proportion == 0.5
+    with pytest.raises(NoCudaDeviceError):
+        mgr.get_available_memory("default")
 
 
 def test_probe_device_sizes_a_manager_built_without_one():
-    """A later probe sizes the manager and every registered cap."""
+    """A later device answer sizes an unsized manager."""
     total = 24 * 1024**3
     devices = []
 
     class LateDeviceMemoryManager(MemoryManager):
         def get_memory_info(self):
             if not devices:
-                raise ValueError("no device here")
+                raise CudaSupportError("Error at driver init")
             return total // 2, total
 
     mgr = LateDeviceMemoryManager()
-    auto_client = MemoryClient()
-    manual_client = MemoryClient()
-    mgr.register(auto_client)
-    mgr.register(manual_client, proportion=0.25)
+    assert mgr.totalmem is None
 
     devices.append("device")
     mgr.probe_device()
@@ -1523,8 +1500,25 @@ def test_probe_device_sizes_a_manager_built_without_one():
     assert mgr.totalmem == total
     assert mgr.pinned_max_bytes == total
     assert mgr._device_probe_error is None
-    assert mgr.registry[id(manual_client)].cap == int(0.25 * total)
-    assert mgr.registry[id(auto_client)].cap == int(0.75 * total)
+
+
+def test_sizing_recovers_when_a_device_appears():
+    """A sizing decision reprobes an unsized manager by itself."""
+    total = 24 * 1024**3
+    devices = []
+
+    class LateDeviceMemoryManager(MemoryManager):
+        def get_memory_info(self):
+            if not devices:
+                raise CudaSupportError("Error at driver init")
+            return total // 2, total
+
+    mgr = LateDeviceMemoryManager()
+    assert mgr.totalmem is None
+
+    devices.append("device")
+    assert mgr.get_available_memory("default") == total // 2
+    assert mgr.totalmem == total
 
 
 def test_register_proportion_out_of_range(mgr, memory_client):
@@ -1721,17 +1715,14 @@ def test_replace_with_chunked_size():
 
 
 def test_attrs_post_init_unexpected_exception():
-    """Any probe failure holds no size and keeps its own error."""
+    """A probe failure that is not device absence stays visible."""
 
     class BrokenMemoryManager(MemoryManager):
         def get_memory_info(self):
             raise RuntimeError("boom")
 
-    mgr = BrokenMemoryManager()
-    assert mgr.totalmem is None
-    with pytest.raises(NoCudaDeviceError) as excinfo:
-        mgr.pinned_budget_bytes
-    assert str(excinfo.value.__cause__) == "boom"
+    with pytest.raises(RuntimeError, match="boom"):
+        BrokenMemoryManager()
 
 
 def test_totalmem_is_not_a_constructor_argument():
@@ -2298,6 +2289,21 @@ def test_choose_host_memory_type_default_threshold(mgr):
     assert mgr.choose_host_memory_type(ram_threshold + 1) == "memmap"
     mgr.pinned_max_bytes = 256
     assert mgr.choose_host_memory_type(128) == "pinned"
+
+
+def test_choose_host_memory_type_host_only_without_device():
+    """Disk and pageable backing decide without touching a device."""
+
+    class NoCudaMemoryManager(MemoryManager):
+        def get_memory_info(self):
+            raise CudaSupportError("Error at driver init")
+
+    mgr = NoCudaMemoryManager()
+    assert mgr.choose_host_memory_type(2048, 1024) == "memmap"
+    assert (
+        mgr.choose_host_memory_type(128, 1024, allow_pinned=False)
+        == "host"
+    )
 
 
 def test_pinned_ceiling_defaults_to_vram(mgr):

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -1478,12 +1478,7 @@ def test_sizing_raises_from_the_stored_probe_error():
 
 
 def test_registration_survives_without_a_device():
-    """Registration works device-free; its unsized cap is None.
-
-    Both pools behave the same way: a proportion is policy, and only
-    the byte cap needs a device size. A raise here would land after
-    the caller had already moved the instance out of a pool.
-    """
+    """Registration works device-free; both pools get a None cap."""
 
     class NoCudaMemoryManager(MemoryManager):
         def get_memory_info(self):
@@ -1506,11 +1501,7 @@ def test_registration_survives_without_a_device():
 
 
 def test_probe_device_sizes_a_manager_built_without_one():
-    """A late device resizes every registered cap.
-
-    The precompile plugin patches ``get_memory_info`` after cubie
-    imports, so the shared manager probes again to pick it up.
-    """
+    """A later probe sizes the manager and every registered cap."""
     total = 24 * 1024**3
     devices = []
 

--- a/tests/precompile_plugin.py
+++ b/tests/precompile_plugin.py
@@ -533,12 +533,11 @@ if POPULATION:
     _MemoryManager.get_available_memory = lambda self, group: 8 << 30
     _MemoryManager.get_memory_info = lambda self: (8 << 30, 24 << 30)
 
-    # The shared manager probed before the patch above; restate it.
+    # The shared manager probed before the patch above, so it holds no
+    # size; probing again reads the patched figures.
     from cubie.memory import default_memmgr as _default_memmgr  # noqa: E402
 
-    _default_memmgr.totalmem = 24 << 30
-    _default_memmgr.pinned_max_bytes = 24 << 30
-    _default_memmgr._device_probe_error = None
+    _default_memmgr.probe_device()
 
     # ArrayInterpolator.get_interpolated stages its kernel arguments
     # through cupy directly; without a CUDA driver those calls raise

--- a/tests/precompile_plugin.py
+++ b/tests/precompile_plugin.py
@@ -533,8 +533,7 @@ if POPULATION:
     _MemoryManager.get_available_memory = lambda self, group: 8 << 30
     _MemoryManager.get_memory_info = lambda self: (8 << 30, 24 << 30)
 
-    # The shared manager probed before the patch above, so it holds no
-    # size; probing again reads the patched figures.
+    # Read the patched figures into the already-built shared manager.
     from cubie.memory import default_memmgr as _default_memmgr  # noqa: E402
 
     _default_memmgr.probe_device()

--- a/tests/precompile_plugin.py
+++ b/tests/precompile_plugin.py
@@ -533,6 +533,13 @@ if POPULATION:
     _MemoryManager.get_available_memory = lambda self, group: 8 << 30
     _MemoryManager.get_memory_info = lambda self: (8 << 30, 24 << 30)
 
+    # The shared manager probed before the patch above; restate it.
+    from cubie.memory import default_memmgr as _default_memmgr  # noqa: E402
+
+    _default_memmgr.totalmem = 24 << 30
+    _default_memmgr.pinned_max_bytes = 24 << 30
+    _default_memmgr._device_probe_error = None
+
     # ArrayInterpolator.get_interpolated stages its kernel arguments
     # through cupy directly; without a CUDA driver those calls raise
     # before the launch, so the kernel would never reach the cache.


### PR DESCRIPTION
Two ways a chunked or spilled solve could stall forever with no output.

### A missing device left the memory manager sized at one byte

`MemoryManager` answered a failed device probe with `totalmem = 1`. One byte is a real number to everything downstream: #697 gave the pinned ledger a budget of `min(pinned_max_bytes, 0.8 × RAM)`, so a 1-byte `totalmem` made `pinned_budget_bytes` refuse every staging buffer, and `ChunkBufferPool.acquire` blocked on `_condition.wait()` for a release only another buffer could produce. All 16 precompile lanes of run 30778352194 stopped after `[ 98%]` at 02:09:38 and were cancelled 57 minutes later.

A failed probe now stores the driver's error and leaves `totalmem` and `pinned_max_bytes` at `None`. Construction still succeeds, so importing cubie on a GPU-less machine works and the `cpu-verdicts` lanes keep banking. `pinned_budget_bytes`, `allocate_pinned_array` and `choose_host_memory_type` raise `NoCudaDeviceError` **from** the stored error.

Registration and proportion changes carry an unsized cap instead of raising. `register`, `set_manual_proportion` and `set_manual_limit_mode` move the instance between pools before the cap is sized, so a raise there would leave it in neither. `_cap_bytes` is the single place a proportion becomes bytes, answering `None` with no device. `get_available_memory` and `get_chunk_parameters`, the active-mode readers of those caps, probe the device before they touch one.

`probe_device()` carries the probe. It runs at construction and again on demand, re-reading the device and resizing every registered cap. The precompile plugin patches `get_memory_info` after cubie has imported, after the shared manager has already probed, and calls it to read the patched figures in.

`totalmem` is no longer a constructor argument. Nothing passed it, `__attrs_post_init__` overwrote whatever a caller did pass, and a manager reporting a size the device does not have would size allocations against it.

### A failed writeback stranded its buffer and its pending count

An exception completing a writeback task escaped both drain paths: on the polling thread it killed the thread and dropped the popped task, and on the `wait_all` path it re-queued a task that can never succeed. Either way `_pending_count` never reached zero and the buffer stayed in use, so `wait_for_writeback`, which `Solver.solve` calls with no timeout, waited forever. Only the output side is exposed; input tasks carry no target array.

`_complete_task` now copies inside `try`/`except`/`finally`. The error goes to `_record_error`, the buffer is released either way, and nothing propagates from the failure point, so both drain paths behave identically. `wait_all` re-raises the stored error once the queue drains, then clears it. `_service_next_task` retires a task whose event cannot be queried. `_submit_task` starts the thread before queueing, so a `submit` that raises has not taken the buffer. The staging loops in `InputArrays` and `OutputArrays` release their buffer when the device copy raises before the watcher takes it.

A writeback copy failure now reaches the caller from `wait_all` at the end of the solve rather than from the thread that hit it, and `close()` re-raises a solve error that was never waited on.

### Tests

Pools in `tests/memory/test_chunk_buffer_pool.py` are built on the `mgr` fixture, charging growth to a fixed budget rather than the machine's device. The two refusals, RAM headroom and pinned budget, share one blocking-behaviour helper. The watcher's failure tests drive `_service_next_task` directly rather than racing `wait_all` for the task.

### Verification
- Real GPU, `-m "not specific_algos and not sim_only"`: **3151 passed** in 64.20s
- CUDASIM, `-m "not nocudasim and not cupy and not specific_algos"`: **3102 passed** in 21.58s
- Driverless precompile lane (`CUDA_VISIBLE_DEVICES=-1`), full suite: **61.51s**, cache holds 199 kernel payloads
- Driverless `import cubie`: both pools register at `cap = None`; `pinned_budget_bytes`, `choose_host_memory_type` and `allocate_pinned_array` raise `NoCudaDeviceError` from `CudaSupportError: cuInit ... CUDA_ERROR_NO_DEVICE`; `ChunkBufferPool.acquire` raises rather than blocking; `probe_device()` against a restored `get_memory_info` sizes the manager and both caps
- Writeback failure, before → after: watcher thread dead → alive; `_pending_count` 1 forever → 0; buffer in use forever → released; `wait_all` blocks forever → raises once
- Removing the staging guard turns `test_stage_output_releases_the_buffer_when_the_copy_fails` red on its buffer assertion

### Performance gate
`--pairs 8`.
```
numba-cuda fixed          kernel  A    61.978  B    61.993   +0.01%  ok
numba-cuda fixed          wall    A    75.557  B    71.768   -4.93%  ok
numba-cuda adaptive       kernel  A    17.805  B    17.821   -0.09%  ok  DISTRUST
numba-cuda adaptive       wall    A    21.537  B    20.945   -2.60%  ok
numba-cuda host_overhead  wall    A     0.791  B     0.626   -0.163ms  ok
numba-cuda chunked        kernel  A    62.366  B    62.374   -0.01%  ok
numba-cuda chunked        wall    A    76.494  B    76.565   +0.11%  ok
numba-cuda wave           kernel  A    25.560  B    25.563   -0.00%  ok
numba-cuda wave           wall    A    27.246  B    27.285   +0.16%  ok
mlir       fixed          kernel  A    62.042  B    62.064   +0.01%  ok
mlir       fixed          wall    A    75.069  B    75.046   -0.08%  ok
mlir       adaptive       kernel  A    17.218  B    17.223   +0.00%  ok
mlir       adaptive       wall    A    21.075  B    20.973   -0.35%  ok
mlir       host_overhead  wall    A     0.823  B     0.847   -0.003ms  ok
mlir       chunked        kernel  A    62.437  B    62.462   +0.00%  ok
mlir       chunked        wall    A    76.786  B    76.724   -0.20%  ok
mlir       wave           kernel  A    25.683  B    25.688   -0.00%  ok
mlir       wave           wall    A    27.825  B    27.666   -0.63%  ok
GATE: INCONCLUSIVE (kernel threshold 0.50%, wall threshold 10.00%, host-overhead threshold 0.25 ms)
```

Co-authored by Chris' bot
