### PR TITLE
fix(memory): host RAM availability counts reclaimable memory on Linux

### DIFF
--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -168,14 +168,8 @@ def total_system_ram() -> int:
 
 
 def available_system_ram() -> int:
-    """Return currently available physical RAM in bytes.
-
-    On Linux this is ``MemAvailable`` from ``/proc/meminfo``: the
-    kernel's estimate of memory usable without swapping, including
-    reclaimable page cache. The ``sysconf`` figure counts only free
-    pages, which a loaded machine keeps near zero while most of its
-    RAM sits in reclaimable cache.
-    """
+    """Return available physical RAM in bytes, including
+    reclaimable page cache on Linux."""
     if sys.platform == "win32":
         return int(_memory_status().ullAvailPhys)
     if sys.platform == "linux":

--- a/src/cubie/memory/mem_manager.py
+++ b/src/cubie/memory/mem_manager.py
@@ -168,9 +168,21 @@ def total_system_ram() -> int:
 
 
 def available_system_ram() -> int:
-    """Return currently available physical RAM in bytes."""
+    """Return currently available physical RAM in bytes.
+
+    On Linux this is ``MemAvailable`` from ``/proc/meminfo``: the
+    kernel's estimate of memory usable without swapping, including
+    reclaimable page cache. The ``sysconf`` figure counts only free
+    pages, which a loaded machine keeps near zero while most of its
+    RAM sits in reclaimable cache.
+    """
     if sys.platform == "win32":
         return int(_memory_status().ullAvailPhys)
