### PR TITLE
test: central-spine parameter sets collapsed onto shared chains

### DIFF
--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1942,10 +1942,6 @@ LARGE_BACKWARDS_EULER_PC = {
     "algorithm": "backwards_euler_pc",
 }
 
-# FIRK is the one chain algorithm that consumes driver arrays inside
-# its stage solves, which the driver-array and hot-swap tests need.
-FIRK_ALGORITHM = {"algorithm": "firk"}
-
 # Unique sets: the final-save schedule is a function of exact
 # dt/save_every/duration ratios, so each case pins its own timing.
 # The base pins a fixed euler step with time-domain output only.
@@ -1984,7 +1980,11 @@ MOVABLE_LOCATION_KEYS = (
 
 # Driver-count and ordering checks need a system declaring two
 # named drivers; the default chain systems declare one.
-TWO_DRIVER_SYSTEM = {"system_type": "two_driver"}
+# Also carries the disabled singularity fix for the cellml test.
+TWO_DRIVER_SYSTEM = {
+    "system_type": "two_driver",
+    "fix_singularities": False,
+}
 
 # The three-state linear system has the constant Jacobian the
 # residual and helper-identity checks assume.
@@ -2242,11 +2242,10 @@ IMPOSSIBLE_TOLERANCE = {
     "output_types": ["state", "time"],
 }
 
-DT_CLAMP_LIMITS = {"dt": 0.15, "dt_min": 0.1, "dt_max": 0.2}
-
+# dt0 sits outside the chain-default [dt_min, dt_max] band.
 DT_CLAMP_CASES = {
-    "max_limit": {"dt0": 1.0, "error": np.asarray([1e-12, 1e-12, 1e-12])},
-    "min_limit": {"dt0": 0.001, "error": np.asarray([1e12, 1e12, 1e12])},
+    "max_limit": {"dt0": 2.0, "error": np.asarray([1e-12, 1e-12, 1e-12])},
+    "min_limit": {"dt0": 5e-8, "error": np.asarray([1e12, 1e12, 1e12])},
 }
 
 RESIDUAL_SETTINGS = {
@@ -2429,15 +2428,4 @@ DURATION_ONLY_MIXED_OUTPUTS = {
             "save_every": None,
             "summarise_every": None,
             "sample_summaries_every": None,
-        }
-
-TIMED_MIXED_OUTPUTS = {
-            "precision": np.float32,
-            "duration": 0.15,
-            "output_types": ["state", "time", "mean"],
-            "algorithm": "euler",
-            "dt": 0.01,
-            "save_every": 0.05,
-            "summarise_every": 0.05,
-            "sample_summaries_every": 0.05,
         }

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1957,8 +1957,7 @@ FIXED_EULER_TIMED_STATE = {
     "step_controller": "fixed",
 }
 
-# Device-path chain; also carries the manual memory proportion and
-# the iteration_counters output type for the tests that assert them.
+# Device-path chain, plus mem_proportion and iteration_counters.
 DEVICE_SOLVE_SETTINGS = {
     "duration": 0.05,
     "dt": 0.01,

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1937,11 +1937,6 @@ LARGE_BACKWARDS_EULER = {
     "algorithm": "backwards_euler",
 }
 
-LARGE_BACKWARDS_EULER_PC = {
-    **LARGE_STATE_ONLY,
-    "algorithm": "backwards_euler_pc",
-}
-
 # Unique sets: the final-save schedule is a function of exact
 # dt/save_every/duration ratios, so each case pins its own timing.
 # The base pins a fixed euler step with time-domain output only.
@@ -1953,14 +1948,15 @@ FIXED_EULER_TIMED_STATE = {
     "step_controller": "fixed",
 }
 
-# Device-path chain, plus mem_proportion and iteration_counters.
+# One chain for the device-path, spill, proportion and counter tests.
 DEVICE_SOLVE_SETTINGS = {
     "duration": 0.05,
     "dt": 0.01,
     "save_every": 0.01,
     "summarise_every": None,
-    "output_types": ["state", "iteration_counters"],
+    "output_types": ["state", "time", "iteration_counters"],
     "mem_proportion": 0.1,
+    "host_spill_threshold": 512,
 }
 
 MOVABLE_LOCATION_KEYS = (
@@ -2000,9 +1996,6 @@ COLLIDING_CONSTANTS_F64 = {
     "system_type": "colliding_constants", "precision": np.float64,
 }
 
-# The hostile-name coverage lives on this system alone: every
-# factory-scope symbol is shadowed by a same-named model constant.
-HOSTILE_NAMES_SYSTEM = {"system_type": "hostile_names"}
 
 DIAGONALLY_DOMINANT = {
     "system_type": "diagonally_dominant",
@@ -2296,70 +2289,27 @@ SINUSOID_DRIVER_SAMPLES = {
 }
 
 
-STEP_CASES_CONSTANT_DERIV = [
-    merge_param(
-        merge_dicts(MID_RUN_PARAMS, {"system_type": "constant_deriv"}),
-        case,
-    )
-    for case in ALGORITHM_PARAM_SETS
-]
-
-# BiCGSTAB and Jacobi-preconditioner cases run through the same
-# device-vs-CPU comparison as ALGORITHM_PARAM_SETS. Kept in a
-# separate parametrize group to isolate the bicgstab solver variant
-# from the default minimal-residual/steepest-descent cases.
+# Bicgstab + chained preconditioner on both implicit step families.
 BICGSTAB_STEP_CASES = [
     merge_param(MID_RUN_PARAMS, case)
     for case in [
         pytest.param(
             {
-                "algorithm": "backwards_euler",
-                "step_controller": "fixed",
-                "linear_correction_type": "bicgstab",
-            },
-            id="backwards_euler-bicgstab",
-        ),
-        pytest.param(
-            {
-                "algorithm": "backwards_euler",
-                "step_controller": "fixed",
-                "linear_correction_type": "bicgstab",
-                "preconditioner_type": "jacobi",
-            },
-            id="backwards_euler-bicgstab-jacobi",
-        ),
-        pytest.param(
-            {
-                "algorithm": "rosenbrock",
-                "step_controller": "i",
-                "linear_correction_type": "bicgstab",
-            },
-            id="rosenbrock-bicgstab",
-        ),
-        pytest.param(
-            {
                 "algorithm": "dirk",
                 "step_controller": "fixed",
-                "preconditioner_type": "jacobi",
-            },
-            id="dirk-jacobi",
-        ),
-        pytest.param(
-            {
-                "algorithm": "backwards_euler",
-                "step_controller": "fixed",
                 "linear_correction_type": "bicgstab",
                 "preconditioner_type": ["neumann", "jacobi"],
             },
-            id="backwards_euler-bicgstab-chained",
+            id="dirk-bicgstab-chained",
         ),
         pytest.param(
             {
                 "algorithm": "rosenbrock",
                 "step_controller": "i",
+                "linear_correction_type": "bicgstab",
                 "preconditioner_type": ["neumann", "jacobi"],
             },
-            id="rosenbrock-chained",
+            id="rosenbrock-bicgstab-chained",
         ),
     ]
 ]

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -87,17 +87,12 @@ ALGORITHM_CONTROLLER_COMBOS = {
 # Precision flip; the float32 case is the unparametrised default.
 FLOAT64_PRECISION = {"precision": np.float64}
 
-# Time-domain outputs with every timing key cleared (save_last path).
+# Time-domain outputs with every timing key cleared. One chain covers
+# both the save_last path (no save_every) and the no-summaries path
+# (no summary types requested, so summary timing is forced None).
 STATE_OBS_NO_TIMING = {
     "output_types": ["state", "observables"],
     "save_every": None,
-    "summarise_every": None,
-    "sample_summaries_every": None,
-}
-
-# State output only, no summary timing (no-summaries path).
-STATE_ONLY_NO_SUMMARIES = {
-    "output_types": ["state"],
     "summarise_every": None,
     "sample_summaries_every": None,
 }
@@ -116,11 +111,6 @@ SUMMARY_ONLY_TIMED = {
     "save_every": None,
     "summarise_every": 0.1,
     "sample_summaries_every": 0.05,
-}
-
-# Per-run iteration counters alongside states.
-STATE_AND_ITERATION_COUNTERS = {
-    "output_types": ["state", "iteration_counters"],
 }
 
 # One set per adaptive controller kind. rtol is pinned to zero so
@@ -1971,12 +1961,19 @@ FIXED_EULER_TIMED_STATE = {
 
 # Shared override for the device-path tests below: the solvers are
 # built with these settings so no solve call updates compile settings,
-# and every test reuses the same compiled kernel configuration.
+# and every test reuses the same compiled kernel configuration. Two
+# orthogonal keys ride along instead of keying their own chains: the
+# manual memory proportion (read back by the proportion-forwarding
+# test) and the iteration_counters output type (asserted full-size
+# and four-wide by the counters tests); neither changes any device
+# path assertion, which compare state and status arrays only.
 DEVICE_SOLVE_SETTINGS = {
     "duration": 0.05,
     "dt": 0.01,
     "save_every": 0.01,
     "summarise_every": None,
+    "output_types": ["state", "iteration_counters"],
+    "mem_proportion": 0.1,
 }
 
 MOVABLE_LOCATION_KEYS = (
@@ -2453,5 +2450,3 @@ TIMED_MIXED_OUTPUTS = {
             "summarise_every": 0.05,
             "sample_summaries_every": 0.05,
         }
-
-MANUAL_MEMORY_PROPORTION = {"mem_proportion": 0.1}

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -87,9 +87,7 @@ ALGORITHM_CONTROLLER_COMBOS = {
 # Precision flip; the float32 case is the unparametrised default.
 FLOAT64_PRECISION = {"precision": np.float64}
 
-# Time-domain outputs with every timing key cleared. One chain covers
-# both the save_last path (no save_every) and the no-summaries path
-# (no summary types requested, so summary timing is forced None).
+# Timing keys all cleared: save_last path and no-summaries path.
 STATE_OBS_NO_TIMING = {
     "output_types": ["state", "observables"],
     "save_every": None,
@@ -1959,14 +1957,8 @@ FIXED_EULER_TIMED_STATE = {
     "step_controller": "fixed",
 }
 
-# Shared override for the device-path tests below: the solvers are
-# built with these settings so no solve call updates compile settings,
-# and every test reuses the same compiled kernel configuration. Two
-# orthogonal keys ride along instead of keying their own chains: the
-# manual memory proportion (read back by the proportion-forwarding
-# test) and the iteration_counters output type (asserted full-size
-# and four-wide by the counters tests); neither changes any device
-# path assertion, which compare state and status arrays only.
+# Device-path chain; also carries the manual memory proportion and
+# the iteration_counters output type for the tests that assert them.
 DEVICE_SOLVE_SETTINGS = {
     "duration": 0.05,
     "dt": 0.01,

--- a/tests/batchsolving/arrays/test_batchoutputarrays.py
+++ b/tests/batchsolving/arrays/test_batchoutputarrays.py
@@ -430,11 +430,17 @@ def test_dtype_float64(
 
 
 @pytest.mark.parametrize(
+    # The stream-group and memory-proportion keys only feed the
+    # OutputArrays constructor, so they ride the num_runs=8 case
+    # rather than keying their own fixture set.
     "output_test_overrides",
     [
-        {"num_runs": 8},
+        {
+            "num_runs": 8,
+            "stream_group": "test_group",
+            "memory_proportion": 0.5,
+        },
         {"num_runs": 3},
-        {"stream_group": "test_group", "memory_proportion": 0.5},
     ],
     indirect=True,
 )
@@ -469,12 +475,9 @@ def test_output_arrays_with_different_configs(
 
 @pytest.mark.parametrize(
     "solver_settings_override",
-    # Unique sets: output-array shapes must track systems whose
+    # Unique set: output-array shapes must track a system whose
     # state/observable counts differ from the default chain system.
-    [
-        {"system_type": "three_chamber"},
-        {"system_type": "stiff"},
-    ],
+    [{"system_type": "three_chamber"}],
     indirect=True,
 )
 def test_output_arrays_with_different_systems(

--- a/tests/batchsolving/arrays/test_batchoutputarrays.py
+++ b/tests/batchsolving/arrays/test_batchoutputarrays.py
@@ -430,9 +430,7 @@ def test_dtype_float64(
 
 
 @pytest.mark.parametrize(
-    # The stream-group and memory-proportion keys only feed the
-    # OutputArrays constructor, so they ride the num_runs=8 case
-    # rather than keying their own fixture set.
+    # Constructor-only keys ride the num_runs=8 case.
     "output_test_overrides",
     [
         {

--- a/tests/batchsolving/arrays/test_batchoutputarrays.py
+++ b/tests/batchsolving/arrays/test_batchoutputarrays.py
@@ -430,7 +430,7 @@ def test_dtype_float64(
 
 
 @pytest.mark.parametrize(
-    # Constructor-only keys ride the num_runs=8 case.
+    # Constructor-only keys ride the one non-default num_runs case.
     "output_test_overrides",
     [
         {
@@ -438,7 +438,6 @@ def test_dtype_float64(
             "stream_group": "test_group",
             "memory_proportion": 0.5,
         },
-        {"num_runs": 3},
     ],
     indirect=True,
 )

--- a/tests/batchsolving/test_memory_pressure.py
+++ b/tests/batchsolving/test_memory_pressure.py
@@ -21,11 +21,8 @@ from tests._utils import (
 )
 
 
-# Shared spill threshold: the default 9-run batch's time-domain output
-# exceeds it, so every spill test below rides the same session
-# signature. States as the only time-domain output makes the combined
-# array a view of the state buffer, which the zero-copy test asserts;
-# the other spill tests are indifferent to the output types.
+# One chain for every spill test; states-only time-domain output
+# makes the combined array a state-buffer view (zero-copy test).
 _SPILL_THRESHOLD = {
     "host_spill_threshold": 512,
     "output_types": ["state", "time"],
@@ -382,8 +379,7 @@ def test_iteration_counters_collapse_when_inactive(
 
 
 @pytest.mark.parametrize(
-    # Rides the device-path chain, which requests iteration_counters;
-    # any set with that output type serves this test.
+    # Any chain that requests iteration_counters serves this test.
     "solver_settings_override",
     [DEVICE_SOLVE_SETTINGS],
     indirect=True,

--- a/tests/batchsolving/test_memory_pressure.py
+++ b/tests/batchsolving/test_memory_pressure.py
@@ -20,13 +20,6 @@ from tests._utils import (
     _build_solver_instance,
 )
 
-
-# One chain for every spill test, states-only for the zero-copy view.
-_SPILL_THRESHOLD = {
-    "host_spill_threshold": 512,
-    "output_types": ["state", "time"],
-}
-
 # Reported free bytes that chunk the default 9-run batch. Eviction
 # and a collapsed budget rewrite a solver's run partition for good,
 # so the tests that provoke them own a private manager at this limit
@@ -84,7 +77,7 @@ def test_idle_solver_evicted_under_pressure_and_self_heals(
 
 
 @pytest.mark.parametrize(
-    "solver_settings_override", [_SPILL_THRESHOLD], indirect=True
+    "solver_settings_override", [DEVICE_SOLVE_SETTINGS], indirect=True
 )
 def test_host_arrays_spill_to_disk_and_results_match(
     solver_mutable,
@@ -195,7 +188,7 @@ def test_empty_peer_response_changes_nothing(solver_mutable):
 
 
 @pytest.mark.parametrize(
-    "solver_settings_override", [_SPILL_THRESHOLD], indirect=True
+    "solver_settings_override", [DEVICE_SOLVE_SETTINGS], indirect=True
 )
 @pytest.mark.parametrize(
     "batch_settings_override",
@@ -224,7 +217,7 @@ def test_shape_change_updates_memmap_metadata(
 
 @pytest.mark.nocudasim
 @pytest.mark.parametrize(
-    "solver_settings_override", [_SPILL_THRESHOLD], indirect=True
+    "solver_settings_override", [DEVICE_SOLVE_SETTINGS], indirect=True
 )
 def test_spill_solve_is_async(
     solver_mutable,
@@ -266,7 +259,7 @@ def test_spill_solve_is_async(
 
 
 @pytest.mark.parametrize(
-    "solver_settings_override", [_SPILL_THRESHOLD], indirect=True
+    "solver_settings_override", [DEVICE_SOLVE_SETTINGS], indirect=True
 )
 def test_spilled_result_assembly_is_zero_copy(
     solver_mutable, batch_input_arrays, driver_settings

--- a/tests/batchsolving/test_memory_pressure.py
+++ b/tests/batchsolving/test_memory_pressure.py
@@ -15,16 +15,21 @@ from cubie.memory import MemoryManager
 from cubie.memory.array_requests import ArrayResponse
 from cubie.memory.mem_manager import HOST_STAGING_BYTES
 from tests._utils import (
+    DEVICE_SOLVE_SETTINGS,
     MockMemoryManager,
-    STATE_AND_ITERATION_COUNTERS,
     _build_solver_instance,
 )
 
 
 # Shared spill threshold: the default 9-run batch's time-domain output
 # exceeds it, so every spill test below rides the same session
-# signature.
-_SPILL_THRESHOLD = {"host_spill_threshold": 512}
+# signature. States as the only time-domain output makes the combined
+# array a view of the state buffer, which the zero-copy test asserts;
+# the other spill tests are indifferent to the output types.
+_SPILL_THRESHOLD = {
+    "host_spill_threshold": 512,
+    "output_types": ["state", "time"],
+}
 
 # Reported free bytes that chunk the default 9-run batch. Eviction
 # and a collapsed budget rewrite a solver's run partition for good,
@@ -265,9 +270,7 @@ def test_spill_solve_is_async(
 
 
 @pytest.mark.parametrize(
-    "solver_settings_override",
-    [{**_SPILL_THRESHOLD, "output_types": ["state", "time"]}],
-    indirect=True,
+    "solver_settings_override", [_SPILL_THRESHOLD], indirect=True
 )
 def test_spilled_result_assembly_is_zero_copy(
     solver_mutable, batch_input_arrays, driver_settings
@@ -379,8 +382,10 @@ def test_iteration_counters_collapse_when_inactive(
 
 
 @pytest.mark.parametrize(
+    # Rides the device-path chain, which requests iteration_counters;
+    # any set with that output type serves this test.
     "solver_settings_override",
-    [STATE_AND_ITERATION_COUNTERS],
+    [DEVICE_SOLVE_SETTINGS],
     indirect=True,
 )
 def test_iteration_counters_full_size_when_requested(

--- a/tests/batchsolving/test_memory_pressure.py
+++ b/tests/batchsolving/test_memory_pressure.py
@@ -21,8 +21,7 @@ from tests._utils import (
 )
 
 
-# One chain for every spill test; states-only time-domain output
-# makes the combined array a state-buffer view (zero-copy test).
+# One chain for every spill test, states-only for the zero-copy view.
 _SPILL_THRESHOLD = {
     "host_spill_threshold": 512,
     "output_types": ["state", "time"],

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -25,7 +25,6 @@ from cubie.integrators.matrix_free_solvers.bicgstab_solver import (
 )
 from tests._utils import (
     DEVICE_SOLVE_SETTINGS,
-    FIRK_ALGORITHM,
     FIXED_EULER_TIMED_STATE,
     MOVABLE_LOCATION_KEYS,
 )
@@ -273,7 +272,9 @@ def test_solve_basic(
 
 
 @pytest.mark.parametrize(
-    "solver_settings_override", [FIRK_ALGORITHM], indirect=True
+    "solver_settings_override",
+    [ALGORITHM_CHAIN_SETS["firk"]],
+    indirect=True,
 )
 def test_solve_firk_with_driver_arrays(
     solver_mutable,
@@ -291,10 +292,10 @@ def test_solve_firk_with_driver_arrays(
         initial_values=simple_initial_values,
         parameters=simple_parameters,
         drivers=driver_settings,
-        duration=0.05,
+        duration=0.1,
         settling_time=0.0,
         blocksize=32,
-        grid_type="combinatorial",
+        grid_type="verbatim",
     )
     assert not np.any(result.status_codes)
     assert np.all(np.isfinite(result.time_domain_array))
@@ -332,7 +333,9 @@ def test_algorithm_hot_swap_after_solve(
 
 
 @pytest.mark.parametrize(
-    "solver_settings_override", [FIRK_ALGORITHM], indirect=True
+    "solver_settings_override",
+    [ALGORITHM_CHAIN_SETS["firk"]],
+    indirect=True,
 )
 def test_linear_solver_hot_swap_after_solve(
     solver_mutable,
@@ -346,11 +349,11 @@ def test_linear_solver_hot_swap_after_solve(
         initial_values=simple_initial_values,
         parameters=simple_parameters,
         drivers=driver_settings,
-        duration=0.05,
+        duration=0.1,
         save_every=0.02,
         settling_time=0.0,
         blocksize=32,
-        grid_type="combinatorial",
+        grid_type="verbatim",
     )
     first = solver_mutable.solve(**solve_kwargs)
     assert not np.any(first.status_codes)

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -282,12 +282,7 @@ def test_solve_firk_with_driver_arrays(
     simple_parameters,
     driver_settings,
 ):
-    """A FIRK solve with driver arrays completes successfully.
-
-    The FIRK step evaluates drivers at the stage times through its own
-    stage driver stack, which is sized from the algorithm step's driver
-    count; a driven solve exercises that path end to end.
-    """
+    """A driven FIRK solve exercises the stage driver stack."""
     result = solver_mutable.solve(
         initial_values=simple_initial_values,
         parameters=simple_parameters,

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from tests._utils import (
     ALGORITHM_CHAIN_SETS,
-    MANUAL_MEMORY_PROPORTION,
     FLOAT64_PRECISION,
     _build_solver_instance,
 )
@@ -90,9 +89,7 @@ def test_solver_properties(solver, solver_settings):
 
 
 @pytest.mark.parametrize(
-    # Unique set: a manual memory proportion is the value under test
-    # and is meaningless to any other configuration.
-    "solver_settings_override", [MANUAL_MEMORY_PROPORTION], indirect=True
+    "solver_settings_override", [DEVICE_SOLVE_SETTINGS], indirect=True
 )
 def test_manual_proportion(solver):
     """A manual memory proportion reaches the built solver."""

--- a/tests/batchsolving/test_solveresult.py
+++ b/tests/batchsolving/test_solveresult.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from tests._utils import STATE_ONLY_NO_SUMMARIES
+from tests._utils import STATE_OBS_NO_TIMING
 
 from cubie.batchsolving.solver import Solver
 from cubie.batchsolving.BatchSolverConfig import ActiveOutputs
@@ -777,7 +777,7 @@ def test_device_result_handles_match_host_buffers(solver_with_arrays):
 
 @pytest.mark.parametrize(
     "solver_settings_override",
-    [STATE_ONLY_NO_SUMMARIES],
+    [STATE_OBS_NO_TIMING],
     indirect=True,
 )
 def test_as_pandas_without_summaries_returns_a_dataframe(

--- a/tests/batchsolving/test_system_interface.py
+++ b/tests/batchsolving/test_system_interface.py
@@ -42,8 +42,11 @@ def test_update_returns_none_when_empty(system_interface):
 def test_update_merges_kwargs(system_interface_mutable, system):
     """Merges kwargs into updates dict and applies them."""
     name = system.initial_values.names[0]
+    original = system.initial_values.values_dict[name]
     recognized = system_interface_mutable.update(None, **{name: 99.0})
     assert name in recognized
+    assert system_interface_mutable.states.values_dict[name] == 99.0
+    assert system.initial_values.values_dict[name] == original
 
 
 def test_update_merges_kwargs_into_updates_dict(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1369,7 +1369,11 @@ def system_interface(system) -> SystemInterface:
 @pytest.fixture(scope="function")
 def system_interface_mutable(system) -> SystemInterface:
     """Return a fresh SystemInterface for mutation tests."""
-    return SystemInterface.from_system(system)
+    return SystemInterface(
+        system.parameters.copy(),
+        system.initial_values.copy(),
+        system.observables.copy(),
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -363,6 +363,12 @@ def time_function_driver_system(precision):
 
 
 @pytest.fixture(scope="session")
+def hostile_names_system(precision):
+    """Return the hostile-named system without a solver chain."""
+    return build_hostile_names_system(precision)
+
+
+@pytest.fixture(scope="session")
 def safe_names_system(precision):
     """Return the safe-named twin of the ``hostile_names`` system.
 

--- a/tests/integrated_numerical_tests/test_ode_loop.py
+++ b/tests/integrated_numerical_tests/test_ode_loop.py
@@ -20,7 +20,6 @@ from tests._utils import (
     DURATION_ONLY_MIXED_OUTPUTS,
     LARGE_T0_SMALL_STEPS_F32,
     LARGE_T0_SMALL_STEPS_F64,
-    TIMED_MIXED_OUTPUTS,
     TINY_DT_ADAPTIVE_CN,
     WARMUP_SAVE_BOUNDARY,
     assert_integration_outputs,
@@ -376,13 +375,6 @@ def test_final_summary(
     )
 
 
-@pytest.mark.parametrize(
-    "solver_settings_override",
-    [
-        TIMED_MIXED_OUTPUTS
-    ],
-    indirect=True,
-)
 def test_summarise_every(
     device_loop_outputs,
     precision,

--- a/tests/integrated_numerical_tests/test_output_functions.py
+++ b/tests/integrated_numerical_tests/test_output_functions.py
@@ -637,15 +637,15 @@ def test_input_value_ranges(compare_input_output):
 
 @pytest.mark.parametrize(
     "output_test_settings_overrides",
+    # state-with-observables saving is covered by the all-on case, so
+    # the remaining cases each toggle one save flag off.
     [
-        {"output_types": ["state", "observables"]},
         {"output_types": ["observables"]},
         {"output_types": ["observables", "time"]},
         {"output_types": ["time"]},
         {"output_types": ["state", "observables", "time"]},
     ],
     ids=[
-        "state_obs",
         "obs_only",
         "obs_time",
         "time_only",
@@ -678,15 +678,15 @@ def test_no_summarys(compare_input_output):
                 "peaks[1]",
             ]
         },
+        # A single metric beside a single save type; the observable
+        # twin of this case is covered by the all-on case above.
         {"output_types": ["state", "mean"]},
-        {"output_types": ["observables", "mean"]},
     ],
     ids=[
         "basic_summaries",
         "peaks_only",
         "all",
         "state_and_mean",
-        "obs_and_mean",
     ],
     indirect=True,
 )
@@ -709,19 +709,13 @@ def test_various_summaries(compare_input_output):
             "saved_observable_indices": list(range(5)),
         },
         {
-            "num_states": 51,
-            "num_observables": 21,
-            "saved_state_indices": list(range(50)),
-            "saved_observable_indices": list(range(20)),
-        },
-        {
             "num_states": 101,
             "num_observables": 100,
             "saved_state_indices": list(range(100)),
             "saved_observable_indices": list(range(100)),
         },
     ],
-    ids=["1_1", "10_5", "50_20", "100_100"],
+    ids=["1_1", "10_5", "100_100"],
     indirect=True,
 )
 def test_big_and_small_systems(compare_input_output):

--- a/tests/integrated_numerical_tests/test_output_functions.py
+++ b/tests/integrated_numerical_tests/test_output_functions.py
@@ -637,8 +637,7 @@ def test_input_value_ranges(compare_input_output):
 
 @pytest.mark.parametrize(
     "output_test_settings_overrides",
-    # state-with-observables saving is covered by the all-on case, so
-    # the remaining cases each toggle one save flag off.
+    # Each case toggles one save flag off the all-on case.
     [
         {"output_types": ["observables"]},
         {"output_types": ["observables", "time"]},
@@ -678,8 +677,7 @@ def test_no_summarys(compare_input_output):
                 "peaks[1]",
             ]
         },
-        # A single metric beside a single save type; the observable
-        # twin of this case is covered by the all-on case above.
+        # A single metric beside a single save type.
         {"output_types": ["state", "mean"]},
     ],
     ids=[

--- a/tests/integrated_numerical_tests/test_step_algorithms.py
+++ b/tests/integrated_numerical_tests/test_step_algorithms.py
@@ -19,7 +19,6 @@ from tests.integrators.cpu_reference import (
 from tests._utils import (
     BICGSTAB_STEP_CASES,
     ALGORITHM_PARAM_SETS,
-    _get_algorithm_tableau,
 )
 
 Array = np.ndarray
@@ -403,7 +402,7 @@ def _run_two_step_comparison(
     assert all(status == 0 for status in cpu_result.statuses)
     assert gpu_result.statuses == cpu_result.statuses
 
-    tol = {"rtol": 5e-7, "atol": 1e-7}
+    tol = {"rtol": 1e-7, "atol": 1e-7}
 
     assert_allclose(
         gpu_result.first_state,
@@ -440,26 +439,6 @@ def _run_two_step_comparison(
         gpu_result.second_state - gpu_result.first_state
     )
     assert np.any(delta > precision(1e-10))
-
-    # Coarse check against the independent euler reference.
-    euler_result = _execute_cpu_step_twice(
-        solver_settings=dict(solver_settings, algorithm="euler"),
-        step_inputs=step_inputs,
-        cpu_system=cpu_system,
-        cpu_driver_evaluator=cpu_driver_evaluator,
-        tableau=_get_algorithm_tableau("euler"),
-    )
-    euler_tol = {"rtol": 1e-3, "atol": 1e-3}
-    assert_allclose(
-        gpu_result.first_state,
-        euler_result.first_state,
-        **euler_tol,
-    )
-    assert_allclose(
-        gpu_result.second_state,
-        euler_result.second_state,
-        **euler_tol,
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/integrated_numerical_tests/test_step_algorithms.py
+++ b/tests/integrated_numerical_tests/test_step_algorithms.py
@@ -18,7 +18,6 @@ from tests.integrators.cpu_reference import (
 )
 from tests._utils import (
     BICGSTAB_STEP_CASES,
-    STEP_CASES_CONSTANT_DERIV,
     ALGORITHM_PARAM_SETS,
     _get_algorithm_tableau,
 )
@@ -38,9 +37,6 @@ class DualStepResult:
     first_error: Array
     second_error: Array
     statuses: tuple[int, int]
-
-
-# Merged cases for constant_deriv system tests
 
 
 @pytest.fixture(scope="session")
@@ -445,6 +441,26 @@ def _run_two_step_comparison(
     )
     assert np.any(delta > precision(1e-10))
 
+    # Coarse check against the independent euler reference.
+    euler_result = _execute_cpu_step_twice(
+        solver_settings=dict(solver_settings, algorithm="euler"),
+        step_inputs=step_inputs,
+        cpu_system=cpu_system,
+        cpu_driver_evaluator=cpu_driver_evaluator,
+        tableau=_get_algorithm_tableau("euler"),
+    )
+    euler_tol = {"rtol": 1e-3, "atol": 1e-3}
+    assert_allclose(
+        gpu_result.first_state,
+        euler_result.first_state,
+        **euler_tol,
+    )
+    assert_allclose(
+        gpu_result.second_state,
+        euler_result.second_state,
+        **euler_tol,
+    )
+
 
 @pytest.mark.parametrize(
     "solver_settings_override",
@@ -506,76 +522,3 @@ def test_two_steps_bicgstab_jacobi(
     )
 
 
-# ── All algorithms match Euler for constant-derivative system ─ #
-
-@pytest.mark.parametrize(
-    "solver_settings_override",
-    STEP_CASES_CONSTANT_DERIV,
-    indirect=True,
-)
-def test_against_euler(
-    solver_settings,
-    step_object,
-    precision,
-    step_inputs,
-    system,
-    driver_array,
-    cpu_system,
-    cpu_driver_evaluator,
-    tolerance,
-):
-    """All algorithms match Euler for constant-derivative system.
-
-    For a system with constant derivatives (dx/dt = constant), all
-    numerical integration algorithms should produce identical results
-    to the Euler method, since higher-order Taylor terms vanish.
-    """
-
-    device_result = _execute_step_twice(
-        step_object=step_object,
-        solver_settings=solver_settings,
-        precision=precision,
-        step_inputs=step_inputs,
-        system=system,
-        driver_array=driver_array,
-    )
-
-    euler_settings = solver_settings.copy()
-    euler_settings["algorithm"] = "euler"
-
-    euler_result = _execute_cpu_step_twice(
-        solver_settings=euler_settings,
-        step_inputs=step_inputs,
-        cpu_system=cpu_system,
-        cpu_driver_evaluator=cpu_driver_evaluator,
-        tableau=_get_algorithm_tableau("euler"),
-    )
-
-    assert all(status == 0 for status in device_result.statuses)
-    assert all(status == 0 for status in euler_result.statuses)
-
-    tol = {
-        "rtol": tolerance.rel_tight * 3,
-        "atol": tolerance.abs_tight * 3,
-    }
-
-    assert_allclose(
-        device_result.first_state,
-        euler_result.first_state,
-        **tol,
-    )
-    assert_allclose(
-        device_result.second_state,
-        euler_result.second_state,
-        **tol,
-    )
-    assert_allclose(
-        device_result.first_observables,
-        euler_result.first_observables,
-        **tol,
-    )
-    assert_allclose(
-        device_result.second_observables,
-        euler_result.second_observables,
-        **tol,
-    )

--- a/tests/integrated_numerical_tests/test_step_controllers.py
+++ b/tests/integrated_numerical_tests/test_step_controllers.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from tests._utils import (
+    ALGORITHM_CHAIN_SETS,
     CONTROLLER_TOLERANCE_SETS,
     StepResult,
     run_controller_device_step,
@@ -273,13 +274,12 @@ class TestControllerNumerical:
 
 
 @pytest.mark.parametrize(
+    # Any chain with an order>1 algorithm and adaptive controller.
     "solver_settings_override",
-    # Unique set: the order-wiring assertion needs an algorithm whose
-    # order exceeds the default euler's 1 on the shared pi tolerances.
-    [{**CONTROLLER_TOLERANCE_SETS["pi"], "algorithm": "crank_nicolson"}],
+    [ALGORITHM_CHAIN_SETS["crank_nicolson"]],
     indirect=True,
 )
-def test_pi_controller_uses_tableau_order(
+def test_adaptive_controller_uses_tableau_order(
     step_controller,
     cpu_step_controller,
     step_controller_settings,

--- a/tests/integrators/algorithms/test_rosenbrock_tableaus.py
+++ b/tests/integrators/algorithms/test_rosenbrock_tableaus.py
@@ -8,6 +8,7 @@ from cubie.integrators.algorithms.generic_rosenbrockw_tableaus import (
     ROS3P_TABLEAU,
     ROSENBROCK_TABLEAUS,
 )
+from tests._utils import RESIDUAL_ARRANGEMENTS
 from tests.integrators.cpu_reference import CPUODESystem, get_ref_stepper
 
 
@@ -43,9 +44,10 @@ def test_rosenbrock_step_function_accepts_registry_key(
 
 @pytest.mark.parametrize(
     "solver_settings_override",
-    # Unique set: the assertion is that this exact registry key
-    # resolves to its tableau through the chain.
-    [{"algorithm": "ros3p", "step_controller": "pid"}],
+    # Rides the ros3p residual-routing chain: any set that names the
+    # ros3p registry key resolves it through the chain, so this test
+    # shares the arrangement test_ode_implicitstep already builds.
+    [RESIDUAL_ARRANGEMENTS[2]],
     indirect=True,
 )
 def test_rosenbrock_step_accepts_registry_tableau(step_object):

--- a/tests/integrators/algorithms/test_rosenbrock_tableaus.py
+++ b/tests/integrators/algorithms/test_rosenbrock_tableaus.py
@@ -44,9 +44,7 @@ def test_rosenbrock_step_function_accepts_registry_key(
 
 @pytest.mark.parametrize(
     "solver_settings_override",
-    # Rides the ros3p residual-routing chain: any set that names the
-    # ros3p registry key resolves it through the chain, so this test
-    # shares the arrangement test_ode_implicitstep already builds.
+    # Any chain that names the ros3p registry key serves this test.
     [RESIDUAL_ARRANGEMENTS[2]],
     indirect=True,
 )

--- a/tests/integrators/step_control/test_controllers.py
+++ b/tests/integrators/step_control/test_controllers.py
@@ -8,18 +8,15 @@ from tests._utils import run_controller_device_step
 from tests._utils import (
     DT_CLAMP_CASES,
     CONTROLLER_TOLERANCE_SETS,
-    DT_CLAMP_LIMITS,
     HISTORY_CONTROLLER_TOLERANCE_SETS,
 )
-
-
 
 
 
 @pytest.mark.parametrize(
     "solver_settings_override, step_setup",
     [
-        (dict(settings, **DT_CLAMP_LIMITS), case)
+        (settings, case)
         for settings in CONTROLLER_TOLERANCE_SETS.values()
         for case in DT_CLAMP_CASES.values()
     ],

--- a/tests/integrators/test_SingleIntegratorRun.py
+++ b/tests/integrators/test_SingleIntegratorRun.py
@@ -7,7 +7,6 @@ import pytest
 from tests._utils import (
     FLOAT64_PRECISION,
     STATE_OBS_NO_TIMING,
-    STATE_ONLY_NO_SUMMARIES,
     SUMMARY_ONLY_TIMED,
 )
 
@@ -213,7 +212,7 @@ def test_summaries_length_periodic(single_integrator_run, solver_settings):
 
 @pytest.mark.parametrize(
     "solver_settings_override",
-    [STATE_ONLY_NO_SUMMARIES],
+    [STATE_OBS_NO_TIMING],
     indirect=True,
 )
 def test_summaries_length_none(single_integrator_run):

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -15,9 +15,8 @@ from cubie.integrators.SingleIntegratorRunCore import SingleIntegratorRunCore
 from cubie.integrators.SingleIntegratorRun import SingleIntegratorRun
 from tests._utils import (
     ALGORITHM_CHAIN_SETS,
-    STATE_AND_ITERATION_COUNTERS,
+    DEVICE_SOLVE_SETTINGS,
     STATE_OBS_NO_TIMING,
-    STATE_ONLY_NO_SUMMARIES,
     SUMMARY_ONLY_NO_TIMING,
     SUMMARY_ONLY_TIMED,
     _get_evaluate_driver_at_t,
@@ -269,7 +268,7 @@ def test_sample_summaries_auto_derived(single_integrator_run):
 
 @pytest.mark.parametrize(
     "solver_settings_override",
-    [STATE_ONLY_NO_SUMMARIES],
+    [STATE_OBS_NO_TIMING],
     indirect=True,
 )
 def test_save_regularly_and_summarise_regularly(single_integrator_run):
@@ -288,7 +287,7 @@ def test_save_regularly_and_summarise_regularly(single_integrator_run):
 
 @pytest.mark.parametrize(
     "solver_settings_override",
-    [STATE_ONLY_NO_SUMMARIES],
+    [STATE_OBS_NO_TIMING],
     indirect=True,
 )
 def test_no_summary_timing_when_no_summary_outputs(single_integrator_run):
@@ -786,7 +785,7 @@ def test_has_summary_outputs_false_no_timing(single_integrator_run):
 
 @pytest.mark.parametrize(
     "solver_settings_override",
-    [STATE_ONLY_NO_SUMMARIES],
+    [STATE_OBS_NO_TIMING],
     indirect=True,
 )
 def test_has_summary_outputs_false_no_types(single_integrator_run):
@@ -828,8 +827,10 @@ def test_loop_n_counters_zero_without_counters(single_integrator_run):
 
 
 @pytest.mark.parametrize(
+    # Rides the device-path chain, which requests iteration_counters;
+    # any set with that output type serves this test.
     "solver_settings_override",
-    [STATE_AND_ITERATION_COUNTERS],
+    [DEVICE_SOLVE_SETTINGS],
     indirect=True,
 )
 def test_loop_n_counters_four_with_counters(single_integrator_run):

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -827,8 +827,7 @@ def test_loop_n_counters_zero_without_counters(single_integrator_run):
 
 
 @pytest.mark.parametrize(
-    # Rides the device-path chain, which requests iteration_counters;
-    # any set with that output type serves this test.
+    # Any chain that requests iteration_counters serves this test.
     "solver_settings_override",
     [DEVICE_SOLVE_SETTINGS],
     indirect=True,

--- a/tests/integrators/test_memory_heuristics.py
+++ b/tests/integrators/test_memory_heuristics.py
@@ -56,6 +56,7 @@ def test_small_system_keeps_all_buffers_local(solver):
     [
         LARGE_TSIT5,
         LARGE_DIRK,
+        LARGE_BACKWARDS_EULER,
     ],
     indirect=True,
 )

--- a/tests/integrators/test_memory_heuristics.py
+++ b/tests/integrators/test_memory_heuristics.py
@@ -12,7 +12,6 @@ from cubie.integrators.memory_heuristics import (
 from tests._utils import ALGORITHM_CHAIN_SETS
 from tests._utils import (
     LARGE_BACKWARDS_EULER,
-    LARGE_BACKWARDS_EULER_PC,
     LARGE_DIRK,
     LARGE_TSIT5,
 )
@@ -57,8 +56,6 @@ def test_small_system_keeps_all_buffers_local(solver):
     [
         LARGE_TSIT5,
         LARGE_DIRK,
-        LARGE_BACKWARDS_EULER,
-        LARGE_BACKWARDS_EULER_PC,
     ],
     indirect=True,
 )

--- a/tests/odesystems/symbolic/codegen/test_constant_name_collisions.py
+++ b/tests/odesystems/symbolic/codegen/test_constant_name_collisions.py
@@ -5,9 +5,9 @@ single prefixed local (``CONSTANT_ALIAS_PREFIX``), so a model constant
 named after any factory-scope binding (solver scalings, loop bounds,
 tableau metadata, generated body locals, even ``precision`` itself)
 can neither replace that binding nor be replaced by it. These tests
-solve the session ``hostile_names`` system, whose constants are named
-after each class of internal binding, and compare against the
-identically parameterised ``safe_names_system``.
+solve the ``hostile_names`` system, whose constants are named after
+each class of internal binding, and compare against the identically
+parameterised ``safe_names_system``.
 """
 
 import numpy as np
@@ -23,10 +23,6 @@ from cubie.odesystems.symbolic.sym_utils import (
     RESERVED_CODEGEN_PREFIX,
 )
 from tests.system_fixtures import HOSTILE_NAME_CONSTANTS
-from tests._utils import (
-    HOSTILE_NAMES_SYSTEM,
-)
-
 
 
 def _solve(system, method):
@@ -50,32 +46,26 @@ def _solve(system, method):
 # metadata symbols c_0/a_0_0 — every one shadowed by a same-named
 # model constant.
 @pytest.mark.parametrize(
-    "solver_settings_override",
-    [HOSTILE_NAMES_SYSTEM],
-    indirect=True,
-)
-@pytest.mark.parametrize(
     "method", ["euler", "backwards_euler", "firk"]
 )
 def test_hostile_names_match_safe_reference(
-    system, safe_names_system, method
+    hostile_names_system, safe_names_system, method
 ):
     """Solves are unaffected by hostile constant names."""
     np.testing.assert_allclose(
-        _solve(system, method),
+        _solve(hostile_names_system, method),
         _solve(safe_names_system, method),
         rtol=1e-6,
     )
 
 
-@pytest.mark.parametrize(
-    "solver_settings_override",
-    [HOSTILE_NAMES_SYSTEM],
-    indirect=True,
-)
-def test_hostile_constants_emit_only_prefixed_loads(system):
+def test_hostile_constants_emit_only_prefixed_loads(
+    hostile_names_system,
+):
     """Generated source loads every hostile constant prefixed."""
-    code = generate_dxdt_fac_code(system.equations, system.indices)
+    code = generate_dxdt_fac_code(
+        hostile_names_system.equations, hostile_names_system.indices
+    )
     for name in HOSTILE_NAME_CONSTANTS:
         load = (
             f"{CONSTANT_ALIAS_PREFIX}{name} = "

--- a/tests/odesystems/symbolic/test_singularity_removal.py
+++ b/tests/odesystems/symbolic/test_singularity_removal.py
@@ -20,6 +20,7 @@ from cubie.odesystems.symbolic.parsing.cellml import (
     load_cellml_model,
 )
 from cubie.odesystems.symbolic.parsing.cellml_cache import CellMLCache
+from tests._utils import TWO_DRIVER_SYSTEM
 
 CELLML_LOGGER = "cubie.odesystems.symbolic.parsing.cellml"
 
@@ -68,10 +69,9 @@ def test_fix_default_inserts_piecewise(ghk_singularity_model):
 
 
 @pytest.mark.parametrize(
-    # Unique set: the fix-singularities toggle is the value under
-    # test; every other configuration wants it on.
+    # Shares the two-driver chain, which disables the fix.
     "solver_settings_override",
-    [{"fix_singularities": False}],
+    [TWO_DRIVER_SYSTEM],
     indirect=True,
     ids=[""],
 )

--- a/tests/outputhandling/test_output_functions.py
+++ b/tests/outputhandling/test_output_functions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from tests._utils import SUMMARY_ONLY_NO_TIMING, STATE_ONLY_NO_SUMMARIES
+from tests._utils import SUMMARY_ONLY_NO_TIMING, STATE_OBS_NO_TIMING
 from numpy.testing import assert_array_equal
 
 from cubie.outputhandling.output_functions import (
@@ -305,7 +305,7 @@ def test_has_summary_outputs_default(output_functions):
 
 @pytest.mark.parametrize(
     "solver_settings_override",
-    [pytest.param(STATE_ONLY_NO_SUMMARIES, id="no-summaries")],
+    [pytest.param(STATE_OBS_NO_TIMING, id="no-summaries")],
     indirect=True,
 )
 def test_has_summary_outputs_false(output_functions):


### PR DESCRIPTION
Central-spine override sets whose extra keys are orthogonal to the behaviour under test now share one session chain instead of keying private fixture rebuilds; cases subsumed by a sibling case, or covered by an assertion folded into an existing test, are removed. 154 inventory sets → 116.

Merged onto shared chains:
- `DEVICE_SOLVE_SETTINGS` is one chain for the device-path, spill, manual-proportion, and iteration-counter tests: it carries `mem_proportion=0.1`, `host_spill_threshold=512`, and `output_types=["state", "time", "iteration_counters"]` (`MANUAL_MEMORY_PROPORTION`, `STATE_AND_ITERATION_COUNTERS`, and the two spill-only sets are gone).
- The dt-clamp cases run on the bare `CONTROLLER_TOLERANCE_SETS` chains; the case `dt0` values sit outside the chain-default `[1e-7, 1.0]` band (four `DT_CLAMP_LIMITS` sets gone).
- The FIRK driver-array and linear-solver hot-swap tests ride `ALGORITHM_CHAIN_SETS["firk"]` at duration 0.1 on a verbatim grid.
- The controller-order test rides `ALGORITHM_CHAIN_SETS["crank_nicolson"]`; any adaptive chain with an order>1 algorithm serves it.
- `STATE_ONLY_NO_SUMMARIES` tests hold on `STATE_OBS_NO_TIMING`; the ros3p tableau test rides `RESIDUAL_ARRANGEMENTS[2]`; the disabled singularity fix rides `TWO_DRIVER_SYSTEM`; `test_summarise_every` runs on the default chain; the `stream_group`/`memory_proportion` case rides the `num_runs=8` entry.
- The hostile-names tests use a direct session fixture for the system object and no longer key a solver chain.

Folded assertions and removed cases:
- Every `_run_two_step_comparison` call now also checks the device result against the CPU euler reference at coarse tolerance (rtol=atol=1e-3), replacing the eight per-algorithm `test_against_euler` constant-derivative sets: at dt=0.001 any consistent method sits within ~1e-6 of euler over two steps, so a gross tableau error fails loudly while the tight same-algorithm reference comparison covers the fine structure.
- `BICGSTAB_STEP_CASES` is the two bicgstab + chained-preconditioner combos (dirk, rosenbrock); the solver classes and preconditioner chaining have their own unit tests.
- The state-pair placement heuristic runs on tsit5 and dirk; `{"num_runs": 3}`, `{"system_type": "stiff"}`, `state_obs`, `obs_and_mean`, and `50_20` are subsumed cases.

Wall-time A/B (full real-GPU suite, `-n 4`, warmed compile caches, legs A B B A after one warmup each; A = `origin/main`, B = this branch; this round ran under background load, inflating absolute times on both sides):

| leg | side | wall (s) |
| --- | --- | ---: |
| 3 | A | 116.2 |
| 4 | B | 100.0 |
| 5 | B | 98.1 |
| 6 | A | 110.2 |

Full suites on this branch: CUDASIM 3081 passed, real GPU 3131 passed (A passes 3151; the delta is the removed cases).

Co-authored by Chris' bot