### PR TITLE
chore(fleet): GPU CI runs in us-east-2 with Windows runners locked to g5.xlarge

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -6,7 +6,7 @@
 #
 # NOTE: ci_cuda_tests.yml does not use these Flex runners -- its GPU
 # matrix runs on the RunsOn Fleet scale sets defined in infra/fleet
-# (xlarge/2xlarge, two-wide via max-parallel). The Flex GitHub App must NOT
+# (one-wide via max-parallel). The Flex GitHub App must NOT
 # have access to this repository: Flex (v3.1.3) claims any job whose
 # label starts with `runs-on/`, so a fleet-labeled job with Flex
 # attached launches a duplicate default 2-vCPU instance per attempt.

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -29,8 +29,7 @@ images:
 runners:
   # Linux GPU: RunsOn's managed image (driver + CUDA toolkit +
   # container toolkit prebaked; rebuilt by RunsOn ~every 15 days).
-  # Spot-only: the On-Demand G/VT vCPU quota is 0, so every runner
-  # must be spot.
+  # Spot-only: the On-Demand G/VT vCPU quota is 0.
   # price-capacity-optimized (pco, RunsOn's default) picks a high-capacity
   # spot pool that is also among the cheapest -- cost matters here as this
   # is personally funded. Listing three GPU families widens the pools to
@@ -48,9 +47,7 @@ runners:
     image: ubuntu24-gpu-x64
     spot: price-capacity-optimized
 
-  # Windows GPU: our baked AMI, g5.xlarge only -- the bake family, so
-  # the GRID driver is bound before first boot. 4-vCPU (xlarge) for the
-  # same 8-vCPU-quota reason as gpu-linux above.
+  # Windows GPU: our baked AMI on g5.xlarge, the bake family, so the driver is bound before first boot.
   # NOTE: RunsOn's build config defines a stock `windows25-gpu-x64` image
   # (built but, as of this writing, undocumented/unannounced -- the docs
   # still say Windows GPU is unsupported). If it becomes available in your

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -29,8 +29,8 @@ images:
 runners:
   # Linux GPU: RunsOn's managed image (driver + CUDA toolkit +
   # container toolkit prebaked; rebuilt by RunsOn ~every 15 days).
-  # Spot-only: ap-southeast-2 has zero On-Demand G/VT vCPU quota (and it
-  # is not grantable in this region), so every runner must be spot.
+  # Spot-only: the On-Demand G/VT vCPU quota is 0, so every runner
+  # must be spot.
   # price-capacity-optimized (pco, RunsOn's default) picks a high-capacity
   # spot pool that is also among the cheapest -- cost matters here as this
   # is personally funded. Listing three GPU families widens the pools to
@@ -48,11 +48,9 @@ runners:
     image: ubuntu24-gpu-x64
     spot: price-capacity-optimized
 
-  # Windows GPU: our baked AMI (GRID driver already installed). The AWS
-  # GRID driver is multi-GPU, so the same AMI runs on the T4/A10G/L4 spot
-  # pools listed below. 4-vCPU (xlarge) for the same 8-vCPU-quota reason
-  # as gpu-linux above -- two runners fit within quota so serial handoffs
-  # do not collide.
+  # Windows GPU: our baked AMI, g5.xlarge only -- the bake family, so
+  # the GRID driver is bound before first boot. 4-vCPU (xlarge) for the
+  # same 8-vCPU-quota reason as gpu-linux above.
   # NOTE: RunsOn's build config defines a stock `windows25-gpu-x64` image
   # (built but, as of this writing, undocumented/unannounced -- the docs
   # still say Windows GPU is unsupported). If it becomes available in your
@@ -60,6 +58,6 @@ runners:
   # build-windows-gpu-ami.yml, ci/tools/install_gpu_driver.ps1, the
   # `images:` block above) and set `image: windows25-gpu-x64` here instead.
   gpu-windows:
-    family: ["g4dn.xlarge", "g5.xlarge", "g6.xlarge"]
+    family: ["g5.xlarge"]
     image: cubie-win-gpu
     spot: price-capacity-optimized

--- a/.github/workflows/build-windows-gpu-ami.yml
+++ b/.github/workflows/build-windows-gpu-ami.yml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   build-ami:
     runs-on: ubuntu-latest
