### PR TITLE
chore(ci): windows GPU legs prewarm imports; first-context time and per-phase durations logged

### DIFF
--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -519,9 +519,11 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
           CUBIE_CUDA_BACKEND: ${{ matrix.backend }}
+          CUBIE_KERNEL_CACHE_DIR: ${{ github.workspace }}/kernel-cache/kernels
         run: |
+          $imports = 'import cubie, tests.conftest, tests.precompile_plugin'
           Start-Process -WindowStyle Hidden (Get-Command python).Source `
-            -ArgumentList '-c','import cubie, tests.conftest' `
+            -ArgumentList '-c',$imports `
             -RedirectStandardOutput prewarm.out `
             -RedirectStandardError prewarm.err
 
@@ -580,9 +582,17 @@ jobs:
           CUBIE_CUDA_BACKEND: ${{ matrix.backend }}
         run: |
           time python -c "
+          from time import perf_counter
+          t0 = perf_counter()
           from numpy import zeros
           from cubie.cuda_simsafe import cuda
-          cuda.to_device(zeros(1))
+          t1 = perf_counter()
+          array = cuda.to_device(zeros(1))
+          t2 = perf_counter()
+          array.copy_to_host()
+          t3 = perf_counter()
+          print(f'import={t1-t0:.2f}s to_device={t2-t1:.2f}s '
+                f'copy_back={t3-t2:.2f}s')
           "
 
       - name: Test with pytest

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -512,6 +512,19 @@ jobs:
           uv pip install --system -e ".[${{ matrix.extra }}]" \
             -c kernel-cache/constraints.txt
 
+      # Detached; pulls first-touch reads off the critical path.
+      - name: Prewarm imports (background)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          CUBIE_CUDA_BACKEND: ${{ matrix.backend }}
+        run: |
+          Start-Process -WindowStyle Hidden (Get-Command python).Source `
+            -ArgumentList '-c','import cubie, tests.conftest' `
+            -RedirectStandardOutput prewarm.out `
+            -RedirectStandardError prewarm.err
+
       # Last GPU-free step: first-boot driver PnP-binding overlaps setup.
       - name: GPU sanity check
         id: gpu
@@ -560,6 +573,18 @@ jobs:
           name: verdicts-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}
           path: verdicts
 
+      # Reports this lane's per-process CUDA context cost.
+      - name: Time first CUDA context
+        shell: bash
+        env:
+          CUBIE_CUDA_BACKEND: ${{ matrix.backend }}
+        run: |
+          time python -c "
+          from numpy import zeros
+          from cubie.cuda_simsafe import cuda
+          cuda.to_device(zeros(1))
+          "
+
       - name: Test with pytest
         # -n logical (CLI) overrides pyproject's desktop-safe -n8 so the
         # runner uses all its vCPUs; change the runner instance size freely
@@ -599,7 +624,7 @@ jobs:
           python -m coverage run -m pytest \
             -m "not specific_algos and not sim_only" \
             -p tests.precompile_plugin -p tests.banked_plugin \
-            -n logical --no-cov \
+            -n logical --no-cov --pytest-durations=25 \
             --junitxml=pytest-gpu.xml
           status=$?
           coverage_status=0

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -560,6 +560,18 @@ jobs:
           echo "GPU driver never became available" >&2
           exit 1
 
+      # Detached; the first device touch overlaps the downloads below.
+      - name: Probe first CUDA context (background)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        env:
+          CUBIE_CUDA_BACKEND: ${{ matrix.backend }}
+        run: |
+          Start-Process -WindowStyle Hidden (Get-Command python).Source `
+            -ArgumentList 'ci/tools/gpu_probe.py' `
+            -RedirectStandardOutput gpu-probe.out `
+            -RedirectStandardError gpu-probe.err
+
       # A missing artefact fails here rather than after a full test run.
       - name: Download precompiled kernels for this GPU
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -575,25 +587,26 @@ jobs:
           name: verdicts-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}
           path: verdicts
 
-      # Reports this lane's per-process CUDA context cost.
-      - name: Time first CUDA context
+      # Waits out a probe still running, so workers start device-warm.
+      - name: Report first CUDA context timings
         shell: bash
         env:
           CUBIE_CUDA_BACKEND: ${{ matrix.backend }}
         run: |