+    if sys.platform == "linux":
+        with open("/proc/meminfo") as meminfo:
+            for line in meminfo:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024
     return os.sysconf("SC_AVPHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
 
 

--- a/tests/batchsolving/test_writeback_watcher.py
+++ b/tests/batchsolving/test_writeback_watcher.py
@@ -47,13 +47,7 @@ def _record_busy_event():
 
 
 class _UnthrottledPool(ChunkBufferPool):
-    """Pool whose headroom check is forced open.
-
-    Watcher tests acquire several same-label buffers with no
-    release in flight; a machine with exhausted RAM headroom would
-    block the second acquire forever. Growth throttling has its own
-    tests in tests/memory/test_chunk_buffer_pool.py.
-    """
+    """Pool whose headroom check is forced open."""
 
     def _headroom_allows(self, shape, dtype):
         return True

--- a/tests/batchsolving/test_writeback_watcher.py
+++ b/tests/batchsolving/test_writeback_watcher.py
@@ -46,9 +46,22 @@ def _record_busy_event():
     return stream, event
 
 
+class _UnthrottledPool(ChunkBufferPool):
+    """Pool whose headroom check is forced open.
+
+    Watcher tests acquire several same-label buffers with no
+    release in flight; a machine with exhausted RAM headroom would
+    block the second acquire forever. Growth throttling has its own
+    tests in tests/memory/test_chunk_buffer_pool.py.
+    """
+
+    def _headroom_allows(self, shape, dtype):
+        return True
+
+
 def _make_pool():
-    """Return a ChunkBufferPool with its own pinned budget."""
-    return ChunkBufferPool(memory_manager=MemoryManager())
+    """Return a growth-unthrottled pool with its own pinned budget."""
+    return _UnthrottledPool(memory_manager=MemoryManager())
 
 
 def _make_pinned_buffer(shape=(4, 3), dtype=np.float32, fill=1.0):

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -2246,12 +2246,7 @@ def test_total_system_ram_reports_positive():
 
 
 def test_available_system_ram_reports_reclaimable_memory():
-    """The availability probe reports a plausible fraction of RAM.
-
-    A loaded Linux machine keeps free pages near zero while most of
-    its RAM sits in reclaimable page cache, so the probe must count
-    reclaimable memory, not free pages.
-    """
+    """The availability probe reports a plausible fraction of RAM."""
     available = available_system_ram()
     assert 0 < available <= total_system_ram()
 

--- a/tests/memory/test_memmgmt.py
+++ b/tests/memory/test_memmgmt.py
@@ -23,6 +23,7 @@ from cubie.memory.mem_manager import (
     ArrayRequest,
     ArrayResponse,
     InstanceMemorySettings,
+    available_system_ram,
     total_system_ram,
     _numba_stream_ptr,
     current_cupy_stream,
@@ -2242,6 +2243,17 @@ def test_total_system_ram_reports_positive():
     ram_total = total_system_ram()
     assert ram_total is not None
     assert ram_total > 0
+
+
+def test_available_system_ram_reports_reclaimable_memory():
+    """The availability probe reports a plausible fraction of RAM.
+
+    A loaded Linux machine keeps free pages near zero while most of
+    its RAM sits in reclaimable page cache, so the probe must count
+    reclaimable memory, not free pages.
+    """
+    available = available_system_ram()
+    assert 0 < available <= total_system_ram()
 
 
 def test_choose_host_memory_type_applies_policy(mgr, tmp_path):


### PR DESCRIPTION
The Linux RAM-availability probe reads `MemAvailable` from `/proc/meminfo`; `sysconf(SC_AVPHYS_PAGES)` counted only free pages, which a loaded machine keeps near zero while most of its RAM sits in reclaimable page cache. Under that under-report, `host_headroom_bytes()` collapsed and `ChunkBufferPool.acquire` refused all pool growth, so a second same-label acquire with no release in flight waited forever — the 98%-frozen precompile lanes on the linux numba-cuda CI legs (run 30801885541: 4/16 lanes hung; the hang landed in whichever cc pass memory pressure peaked, so Windows lanes and the less-loaded mlir lanes escaped). The non-Linux POSIX path keeps the `sysconf` figure.

Writeback-watcher tests draw buffers from a growth-unthrottled pool with its own pinned budget, so their deliberate double-acquires do not depend on the machine's RAM state; growth throttling keeps its own throttled/unthrottled coverage in `tests/memory/test_chunk_buffer_pool.py`. A regression test asserts the availability probe reports a plausible fraction of total RAM.

Verified: forcing zero headroom reproduces the permanent second-acquire wait on the pre-fix tree and all 28 watcher tests pass under zero headroom post-fix; full real-GPU suite 3151 passed, full CUDASIM suite 3101 passed.

Performance gate (retry with `--pairs 8` after a DISTRUST row, per protocol):

```
A = origin/main (7bf97618)   B = fix/precompile-hang (working tree)   backends: numba-cuda, mlir   (8 block pairs x 15 solves/block/side)


[numba-cuda] compile metrics, A -> B
config         metric                         A           B  flags
fixed          regs                          39          39  
               spill_store_bytes              0           0  
               spill_load_bytes               0           0  
               shared                         0           0  
               dynshared                      4           4  
               const                          0           0  
               blocks_per_sm                 24          24  
               sms                           56          56  
               blocksize                     64          64  
               runs_per_block                64          64  
               runs                     4194304     4194304  
               chunks                         1           1  
adaptive       regs                          95          95  
               spill_store_bytes              0           0  
               spill_load_bytes               0           0  
               shared                         0           0  
               dynshared                      4           4  
               const                          0           0  
               blocks_per_sm                 10          10  
               sms                           56          56  
               blocksize                     64          64  
               runs_per_block                64          64  
               runs                     1048576     1048576  
               chunks                         1           1  
host_overhead  regs                          39          39  
               spill_store_bytes              0           0  
               spill_load_bytes               0           0  
               shared                         0           0  
               dynshared                      4           4  
               const                          0           0  
               blocks_per_sm                 24          24  
               sms                           56          56  
               blocksize                     64          64  
               runs_per_block                64          64  
               runs                           8           8  
               chunks                         1           1  
chunked        regs                          39          39  
               spill_store_bytes              0           0  
               spill_load_bytes               0           0  
               shared                         0           0  
               dynshared                      4           4  
               const                          0           0  
               blocks_per_sm                 24          24  
               sms                           56          56  
               blocksize                     64          64  
               runs_per_block                64          64  
               runs                     4194304     4194304  
               chunks                         3           3  
wave           regs                          39          39  
               spill_store_bytes              0           0  
               spill_load_bytes               0           0  
               shared                         0           0  
               dynshared                      4           4  
               const                          0           0  
               blocks_per_sm                 24          24  
               sms                           56          56  
               blocksize                     64          64  
               runs_per_block                64          64  
               runs                      172032      172032  
               chunks                         1           1  

numba-cuda fixed          kernel  A    62.242  B    62.231   -0.06%  ok
numba-cuda fixed          wall    A    77.237  B    73.225   -4.90%  ok
numba-cuda adaptive       kernel  A    17.986  B    17.899   -0.17%  ok
numba-cuda adaptive       wall    A    22.935  B    21.544   -5.23%  ok
numba-cuda host_overhead  wall    A     1.414  B     0.861   -0.606ms  improvement
numba-cuda chunked        kernel  A    62.693  B    62.741   +0.05%  ok
numba-cuda chunked        wall    A    79.565  B    79.209   -0.21%  ok
numba-cuda wave           kernel  A    25.716  B    25.735   +0.07%  ok
numba-cuda wave           wall    A    27.976  B    27.987   -0.05%  ok

[mlir] compile metrics, A -> B
config         metric                         A           B  flags
fixed          regs                          36          36  
               spill_store_bytes              0           0  
               spill_load_bytes               0           0  
               shared                         0           0  
               dynshared                      4           4  
               const                          0           0  
               blocks_per_sm                 24          24  
               sms                           56          56  
               blocksize                     64          64  
               runs_per_block                64          64  
               runs                     4194304     4194304  
               chunks                         1           1  
adaptive       regs                          96          96  
               spill_store_bytes              0           0  
               spill_load_bytes               0           0  
               shared                         0           0  
               dynshared                      4           4  
               const                          0           0  
               blocks_per_sm                 10          10  
               sms                           56          56  
               blocksize                     64          64  
               runs_per_block                64          64  
               runs                     1048576     1048576  
               chunks                         1           1  
host_overhead  regs                          36          36  
               spill_store_bytes              0           0  
               spill_load_bytes               0           0  
               shared                         0           0  
               dynshared                      4           4  
               const                          0           0  
               blocks_per_sm                 24          24  
               sms                           56          56  
               blocksize                     64          64  
               runs_per_block                64          64  
               runs                           8           8  
               chunks                         1           1  
chunked        regs                          36          36  
               spill_store_bytes              0           0  
               spill_load_bytes               0           0  
               shared                         0           0  
               dynshared                      4           4  
               const                          0           0  
               blocks_per_sm                 24          24  
               sms                           56          56  
               blocksize                     64          64  
               runs_per_block                64          64  
               runs                     4194304     4194304  
               chunks                         3           3  
wave           regs                          36          36  
               spill_store_bytes              0           0  
               spill_load_bytes               0           0  
               shared                         0           0  
               dynshared                      4           4  
               const                          0           0  
               blocks_per_sm                 24          24  
               sms                           56          56  
               blocksize                     64          64  
               runs_per_block                64          64  
               runs                      172032      172032  
               chunks                         1           1  

mlir       fixed          kernel  A    61.926  B    61.878   -0.00%  ok
mlir       fixed          wall    A    77.005  B    76.959   -0.27%  ok
mlir       adaptive       kernel  A    17.228  B    17.250   +0.11%  ok
mlir       adaptive       wall    A    21.933  B    22.122   +0.33%  ok
mlir       host_overhead  wall    A     1.273  B     1.479   +0.233ms  ok  DISTRUST
mlir       chunked        kernel  A    62.374  B    62.405   +0.03%  ok
mlir       chunked        wall    A    78.799  B    78.817   +0.53%  ok
mlir       wave           kernel  A    25.722  B    25.655   +0.05%  ok
mlir       wave           wall    A    28.724  B    28.662   +0.37%  ok

GATE: INCONCLUSIVE (kernel threshold 0.50%, wall threshold 10.00%, host-overhead threshold 0.25 ms)
DISTRUST = the pairs split on the regression call, so that verdict is unreliable; rerun, with more --pairs or a quieter GPU, before acting on it.
```