+    # Bounded so a hung bake's builder is reaped by the cleanup workflow.
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v7
 
@@ -25,7 +27,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_AMI_BUILDER_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: us-east-2
           # Bakes exceed the 1h default; role max session must be >=2h.
           role-duration-seconds: 7200
 
@@ -70,7 +72,7 @@ jobs:
       - name: Build AMI
         if: steps.age.outputs.bake == 'true'
         env:
-          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_REGION: us-east-2
           # Set to pin one subnet (e.g. no default VPC).
           PINNED_SUBNET: ${{ vars.AWS_BUILD_SUBNET_ID }}
           MAX_ROUNDS: "40"
@@ -106,6 +108,7 @@ jobs:
               packer build \
                 -var "region=$AWS_REGION" \
                 -var "subnet_id=$SN" \
+                -var "build_run_id=$GITHUB_RUN_ID" \
                 packer/windows-gpu.pkr.hcl 2>&1 | tee packer.out
               rc=${PIPESTATUS[0]}
               set -e

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -15,11 +15,6 @@ concurrency:
   group: cuda-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
-# Capabilities precompiled for the fleet's GPUs; the GPU leg refuses a
-# device outside this set.
-env:
-  PRECOMPILE_CCS: "7.5 8.6 8.9"
-
 jobs:
   # Trigger gating and commit pinning for the paid GPU matrix. Runs on
   # a free GitHub-hosted runner within seconds of the trigger: for
@@ -98,6 +93,9 @@ jobs:
           - {os: windows, python-version: "3.14", cuda: "12", extra: dev-mlir12, backend: mlir}
           - {os: windows, python-version: "3.14", cuda: "13", extra: dev-mlir13, backend: mlir}
     runs-on: ${{ matrix.os == 'linux' && 'ubuntu-latest' || 'windows-latest' }}