-          time python -c "
-          from time import perf_counter
-          t0 = perf_counter()
-          from numpy import zeros
-          from cubie.cuda_simsafe import cuda
-          t1 = perf_counter()
-          array = cuda.to_device(zeros(1))
-          t2 = perf_counter()
-          array.copy_to_host()
-          t3 = perf_counter()
-          print(f'import={t1-t0:.2f}s to_device={t2-t1:.2f}s '
-                f'copy_back={t3-t2:.2f}s')
-          "
+          if [ "${{ matrix.os }}" != "windows" ]; then
+            time python ci/tools/gpu_probe.py
+            exit 0
+          fi
+          for _ in $(seq 1 36); do
+            [ -s gpu-probe.out ] && break
+            sleep 5
+          done
+          cat gpu-probe.err || true
+          if [ -s gpu-probe.out ]; then
+            cat gpu-probe.out
+          else
+            echo "probe produced no output within 180s"
+          fi
 
       - name: Test with pytest
         # -n logical (CLI) overrides pyproject's desktop-safe -n8 so the

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -560,13 +560,14 @@ jobs:
           echo "GPU driver never became available" >&2
           exit 1
 
-      # Detached; the first device touch overlaps the downloads below.
+      # Detached: pays the lane's first device touch while the downloads run.
       - name: Probe first CUDA context (background)
         if: matrix.os == 'windows'
         shell: pwsh
         env:
           CUBIE_CUDA_BACKEND: ${{ matrix.backend }}
         run: |
+          # Timings land in gpu-probe.out; the report step prints them.
           Start-Process -WindowStyle Hidden (Get-Command python).Source `
             -ArgumentList 'ci/tools/gpu_probe.py' `
             -RedirectStandardOutput gpu-probe.out `
@@ -593,10 +594,12 @@ jobs:
         env:
           CUBIE_CUDA_BACKEND: ${{ matrix.backend }}
         run: |
+          # Prints the lane's first-launch split: import / context / copy.
           if [ "${{ matrix.os }}" != "windows" ]; then
             time python ci/tools/gpu_probe.py
             exit 0
           fi
+          # Durations table below: first-launch tests ~12s = per-process cost; ~1s = the probe's warm carried.
           for _ in $(seq 1 36); do
             [ -s gpu-probe.out ] && break
             sleep 5

--- a/ci/tools/gpu_probe.py
+++ b/ci/tools/gpu_probe.py
@@ -1,0 +1,16 @@
+"""Time the interpreter's first CUDA context and transfers."""
+from time import perf_counter
+
+t0 = perf_counter()
+from numpy import zeros  # noqa: E402
+from cubie.cuda_simsafe import cuda  # noqa: E402
+
+t1 = perf_counter()
+array = cuda.to_device(zeros(1))
+t2 = perf_counter()
+array.copy_to_host()
+t3 = perf_counter()
+print(
+    f"import={t1 - t0:.2f}s to_device={t2 - t1:.2f}s "
+    f"copy_back={t3 - t2:.2f}s"
+)


### PR DESCRIPTION
## What changed

The Windows `cuda` legs start a detached background process importing `cubie`, `tests.conftest`, and `tests.precompile_plugin` right after the install, so the interpreter's first-touch reads overlap the GPU sanity wait and the artefact downloads instead of the pytest step. That import set covers 2470 of the 2520 modules the pytest master loads (the remainder are pytest internals and stdlib modules pytest itself pulls). Run 30838868303 put the cost at 44-69 s before the pytest session opened in every Windows lane, repeated in each xdist worker's boot.

On Windows, `ci/tools/gpu_probe.py` runs detached immediately after the sanity check confirms the driver, overlapping the two artefact downloads; it times import / first `to_device` / first `copy_to_host`. A report step before pytest waits out a still-running probe and prints its timings, so the workers always start against a device that has already served a context. Linux runs the same probe inline there (its first-launch cost is 1-2 s). Per-test junit times show a deterministic per-process first-launch cost of ~12 s on CI Windows (12.04-12.06 s A10G, 12.46-12.51 s T4, uniform across workers) against 1.1-1.8 s on CI Linux and 0.4 s on a local Windows GPU box running the identical plugin-plus-kernel-cache path, so the cost sits in the CI Windows driver path rather than in cubie or the test code. If the probe's warm carries to the workers, their first launches drop in the durations output and the ~12 s leaves the measured lane time; if it does not, the probe cost stays hidden inside the download window either way.

The pytest step passes `--pytest-durations=25`, so the log carries setup/call/teardown splits for the slowest tests.

Co-authored by Chris' bot