+    # Capabilities precompiled per OS: Windows runners are g5-only (cc 8.6).
+    env:
+      PRECOMPILE_CCS: ${{ matrix.os == 'windows' && '8.6' || '7.5 8.6 8.9' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -232,6 +230,7 @@ jobs:
             kernel-cache/numba-cpu
 
       - name: Upload kernel cache (cc7.5)
+        if: matrix.os == 'linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kernel-cache-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}-cc7.5
@@ -244,6 +243,7 @@ jobs:
           path: kernel-cache/cc8.6
 
       - name: Upload kernel cache (cc8.9)
+        if: matrix.os == 'linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kernel-cache-${{ matrix.os }}-py${{ matrix.python-version }}-cuda${{ matrix.cuda }}-${{ matrix.backend }}-cc8.9
@@ -410,11 +410,14 @@ jobs:
     name: cuda (${{ matrix.os }}, ${{ matrix.python-version }}, ${{ matrix.cuda }}, ${{ matrix.backend }})
     permissions:
       contents: read
-    # Spot-only runners inside the fixed 8-vCPU G/VT spot quota: max-parallel 2 x 4-vCPU legs.
+    # The sanity gate refuses a device outside the leg's precompiled set.
+    env:
+      PRECOMPILE_CCS: ${{ matrix.os == 'windows' && '8.6' || '7.5 8.6 8.9' }}
+    # Spot-only inside the fixed 8-vCPU G/VT spot quota: max-parallel 1 leaves quota room for a finishing leg's teardown.
     strategy:
       # Param-set xdist grouping (conftest + --dist=loadgroup) keeps -n scaling near-linear.
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 1
       # The mlir lanes mirror the numba-cuda lanes, except that
       # numba-cuda-mlir needs Python >= 3.11, so its lower-bound lanes
       # run 3.11 where the numba-cuda lanes run 3.10.

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -410,15 +410,9 @@ jobs:
     name: cuda (${{ matrix.os }}, ${{ matrix.python-version }}, ${{ matrix.cuda }}, ${{ matrix.backend }})
     permissions:
       contents: read
-    # Runners are spot-only (On-Demand G/VT quota is 0) inside the fixed 8-vCPU G/VT spot quota.
-    # Windows legs run g5.xlarge only -- the AMI's bake family, so the GRID driver is bound before first boot.
-    # Linux legs pick across g4dn/g5/g6 xlarge/2xlarge by price-capacity allocation.
-    # Two 4-vCPU legs fit the quota at once (max-parallel: 2); fleet scale sets launch per assigned job, so demand tracks it.
-    # A Linux 2xlarge quota-blocks the other slot until it finishes; the fleet retries, costing latency, never a failed leg.
-    # The param-set xdist grouping (tests/conftest.py +
-    # --dist=loadgroup in addopts) keeps thread scaling near-linear
-    # across however many workers `-n logical` resolves to.
+    # Spot-only runners inside the fixed 8-vCPU G/VT spot quota: max-parallel 2 x 4-vCPU legs.
     strategy:
+      # Param-set xdist grouping (conftest + --dist=loadgroup) keeps -n scaling near-linear.
       fail-fast: false
       max-parallel: 2
       # The mlir lanes mirror the numba-cuda lanes, except that
@@ -442,6 +436,7 @@ jobs:
           - {os: windows, python-version: "3.11", cuda: "13", extra: dev-mlir13, backend: mlir, fleet: gpu-windows}
           - {os: windows, python-version: "3.14", cuda: "12", extra: dev-mlir12, backend: mlir, fleet: gpu-windows}
           - {os: windows, python-version: "3.14", cuda: "13", extra: dev-mlir13, backend: mlir, fleet: gpu-windows}
+    # Windows fleet is g5.xlarge, the AMI bake family; Linux picks g4dn/g5/g6 by price-capacity.
     runs-on: runs-on/fleet=${{ matrix.fleet }}/env=production
 
     steps:

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -410,19 +410,11 @@ jobs:
     name: cuda (${{ matrix.os }}, ${{ matrix.python-version }}, ${{ matrix.cuda }}, ${{ matrix.backend }})
     permissions:
       contents: read
-    # Runners are spot-only (ap-southeast-2 has zero On-Demand G/VT
-    # quota, not grantable here) and the "All G and VT Spot" quota is
-    # a fixed 8 vCPU. A leg gets a 2xlarge (8 vCPU) when that capacity
-    # exists and an xlarge (4 vCPU) otherwise -- ap-southeast-2 is
-    # structurally short of 2xlarge GPU spot (placement score 1/10 vs
-    # 9/10 for xlarge), so xlarge is what usually runs, and two xlarge
-    # legs fit the quota concurrently: max-parallel: 2. The fleet
-    # runners (infra/fleet) are RunsOn *scale sets*: GitHub assigns at
-    # most two jobs at a time and instances launch per assigned job,
-    # so runner demand tracks max-parallel and never exceeds the
-    # quota. If a leg does land a 2xlarge, the other
-    # slot's launch is quota-blocked until it finishes; the fleet
-    # retries with backoff, so that costs latency, never a failed leg.
+    # Runners are spot-only (On-Demand G/VT quota is 0) inside the fixed 8-vCPU G/VT spot quota.
+    # Windows legs run g5.xlarge only -- the AMI's bake family, so the GRID driver is bound before first boot.
+    # Linux legs pick across g4dn/g5/g6 xlarge/2xlarge by price-capacity allocation.
+    # Two 4-vCPU legs fit the quota at once (max-parallel: 2); fleet scale sets launch per assigned job, so demand tracks it.
+    # A Linux 2xlarge quota-blocks the other slot until it finishes; the fleet retries, costing latency, never a failed leg.
     # The param-set xdist grouping (tests/conftest.py +
     # --dist=loadgroup in addopts) keeps thread scaling near-linear
     # across however many workers `-n logical` resolves to.
@@ -538,7 +530,8 @@ jobs:
               echo "cc=$cc" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            command -v pnputil.exe >/dev/null 2>&1 && pnputil.exe /scan-devices || true
+            # Doubled slash survives Git Bash's path mangling of /scan-devices.
+            command -v pnputil.exe >/dev/null 2>&1 && pnputil.exe //scan-devices || true
             echo "nvidia-smi not ready (attempt ${attempt}/36); retrying in 5s"
             sleep 5
           done

--- a/.github/workflows/cleanup-ami-builder.yml
+++ b/.github/workflows/cleanup-ami-builder.yml
@@ -1,0 +1,38 @@
+name: Cleanup AMI builder
+on:
+  workflow_run:
+    workflows: ["Build Windows GPU AMI"]
+    types: [completed]
+
+permissions:
+  id-token: write   # OIDC -> AWS
+  contents: read
+
+jobs:
+  terminate-builder:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_AMI_BUILDER_ROLE }}
+          aws-region: us-east-2
+
+      # Terminates only builders the finished run tagged; no-op when Packer cleaned up.
+      - name: Terminate leftover builder instances
+        env:
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          ids=$(aws ec2 describe-instances \
+            --filters "Name=tag:Purpose,Values=cubie-ami-bake" \
+                      "Name=tag:BuildRunId,Values=${RUN_ID}" \
+                      "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+            --query 'Reservations[].Instances[].InstanceId' --output text)
+          if [ -z "$ids" ]; then
+            echo "No leftover builder instances for run ${RUN_ID}."
+            exit 0
+          fi
+          aws ec2 terminate-instances --instance-ids $ids
+          echo "Terminated: $ids"

--- a/infra/fleet/README.md
+++ b/infra/fleet/README.md
@@ -17,10 +17,8 @@ re-dispatching `retry` job.
 Fleet uses GitHub runner **scale sets**: jobs queue on the GitHub side
 and the Fleet runtime launches EC2 capacity per *assigned* job, so
 `strategy.max-parallel` genuinely bounds instance demand and the retry
-apparatus goes away. The workflow runs `max-parallel: 1`: a finishing
-leg's teardown and its successor's launch fit the quota together.
-Windows runners are
-g5.xlarge; Linux runners span three families in both sizes under
+apparatus goes away. The workflow runs `max-parallel: 1`. Windows
+runners are g5.xlarge; Linux runners span three families in both sizes under
 price-capacity allocation. On a launch failure the Fleet runtime
 retries with backoff while the job stays queued, so capacity droughts
 cost latency, not red legs.

--- a/infra/fleet/README.md
+++ b/infra/fleet/README.md
@@ -17,8 +17,9 @@ re-dispatching `retry` job.
 Fleet uses GitHub runner **scale sets**: jobs queue on the GitHub side
 and the Fleet runtime launches EC2 capacity per *assigned* job, so
 `strategy.max-parallel` genuinely bounds instance demand and the retry
-apparatus goes away. The workflow runs `max-parallel: 2`: two xlarge
-(4-vCPU) legs fit the quota concurrently. Windows runners are
+apparatus goes away. The workflow runs `max-parallel: 1`: a finishing
+leg's teardown and its successor's launch fit the quota together.
+Windows runners are
 g5.xlarge; Linux runners span three families in both sizes under
 price-capacity allocation. On a launch failure the Fleet runtime
 retries with backoff while the job stays queued, so capacity droughts

--- a/infra/fleet/README.md
+++ b/infra/fleet/README.md
@@ -19,11 +19,10 @@ and the Fleet runtime launches EC2 capacity per *assigned* job, so
 `strategy.max-parallel` genuinely bounds instance demand and the retry
 apparatus goes away. The workflow runs `max-parallel: 2`: two xlarge
 (4-vCPU) legs fit the quota concurrently. Windows runners are
-g5.xlarge only — the family the AMI bakes on, so the GRID driver is
-bound before a runner's first boot; Linux runners span three families
-in both sizes under price-capacity allocation. On a launch failure the
-Fleet runtime retries with backoff while the job stays queued, so
-capacity droughts cost latency, not red legs.
+g5.xlarge; Linux runners span three families in both sizes under
+price-capacity allocation. On a launch failure the Fleet runtime
+retries with backoff while the job stays queued, so capacity droughts
+cost latency, not red legs.
 
 The fleets have no `schedule` (warm standby) on purpose: RunsOn warm
 pools use on-demand capacity, which this account cannot launch for G

--- a/infra/fleet/README.md
+++ b/infra/fleet/README.md
@@ -6,7 +6,7 @@ the GPU runners for `.github/workflows/ci_cuda_tests.yml`.
 ## Why Fleet
 
 The account's "All G and VT Spot" quota is a fixed 8 vCPU and the
-On-Demand G/VT quota is 0 (not grantable in ap-southeast-2). Under the
+On-Demand G/VT quota is 0. Under the
 old Flex setup, each queued matrix job's webhook launched an instance
 immediately — Flex has no `max-parallel` awareness — so the matrix
 overran the quota, quota rejections tripped Flex's fixed 5-minute
@@ -18,11 +18,12 @@ Fleet uses GitHub runner **scale sets**: jobs queue on the GitHub side
 and the Fleet runtime launches EC2 capacity per *assigned* job, so
 `strategy.max-parallel` genuinely bounds instance demand and the retry
 apparatus goes away. The workflow runs `max-parallel: 2`: two xlarge
-(4-vCPU) legs fit the quota concurrently, and a leg lands a 2xlarge
-when ap-southeast-2 has that capacity (rare — spot placement score
-1/10 for 2xlarge vs 9/10 for xlarge). On a launch failure the Fleet
-runtime retries with backoff while the job stays queued, so capacity
-droughts cost latency, not red legs.
+(4-vCPU) legs fit the quota concurrently. Windows runners are
+g5.xlarge only — the family the AMI bakes on, so the GRID driver is
+bound before a runner's first boot; Linux runners span three families
+in both sizes under price-capacity allocation. On a launch failure the
+Fleet runtime retries with backoff while the job stays queued, so
+capacity droughts cost latency, not red legs.
 
 The fleets have no `schedule` (warm standby) on purpose: RunsOn warm
 pools use on-demand capacity, which this account cannot launch for G

--- a/infra/fleet/bootstrap/cloudshell-iam.sh
+++ b/infra/fleet/bootstrap/cloudshell-iam.sh
@@ -22,7 +22,7 @@
 # Credentials block into ~/.aws/credentials under [cubie-fleet].
 set -euo pipefail
 
-REGION="ap-southeast-2"
+REGION="us-east-2"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
 # Permissions, by statement:
@@ -37,8 +37,8 @@ ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 # - CostExplorerReadOnly: read-only Cost Explorer for the CI
 #   cost/usage report. Cost Explorer is a global service reached
 #   through us-east-1, so it CANNOT sit in the region-locked ReadOnly
-#   statement (the aws:RequestedRegion=ap-southeast-2 condition would
-#   deny every call); it gets its own un-region-locked statement.
+#   statement (the aws:RequestedRegion condition would deny every
+#   call); it gets its own un-region-locked statement.
 #   Read-only and carries no secret material.
 # - Ec2Provision: creation of brand-new EC2 networking/template
 #   resources only -- creating a resource cannot touch an existing

--- a/infra/fleet/bootstrap/cloudshell-iam.sh
+++ b/infra/fleet/bootstrap/cloudshell-iam.sh
@@ -37,8 +37,7 @@ ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 # - CostExplorerReadOnly: read-only Cost Explorer for the CI
 #   cost/usage report. Cost Explorer is a global service reached
 #   through us-east-1, so it CANNOT sit in the region-locked ReadOnly
-#   statement (the aws:RequestedRegion condition would deny every
-#   call); it gets its own un-region-locked statement.
+#   statement (aws:RequestedRegion would deny it), so it is un-region-locked.
 #   Read-only and carries no secret material.
 # - Ec2Provision: creation of brand-new EC2 networking/template
 #   resources only -- creating a resource cannot touch an existing

--- a/infra/fleet/cost_dashboard.py
+++ b/infra/fleet/cost_dashboard.py
@@ -54,7 +54,7 @@ from uuid import uuid4
 REPO = "cubiepy/cubie"
 WORKFLOW = "ci_cuda_tests.yml"
 PROFILE = "cubie-fleet"
-REGION = "ap-southeast-2"
+REGION = "us-east-2"
 EC2_COMPUTE = "Amazon Elastic Compute Cloud - Compute"
 HERE = Path(__file__).resolve().parent
 CACHE_DIR = HERE / ".dashboard-cache"

--- a/infra/fleet/main.tf
+++ b/infra/fleet/main.tf
@@ -3,9 +3,7 @@
 # Fleet (runs-on.com/docs/flex-vs-fleet/) registers GitHub runner scale
 # sets and launches EC2 capacity from *assigned-job* demand, so the
 # workflow's `strategy.max-parallel` bounds runner demand on the RunsOn
-# side as well, keeping it inside the fixed 8-vCPU "All G and VT Spot"
-# quota (on-demand G/VT quota is 0). Two xlarge legs fit that quota
-# concurrently.
+# side as well, keeping it inside the fixed 8-vCPU G/VT spot quota.
 #
 # Deliberately no `schedule` (hot/stopped standby) on the fleets: warm
 # pool inventory uses on-demand EC2 capacity, which this account cannot
@@ -42,11 +40,10 @@ locals {
     }
   }
 
-  # Windows runners: g5.xlarge only, matching the AMI bake family (packer/windows-gpu.pkr.hcl) so the driver is bound before first boot.
-  # Linux runners: xlarge/2xlarge of three GPU families; price-capacity allocation chooses, and `pytest -n logical` scales to either size.
-  # Either size fits the 8-vCPU G/VT spot quota with the workflow's max-parallel: 2.
+  # Either size fits the 8-vCPU G/VT spot quota with max-parallel: 2.
   runners = {
     gpu-linux-2xl = {
+      # Three GPU families in both sizes; price-capacity allocation chooses.
       family = [
         "g4dn.2xlarge", "g5.2xlarge", "g6.2xlarge",
         "g4dn.xlarge", "g5.xlarge", "g6.xlarge",
@@ -61,6 +58,7 @@ locals {
       # runners public repositories can use; cubie is public.
     }
     gpu-windows-g5 = {
+      # The AMI bake family only, so the driver is bound before first boot.
       family = ["g5.xlarge"]
       image  = "cubie-win-gpu"
       spot   = "price-capacity-optimized"

--- a/infra/fleet/main.tf
+++ b/infra/fleet/main.tf
@@ -40,7 +40,7 @@ locals {
     }
   }
 
-  # Either size fits the 8-vCPU G/VT spot quota with max-parallel: 2.
+  # max-parallel: 1 fits a finishing leg's teardown plus its successor inside the 8-vCPU G/VT spot quota.
   runners = {
     gpu-linux-2xl = {
       # Three GPU families in both sizes; price-capacity allocation chooses.

--- a/infra/fleet/main.tf
+++ b/infra/fleet/main.tf
@@ -4,8 +4,8 @@
 # sets and launches EC2 capacity from *assigned-job* demand, so the
 # workflow's `strategy.max-parallel` bounds runner demand on the RunsOn
 # side as well, keeping it inside the fixed 8-vCPU "All G and VT Spot"
-# quota (on-demand G/VT quota is 0 in ap-southeast-2 and not
-# grantable). Two xlarge legs fit that quota concurrently.
+# quota (on-demand G/VT quota is 0). Two xlarge legs fit that quota
+# concurrently.
 #
 # Deliberately no `schedule` (hot/stopped standby) on the fleets: warm
 # pool inventory uses on-demand EC2 capacity, which this account cannot
@@ -42,16 +42,9 @@ locals {
     }
   }
 
-  # Runner shapes. Both xlarge (4 vCPU) and 2xlarge (8 vCPU) sizes of
-  # three GPU families (T4/A10G/L4); the single AWS GRID driver package
-  # in the baked AMI covers all of them, and the workflow's
-  # `pytest -n logical` scales the worker count to whichever size a
-  # leg lands on. 2xlarge is preferred but spot placement scores show
-  # ap-southeast-2 is structurally starved of 2xlarge GPU capacity
-  # (score 1/10 vs 9/10 for xlarge), so xlarge keeps the suite running;
-  # price-capacity-optimized allocation will usually pick it. Either
-  # size fits the fixed 8-vCPU G/VT spot quota, and max-parallel: 2 in
-  # the workflow keeps demand to at most two xlarge-sized legs.
+  # Windows runners: g5.xlarge only, matching the AMI bake family (packer/windows-gpu.pkr.hcl) so the driver is bound before first boot.
+  # Linux runners: xlarge/2xlarge of three GPU families; price-capacity allocation chooses, and `pytest -n logical` scales to either size.
+  # Either size fits the 8-vCPU G/VT spot quota with the workflow's max-parallel: 2.
   runners = {
     gpu-linux-2xl = {
       family = [
@@ -67,13 +60,10 @@ locals {
       # the shared cache bucket must not be enabled for
       # runners public repositories can use; cubie is public.
     }
-    gpu-windows-2xl = {
-      family = [
-        "g4dn.2xlarge", "g5.2xlarge", "g6.2xlarge",
-        "g4dn.xlarge", "g5.xlarge", "g6.xlarge",
-      ]
-      image = "cubie-win-gpu"
-      spot  = "price-capacity-optimized"
+    gpu-windows-g5 = {
+      family = ["g5.xlarge"]
+      image  = "cubie-win-gpu"
+      spot   = "price-capacity-optimized"
       # No s3-cache (Magic Cache) extra, deliberately: it requires a
       # runs-on/action@v2 step in every job (without one the sidecar
       # intercepts the GitHub artifact service and CreateArtifact
@@ -95,7 +85,7 @@ locals {
     }
     gpu-windows = {
       timezone = "UTC"
-      runner   = "gpu-windows-2xl"
+      runner   = "gpu-windows-g5"
     }
   }
 }
@@ -103,9 +93,8 @@ locals {
 # Self-contained network: the stack owns its VPC and shares no
 # networking with any other stack, so nothing outside this
 # configuration can take the fleet's network down. Public subnets in
-# all three AZs: g4dn/g5/g6 GPU spot pools span 2a/2b/2c and g5 exists
-# only in 2a/2c, so full AZ coverage maximises the pools reachable at
-# the fixed 8-vCPU quota. Public-only (no NAT) keeps the VPC free.
+# all three AZs: the GPU spot pools span them, so full AZ coverage
+# maximises reachable pools. Public-only (no NAT) keeps the VPC free.
 resource "aws_vpc" "this" {
   cidr_block           = var.vpc_cidr
   enable_dns_support   = true

--- a/infra/fleet/variables.tf
+++ b/infra/fleet/variables.tf
@@ -1,7 +1,7 @@
 variable "aws_region" {
   description = "AWS region the fleet stack deploys into."
   type        = string
-  default     = "ap-southeast-2"
+  default     = "us-east-2"
 }
 
 variable "aws_profile" {
@@ -44,7 +44,7 @@ variable "vpc_cidr" {
 }
 
 variable "availability_zones" {
-  description = "Availability zones given a public subnet. All three, because GPU spot pools span them and g5 exists only in 2a/2c."
+  description = "Availability zones given a public subnet. All three, because the GPU spot pools span them."
   type        = list(string)
-  default     = ["ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"]
+  default     = ["us-east-2a", "us-east-2b", "us-east-2c"]
 }

--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -11,23 +11,19 @@ packer {
 # runners into (custom AMIs are region-local).
 variable "region" {
   type    = string
-  default = "ap-southeast-2"
+  default = "us-east-2"
 }
 
 # Builder needs a physical GPU present so the driver binds during the
-# bake. The AWS GRID driver it installs is multi-GPU (T4/A10G/L4), so any
-# of these families bakes a working AMI; listing several lets the spot
-# fleet take whichever GPU pool has capacity (g4dn.xlarge spot is often
-# dry across whole AZs). Requested as spot because this region has no
-# On-Demand G quota. Uses the Fleet IAM actions (CreateFleet,
-# CreateLaunchTemplate, DeleteLaunchTemplate) on the builder role.
+# bake. Pinned to the g5 family (A10G): the fleet's Windows runners are
+# g5.xlarge only, and baking on the same family leaves the driver bound
+# before a runner's first boot. Both sizes widen the bake's spot pools.
+# Requested as spot because this account has no On-Demand G quota. Uses
+# the Fleet IAM actions (CreateFleet, CreateLaunchTemplate,
+# DeleteLaunchTemplate) on the builder role.
 variable "spot_instance_types" {
   type    = list(string)
-  default = [
-    "g4dn.xlarge", "g4dn.2xlarge",
-    "g5.xlarge", "g5.2xlarge",
-    "g6.xlarge", "g6.2xlarge",
-  ]
+  default = ["g5.xlarge", "g5.2xlarge"]
 }
 
 # Max hourly spot bid. A ceiling only EXCLUDES pools -- AWS charges the

--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -14,13 +14,7 @@ variable "region" {
   default = "us-east-2"
 }
 
-# Builder needs a physical GPU present so the driver binds during the
-# bake. Pinned to the g5 family (A10G): the fleet's Windows runners are
-# g5.xlarge only, and baking on the same family leaves the driver bound
-# before a runner's first boot. Both sizes widen the bake's spot pools.
-# Requested as spot because this account has no On-Demand G quota. Uses
-# the Fleet IAM actions (CreateFleet, CreateLaunchTemplate,
-# DeleteLaunchTemplate) on the builder role.
+# Bake needs a real GPU; g5 only (the Windows fleet's family, both sizes), spot, via the builder role's Fleet IAM actions.
 variable "spot_instance_types" {
   type    = list(string)
   default = ["g5.xlarge", "g5.2xlarge"]

--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -14,10 +14,16 @@ variable "region" {
   default = "us-east-2"
 }
 
-# Bake needs a real GPU; g5 only (the Windows fleet's family, both sizes), spot, via the builder role's Fleet IAM actions.
+# Bake needs a real GPU; g5.xlarge only (the Windows fleet's exact shape), spot, via the builder role's Fleet IAM actions.
 variable "spot_instance_types" {
   type    = list(string)
-  default = ["g5.xlarge", "g5.2xlarge"]
+  default = ["g5.xlarge"]
+}
+
+# GitHub run ID stamped on the builder instance for post-run cleanup.
+variable "build_run_id" {
+  type    = string
+  default = ""
 }
 
 # Max hourly spot bid. A ceiling only EXCLUDES pools -- AWS charges the
@@ -117,6 +123,12 @@ EOF
     Purpose   = "cuda-ci-windows-gpu"
     BaseImage = var.source_ami_name
   }
+
+  # Builder-instance tags; the cleanup workflow terminates by these.
+  run_tags = {
+    Purpose    = "cubie-ami-bake"
+    BuildRunId = var.build_run_id
+  }
 }
 
 build {
@@ -153,25 +165,11 @@ build {
     scripts = ["ci/tools/populate_uv_cache.ps1"]
   }
 
-  # Disable WinRM in the published AMI and reset EC2Launch so it
-  # re-initialises (and re-runs the RunsOn agent bootstrap) on first boot as
-  # a runner. Block mirrors runs-on/runner-images-for-aws
-  # (windows25-gpu-x64.pkr.hcl) so capture does not need a WinRM reconnect.
+  # EC2Launch reset + Sysprep shutdown; first boot reruns the RunsOn bootstrap.
   provisioner "powershell" {
     inline = [
-      "Write-Host 'Disabling WinRM in the published AMI...'",
-      "Set-Service -Name WinRM -StartupType Disabled",
-      "Write-Host 'Scheduling WinRM shutdown so Packer does not need to reconnect after final capture starts...'",
-      "$null = Start-Process -FilePath 'powershell.exe' -WindowStyle Hidden -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', \"Start-Sleep -Seconds 15; Stop-Service -Name WinRM -Force -ErrorAction SilentlyContinue\")",
-      "$OSVersion = [System.Environment]::OSVersion.Version",
-      "if ($OSVersion.Major -eq 10 -and $OSVersion.Build -ge 20348) {",
-      "    Write-Host 'Windows Server 2022+ detected, using EC2Launch v2'",
-      "    & \"C:\\Program Files\\Amazon\\EC2Launch\\EC2Launch.exe\" reset",
-      "} else {",
-      "    Write-Host 'Windows Server pre-2022 detected, using EC2Launch v1'",
-      "    & C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\InitializeInstance.ps1 -Schedule",
-      "}",
-      "exit 0",
+      "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' reset --block",
+      "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' sysprep --shutdown --block",
     ]
   }
 }


### PR DESCRIPTION
The RunsOn Fleet stack, the AMI bake, the deployer IAM bootstrap, and the cost dashboard all target us-east-2. Windows fleet runners are g5.xlarge only and the bake's spot request is pinned to the g5 family, so the baked GRID driver is bound to the A10G before a runner's first boot and the sanity gate passes immediately. Linux runners keep the three-family xlarge/2xlarge list under price-capacity allocation.

The GPU sanity loop's pnputil rescan uses a doubled slash (`//scan-devices`) so Git Bash's MSYS path conversion no longer rewrites the flag into a filesystem path.

us-east-2 selection: g5.xlarge there holds spot placement score 3 at target capacities from 1 through 16 across two AZs, and its Windows spot rate is 27% below ap-southeast-2's.

ab_gate: not applicable — CI/infra only, no device code changed.

Co-authored by Chris' bot