### PR TITLE
chore(ci): first-launch diagnostic harness (probe workflow, phase instrumentation, single-lane CI)

### DIFF
--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -467,6 +467,17 @@ jobs:
           uv pip install --system -e ".[${{ matrix.extra }}]" \
             -c kernel-cache/constraints.txt
 
+      # Pays Defender's first-execution scan of the NVVM DLL once.
+      - name: Prewarm NVVM (background)
+        if: matrix.os == 'windows' && matrix.backend == 'numba-cuda'
+        shell: pwsh
+        run: |
+          $code = 'from numba.cuda.cudadrv.nvvm import NVVM; NVVM(); open(''nvvm-warm.done'',''w'').write(''ok'')'
+          Start-Process -WindowStyle Hidden (Get-Command python).Source `
+            -ArgumentList ('-c "' + $code + '"') `
+            -RedirectStandardOutput nvvm-warm.log `
+            -RedirectStandardError nvvm-warm.err
+
       # Last GPU-free step: first-boot driver PnP-binding overlaps setup.
       - name: GPU sanity check
         id: gpu
@@ -552,6 +563,19 @@ jobs:
           CUBIE_PROBE_TIMING_FILE: ${{ github.workspace }}/probe-timings.txt
         run: |
           set +e
+          if [ "${{ matrix.os }}" = "windows" ] && \
+             [ "${{ matrix.backend }}" = "numba-cuda" ]; then
+            for _ in $(seq 1 24); do
+              [ -f nvvm-warm.done ] && break
+              sleep 5
+            done
+            if [ -f nvvm-warm.done ]; then
+              echo "nvvm prewarm complete"
+            else
+              echo "nvvm prewarm incomplete after 120s"
+              cat nvvm-warm.err 2>/dev/null || true
+            fi
+          fi
           nvidia-smi --query-gpu=timestamp,utilization.gpu,utilization.memory,clocks.sm,power.draw \
             --format=csv -l 1 > gpu-util.csv 2>&1 &
           UTIL_PID=$!

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -552,12 +552,16 @@ jobs:
           CUBIE_PROBE_TIMING_FILE: ${{ github.workspace }}/probe-timings.txt
         run: |
           set +e
+          nvidia-smi --query-gpu=timestamp,utilization.gpu,utilization.memory,clocks.sm,power.draw \
+            --format=csv -l 1 > gpu-util.csv 2>&1 &
+          UTIL_PID=$!
           python -m coverage run -m pytest \
             -m "not specific_algos and not sim_only" \
             -p tests.precompile_plugin -p tests.banked_plugin \
             -n logical --no-cov --pytest-durations=25 \
             --junitxml=pytest-gpu.xml
           status=$?
+          kill $UTIL_PID 2>/dev/null || true
           coverage_status=0
           python -m coverage combine || coverage_status=$?
           if (( coverage_status == 0 )); then
@@ -574,7 +578,10 @@ jobs:
       - name: Report fixture probe timings
         if: always()
         shell: bash
-        run: cat probe-timings.txt || true
+        run: |
+          cat probe-timings.txt || true
+          echo "=== gpu utilization (1 Hz) ==="
+          cat gpu-util.csv || true
 
       # The artifact service occasionally answers CreateArtifact with a
       # non-JSON error page and the action's five internal retries all

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -81,22 +81,7 @@ jobs:
       # run 3.11 where the numba-cuda lanes run 3.10.
       matrix:
         include:
-          - {os: linux, python-version: "3.10", cuda: "12", extra: dev12, backend: numba-cuda}
-          - {os: linux, python-version: "3.10", cuda: "13", extra: dev13, backend: numba-cuda}
-          - {os: linux, python-version: "3.14", cuda: "12", extra: dev12, backend: numba-cuda}
-          - {os: linux, python-version: "3.14", cuda: "13", extra: dev13, backend: numba-cuda}
-          - {os: windows, python-version: "3.10", cuda: "12", extra: dev12, backend: numba-cuda}
-          - {os: windows, python-version: "3.10", cuda: "13", extra: dev13, backend: numba-cuda}
           - {os: windows, python-version: "3.14", cuda: "12", extra: dev12, backend: numba-cuda}
-          - {os: windows, python-version: "3.14", cuda: "13", extra: dev13, backend: numba-cuda}
-          - {os: linux, python-version: "3.11", cuda: "12", extra: dev-mlir12, backend: mlir}
-          - {os: linux, python-version: "3.11", cuda: "13", extra: dev-mlir13, backend: mlir}
-          - {os: linux, python-version: "3.14", cuda: "12", extra: dev-mlir12, backend: mlir}
-          - {os: linux, python-version: "3.14", cuda: "13", extra: dev-mlir13, backend: mlir}
-          - {os: windows, python-version: "3.11", cuda: "12", extra: dev-mlir12, backend: mlir}
-          - {os: windows, python-version: "3.11", cuda: "13", extra: dev-mlir13, backend: mlir}
-          - {os: windows, python-version: "3.14", cuda: "12", extra: dev-mlir12, backend: mlir}
-          - {os: windows, python-version: "3.14", cuda: "13", extra: dev-mlir13, backend: mlir}
     runs-on: ${{ matrix.os == 'linux' && 'ubuntu-latest' || 'windows-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -259,22 +244,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: linux, python-version: "3.10", cuda: "12", extra: dev12, backend: numba-cuda}
-          - {os: linux, python-version: "3.10", cuda: "13", extra: dev13, backend: numba-cuda}
-          - {os: linux, python-version: "3.14", cuda: "12", extra: dev12, backend: numba-cuda}
-          - {os: linux, python-version: "3.14", cuda: "13", extra: dev13, backend: numba-cuda}
-          - {os: windows, python-version: "3.10", cuda: "12", extra: dev12, backend: numba-cuda}
-          - {os: windows, python-version: "3.10", cuda: "13", extra: dev13, backend: numba-cuda}
           - {os: windows, python-version: "3.14", cuda: "12", extra: dev12, backend: numba-cuda}
-          - {os: windows, python-version: "3.14", cuda: "13", extra: dev13, backend: numba-cuda}
-          - {os: linux, python-version: "3.11", cuda: "12", extra: dev-mlir12, backend: mlir}
-          - {os: linux, python-version: "3.11", cuda: "13", extra: dev-mlir13, backend: mlir}
-          - {os: linux, python-version: "3.14", cuda: "12", extra: dev-mlir12, backend: mlir}
-          - {os: linux, python-version: "3.14", cuda: "13", extra: dev-mlir13, backend: mlir}
-          - {os: windows, python-version: "3.11", cuda: "12", extra: dev-mlir12, backend: mlir}
-          - {os: windows, python-version: "3.11", cuda: "13", extra: dev-mlir13, backend: mlir}
-          - {os: windows, python-version: "3.14", cuda: "12", extra: dev-mlir12, backend: mlir}
-          - {os: windows, python-version: "3.14", cuda: "13", extra: dev-mlir13, backend: mlir}
     runs-on: ${{ matrix.os == 'linux' && 'ubuntu-latest' || 'windows-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -434,22 +404,7 @@ jobs:
       # run 3.11 where the numba-cuda lanes run 3.10.
       matrix:
         include:
-          - {os: linux, python-version: "3.10", cuda: "12", extra: dev12, backend: numba-cuda, fleet: gpu-linux}
-          - {os: linux, python-version: "3.10", cuda: "13", extra: dev13, backend: numba-cuda, fleet: gpu-linux}
-          - {os: linux, python-version: "3.14", cuda: "12", extra: dev12, backend: numba-cuda, fleet: gpu-linux}
-          - {os: linux, python-version: "3.14", cuda: "13", extra: dev13, backend: numba-cuda, fleet: gpu-linux}
-          - {os: windows, python-version: "3.10", cuda: "12", extra: dev12, backend: numba-cuda, fleet: gpu-windows}
-          - {os: windows, python-version: "3.10", cuda: "13", extra: dev13, backend: numba-cuda, fleet: gpu-windows}
           - {os: windows, python-version: "3.14", cuda: "12", extra: dev12, backend: numba-cuda, fleet: gpu-windows}
-          - {os: windows, python-version: "3.14", cuda: "13", extra: dev13, backend: numba-cuda, fleet: gpu-windows}
-          - {os: linux, python-version: "3.11", cuda: "12", extra: dev-mlir12, backend: mlir, fleet: gpu-linux}
-          - {os: linux, python-version: "3.11", cuda: "13", extra: dev-mlir13, backend: mlir, fleet: gpu-linux}
-          - {os: linux, python-version: "3.14", cuda: "12", extra: dev-mlir12, backend: mlir, fleet: gpu-linux}
-          - {os: linux, python-version: "3.14", cuda: "13", extra: dev-mlir13, backend: mlir, fleet: gpu-linux}
-          - {os: windows, python-version: "3.11", cuda: "12", extra: dev-mlir12, backend: mlir, fleet: gpu-windows}
-          - {os: windows, python-version: "3.11", cuda: "13", extra: dev-mlir13, backend: mlir, fleet: gpu-windows}
-          - {os: windows, python-version: "3.14", cuda: "12", extra: dev-mlir12, backend: mlir, fleet: gpu-windows}
-          - {os: windows, python-version: "3.14", cuda: "13", extra: dev-mlir13, backend: mlir, fleet: gpu-windows}
     runs-on: runs-on/fleet=${{ matrix.fleet }}/env=production
 
     steps:
@@ -599,7 +554,7 @@ jobs:
           python -m coverage run -m pytest \
             -m "not specific_algos and not sim_only" \
             -p tests.precompile_plugin -p tests.banked_plugin \
-            -n logical --no-cov \
+            -n logical --no-cov --pytest-durations=25 \
             --junitxml=pytest-gpu.xml
           status=$?
           coverage_status=0
@@ -654,22 +609,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: linux, python-version: "3.10", cuda: "12", backend: numba-cuda}
-          - {os: linux, python-version: "3.10", cuda: "13", backend: numba-cuda}
-          - {os: linux, python-version: "3.14", cuda: "12", backend: numba-cuda}
-          - {os: linux, python-version: "3.14", cuda: "13", backend: numba-cuda}
-          - {os: windows, python-version: "3.10", cuda: "12", backend: numba-cuda}
-          - {os: windows, python-version: "3.10", cuda: "13", backend: numba-cuda}
           - {os: windows, python-version: "3.14", cuda: "12", backend: numba-cuda}
-          - {os: windows, python-version: "3.14", cuda: "13", backend: numba-cuda}
-          - {os: linux, python-version: "3.11", cuda: "12", backend: mlir}
-          - {os: linux, python-version: "3.11", cuda: "13", backend: mlir}
-          - {os: linux, python-version: "3.14", cuda: "12", backend: mlir}
-          - {os: linux, python-version: "3.14", cuda: "13", backend: mlir}
-          - {os: windows, python-version: "3.11", cuda: "12", backend: mlir}
-          - {os: windows, python-version: "3.11", cuda: "13", backend: mlir}
-          - {os: windows, python-version: "3.14", cuda: "12", backend: mlir}
-          - {os: windows, python-version: "3.14", cuda: "13", backend: mlir}
     runs-on: ubuntu-latest
     steps:
       # codecov reads the commit and branch from this checkout.

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -549,6 +549,7 @@ jobs:
           NUMBA_CACHE_LOCATOR_CLASSES: tests.numba_cache_locator.PortableCacheLocator
           NUMBA_CPU_NAME: generic
           NUMBA_CPU_FEATURES: ""
+          CUBIE_PROBE_TIMING_FILE: ${{ github.workspace }}/probe-timings.txt
         run: |
           set +e
           python -m coverage run -m pytest \
@@ -569,6 +570,11 @@ jobs:
             exit $status
           fi
           exit $coverage_status
+
+      - name: Report fixture probe timings
+        if: always()
+        shell: bash
+        run: cat probe-timings.txt || true
 
       # The artifact service occasionally answers CreateArtifact with a
       # non-JSON error page and the action's five internal retries all

--- a/.github/workflows/ci_cuda_tests.yml
+++ b/.github/workflows/ci_cuda_tests.yml
@@ -472,11 +472,27 @@ jobs:
         if: matrix.os == 'windows' && matrix.backend == 'numba-cuda'
         shell: pwsh
         run: |
-          $code = 'from numba.cuda.cudadrv.nvvm import NVVM; NVVM(); open(''nvvm-warm.done'',''w'').write(''ok'')'
-          Start-Process -WindowStyle Hidden (Get-Command python).Source `
-            -ArgumentList ('-c "' + $code + '"') `
-            -RedirectStandardOutput nvvm-warm.log `
-            -RedirectStandardError nvvm-warm.err
+          $ws = $env:GITHUB_WORKSPACE
+          $code = @(
+            'import traceback'
+            "out = open(r'$ws\nvvm-warm.done', 'w')"
+            'try:'
+            '    from numba.cuda.cudadrv.nvvm import NVVM'
+            '    NVVM()'
+            "    out.write('ok')"
+            'except Exception:'
+            '    out.write(traceback.format_exc())'
+            'out.close()'
+          ) -join "`n"
+          Set-Content -Path "$ws\nvvm-warm.py" -Value $code
+          $p = Start-Process -WindowStyle Hidden -PassThru `
+            (Get-Command python).Source `
+            -ArgumentList ('"' + "$ws\nvvm-warm.py" + '"') `
+            -RedirectStandardOutput "$ws\nvvm-warm.log" `
+            -RedirectStandardError "$ws\nvvm-warm.err"
+          Start-Sleep 2
+          "prewarm pid=$($p.Id) exited=$($p.HasExited)"
+          if ($p.HasExited) { "exit code $($p.ExitCode)"; Get-Content "$ws\nvvm-warm.err" -ErrorAction SilentlyContinue }
 
       # Last GPU-free step: first-boot driver PnP-binding overlaps setup.
       - name: GPU sanity check
@@ -570,7 +586,7 @@ jobs:
               sleep 5
             done
             if [ -f nvvm-warm.done ]; then
-              echo "nvvm prewarm complete"
+              echo "nvvm prewarm result: $(cat nvvm-warm.done)"
             else
               echo "nvvm prewarm incomplete after 120s"
               cat nvvm-warm.err 2>/dev/null || true

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -1,6 +1,6 @@
 name: GPU first-launch probe
 
-# Defender A/B: concurrent loads of fresh nvvm DLL copies, excluded vs not.
+# Cold-EBS A/B: first-touch read then load of the baked-cache nvvm DLL.
 on:
   workflow_dispatch:
   push:
@@ -14,8 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  defender:
-    name: defender A/B (windows)
+  cold-read:
+    name: cold-read A/B (windows)
     permissions:
       contents: read
     runs-on: runs-on/fleet=gpu-windows/env=production
@@ -35,38 +35,30 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          enable-cache: true
-          cache-suffix: windows-py3.14-cuda12-numba-cuda
-          cache-dependency-glob: pyproject.toml
+          enable-cache: false
 
-      - name: Install cubie (dev12)
+      # The baked uv cache, exactly as the real Windows legs install.
+      - name: Install cubie (dev12, baked cache)
         shell: bash
-        run: uv pip install --system -e ".[dev12]"
-
-      - name: Add Defender exclusion for the treated path
-        shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force "$env:GITHUB_WORKSPACE\dll-excluded" | Out-Null
-          New-Item -ItemType Directory -Force "$env:GITHUB_WORKSPACE\dll-control" | Out-Null
-          Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE\dll-excluded"
-          "exclusions: $((Get-MpPreference).ExclusionPath -join '; ')"
-          Get-MpComputerStatus |
-            Select-Object RealTimeProtectionEnabled, AntivirusEnabled
+          export UV_CACHE_DIR='C:\uv-cache'
+          uv pip install --system -e ".[dev12]"
 
-      - name: Concurrent DLL loads, control vs excluded
+      - name: First-touch read then load of the nvvm DLL
         shell: bash
         run: |
           src=$(python -c "import glob, sys; print(glob.glob(sys.prefix + '/Lib/site-packages/nvidia/**/nvvm64*.dll', recursive=True)[0])")
           echo "source dll: $src"
           ls -la "$src"
-          cp "$src" dll-control/nvvm-copy.dll
-          cp "$src" dll-excluded/nvvm-copy.dll
-          echo "--- control: fresh copy, no exclusion"
-          export CUBIE_PROBE_DLL="$PWD/dll-control/nvvm-copy.dll"
-          time python ci/tools/first_launch_split.py fanout dll 4
-          echo "--- treated: fresh copy, excluded path"
-          export CUBIE_PROBE_DLL="$PWD/dll-excluded/nvvm-copy.dll"
-          time python ci/tools/first_launch_split.py fanout dll 4
-          echo "--- original: first touch of the installed file"
+          fsutil hardlink list "$src" || true
           export CUBIE_PROBE_DLL="$src"
+          echo "--- first touch: raw byte read"
+          time python ci/tools/first_launch_split.py read
+          echo "--- second read (hydrated)"
+          time python ci/tools/first_launch_split.py read
+          echo "--- WinDLL load after hydration"
           time python ci/tools/first_launch_split.py fanout dll 4
+          echo "--- control: fresh-written copy, first read"
+          cp "$src" nvvm-fresh-copy.dll
+          export CUBIE_PROBE_DLL="$PWD/nvvm-fresh-copy.dll"
+          time python ci/tools/first_launch_split.py read

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -133,3 +133,32 @@ jobs:
             -n 4 --no-cov -q -p tests.precompile_plugin \
             --durations=25 --durations-min=0.2 \
             || echo "coverage rc=$?"
+
+      # Same tests against the full-suite kernel-cache artifact.
+      - name: Download full-suite kernel cache
+        if: matrix.os == 'windows'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kernel-cache-windows-py3.14-cuda12-numba-cuda
+          path: full-kernel-cache
+          run-id: "30864720712"
+          repository: ${{ github.repository }}
+          github-token: ${{ github.token }}
+
+      - name: Pytest carrier with full-suite cache
+        if: matrix.os == 'windows'
+        shell: bash
+        env:
+          CUBIE_CUDA_BACKEND: numba-cuda
+          CUBIE_KERNEL_CACHE_DIR: ${{ github.workspace }}/full-kernel-cache/kernels
+          CUBIE_MAX_CACHE_ENTRIES: "0"
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          du -sh full-kernel-cache/kernels || true
+          ls full-kernel-cache/kernels | head -5 || true
+          TARGET="tests/integrated_numerical_tests/test_step_controllers.py"
+          FILTER="test_matches_cpu and pi"
+          echo "--- measured, full-suite cache"
+          time python -m pytest "$TARGET" -k "$FILTER" -n 4 --no-cov -q \
+            -p tests.precompile_plugin --durations=25 --durations-min=0.2 \
+            || echo "full-cache rc=$?"

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -44,21 +44,24 @@ jobs:
           export UV_CACHE_DIR='C:\uv-cache'
           uv pip install --system -e ".[dev12]"
 
-      - name: First-touch read then load of the nvvm DLL
+      # First-touch DLL read while parallel readers saturate the
+      # baked cache's snapshot-hydration bandwidth.
+      - name: DLL first touch under hydration load
         shell: bash
         run: |
           src=$(python -c "import glob, sys; print(glob.glob(sys.prefix + '/Lib/site-packages/nvidia/**/nvvm64*.dll', recursive=True)[0])")
           echo "source dll: $src"
-          ls -la "$src"
           fsutil hardlink list "$src" || true
+          export CUBIE_PROBE_DIR='C:\uv-cache'
+          export CUBIE_PROBE_SKIP=nvvm
+          python ci/tools/first_launch_split.py saturate &
+          SAT_PID=$!
+          sleep 2
           export CUBIE_PROBE_DLL="$src"
-          echo "--- first touch: raw byte read"
+          echo "--- first touch during saturation"
           time python ci/tools/first_launch_split.py read
-          echo "--- second read (hydrated)"
-          time python ci/tools/first_launch_split.py read
-          echo "--- WinDLL load after hydration"
+          echo "--- 4-way WinDLL during saturation"
           time python ci/tools/first_launch_split.py fanout dll 4
-          echo "--- control: fresh-written copy, first read"
-          cp "$src" nvvm-fresh-copy.dll
-          export CUBIE_PROBE_DLL="$PWD/nvvm-fresh-copy.dll"
+          echo "--- second read after saturation"
+          wait $SAT_PID
           time python ci/tools/first_launch_split.py read

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -109,8 +109,7 @@ jobs:
           echo "--- fanout solver 4"
           time python ci/tools/first_launch_split.py fanout solver 4
 
-      # Warmup compiles into the cache; measured runs are cache-hit,
-      # once without coverage and once with coverage as the CI leg.
+      # Warmup fills the kernel cache; measured runs are cache-hit.
       - name: Pytest carrier A/B (coverage vs none)
         shell: bash
         env:

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -44,8 +44,7 @@ jobs:
           export UV_CACHE_DIR='C:\uv-cache'
           uv pip install --system -e ".[dev12]"
 
-      # First-touch DLL read while parallel readers saturate the
-      # baked cache's snapshot-hydration bandwidth.
+      # First-touch DLL read while readers saturate cache hydration.
       - name: DLL first touch under hydration load
         shell: bash
         run: |

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -25,7 +25,7 @@ jobs:
           - {os: windows, fleet: gpu-windows}
           - {os: linux, fleet: gpu-linux}
     runs-on: runs-on/fleet=${{ matrix.fleet }}/env=production
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       # Actions pinned to commit SHAs: self-hosted AWS runners.
@@ -108,3 +108,29 @@ jobs:
           done
           echo "--- fanout solver 4"
           time python ci/tools/first_launch_split.py fanout solver 4
+
+      # Warmup compiles into the cache; measured runs are cache-hit,
+      # once without coverage and once with coverage as the CI leg.
+      - name: Pytest carrier A/B (coverage vs none)
+        shell: bash
+        env:
+          CUBIE_CUDA_BACKEND: numba-cuda
+          CUBIE_KERNEL_CACHE_DIR: ${{ github.workspace }}/probe-kernels
+          CUBIE_MAX_CACHE_ENTRIES: "0"
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          TARGET="tests/integrated_numerical_tests/test_step_controllers.py"
+          FILTER="test_matches_cpu and pi"
+          echo "--- warmup (compiles, fills the kernel cache)"
+          time python -m pytest "$TARGET" -k "$FILTER" -n 4 --no-cov -q \
+            || echo "warmup rc=$?"
+          echo "--- measured, no coverage"
+          time python -m pytest "$TARGET" -k "$FILTER" -n 4 --no-cov -q \
+            -p tests.precompile_plugin --durations=25 --durations-min=0.2 \
+            || echo "no-coverage rc=$?"
+          echo "--- measured, coverage as in CI"
+          export COVERAGE_PROCESS_START=${{ github.workspace }}/pyproject.toml
+          time python -m coverage run -m pytest "$TARGET" -k "$FILTER" \
+            -n 4 --no-cov -q -p tests.precompile_plugin \
+            --durations=25 --durations-min=0.2 \
+            || echo "coverage rc=$?"

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -94,3 +94,17 @@ jobs:
             echo "--- fanout $spec"
             time python ci/tools/first_launch_split.py fanout $spec
           done
+
+      # First run compiles and fills the disk cache; the rest hit it.
+      - name: Solver probes (cached-kernel path)
+        shell: bash
+        env:
+          CUBIE_CUDA_BACKEND: numba-cuda
+          CUBIE_CACHE_DIR: ${{ github.workspace }}/probe-cache
+        run: |
+          for i in 1 2 3; do
+            echo "--- solver probe $i"
+            time python ci/tools/first_launch_split.py solver
+          done
+          echo "--- fanout solver 4"
+          time python ci/tools/first_launch_split.py fanout solver 4

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -1,6 +1,6 @@
 name: GPU first-launch probe
 
-# Phase-splits a fresh process's first CUDA launch per stack layer.
+# Defender A/B: concurrent loads of fresh nvvm DLL copies, excluded vs not.
 on:
   workflow_dispatch:
   push:
@@ -14,18 +14,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  probe:
-    name: probe (${{ matrix.os }})
+  defender:
+    name: defender A/B (windows)
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - {os: windows, fleet: gpu-windows}
-          - {os: linux, fleet: gpu-linux}
-    runs-on: runs-on/fleet=${{ matrix.fleet }}/env=production
-    timeout-minutes: 45
+    runs-on: runs-on/fleet=gpu-windows/env=production
+    timeout-minutes: 20
 
     steps:
       # Actions pinned to commit SHAs: self-hosted AWS runners.
@@ -33,173 +27,46 @@ jobs:
         with:
           persist-credentials: false
 
-      # Same driver-readiness poll as ci_cuda_tests.yml.
-      - name: GPU sanity check
-        shell: bash
-        run: |
-          for attempt in $(seq 1 36); do
-            if nvidia-smi; then
-              exit 0
-            fi
-            command -v pnputil.exe >/dev/null 2>&1 && pnputil.exe /scan-devices || true
-            echo "nvidia-smi not ready (attempt ${attempt}/36); retrying in 5s"
-            sleep 5
-          done
-          echo "GPU driver never became available" >&2
-          exit 1
-
-      - name: Driver identity
-        shell: bash
-        run: |
-          nvidia-smi --query-gpu=name,driver_version,driver_model.current --format=csv || true
-
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
 
-      # Before any CUDA package install: driver-path cost alone.
-      - name: Driver-level probes (pre-install)
-        shell: bash
-        run: |
-          for i in 1 2 3; do
-            echo "--- driver probe $i"
-            time python ci/tools/first_launch_split.py driver
-          done
-          echo "--- driver fanout 8"
-          time python ci/tools/first_launch_split.py fanout driver 8
-
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
-          cache-suffix: ${{ matrix.os }}-py3.14-cuda12-numba-cuda
+          cache-suffix: windows-py3.14-cuda12-numba-cuda
           cache-dependency-glob: pyproject.toml
 
       - name: Install cubie (dev12)
         shell: bash
         run: uv pip install --system -e ".[dev12]"
 
-      # Each mode twice; a final driver probe after GPU activity.
-      - name: Stack-level probes
-        shell: bash
-        env:
-          CUBIE_CUDA_BACKEND: numba-cuda
+      - name: Add Defender exclusion for the treated path
+        shell: pwsh
         run: |
-          for mode in numba numba cupy cupy cubie cubie kernel kernel driver; do
-            echo "--- $mode probe"
-            time python ci/tools/first_launch_split.py "$mode"
-          done
-          for spec in "numba 8" "kernel 4" "kernel 8"; do
-            echo "--- fanout $spec"
-            time python ci/tools/first_launch_split.py fanout $spec
-          done
+          New-Item -ItemType Directory -Force "$env:GITHUB_WORKSPACE\dll-excluded" | Out-Null
+          New-Item -ItemType Directory -Force "$env:GITHUB_WORKSPACE\dll-control" | Out-Null
+          Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE\dll-excluded"
+          "exclusions: $((Get-MpPreference).ExclusionPath -join '; ')"
+          Get-MpComputerStatus |
+            Select-Object RealTimeProtectionEnabled, AntivirusEnabled
 
-      # First run compiles and fills the disk cache; the rest hit it.
-      - name: Solver probes (cached-kernel path)
+      - name: Concurrent DLL loads, control vs excluded
         shell: bash
-        env:
-          CUBIE_CUDA_BACKEND: numba-cuda
-          CUBIE_CACHE_DIR: ${{ github.workspace }}/probe-cache
         run: |
-          for i in 1 2 3; do
-            echo "--- solver probe $i"
-            time python ci/tools/first_launch_split.py solver
-          done
-          echo "--- fanout solver 4"
-          time python ci/tools/first_launch_split.py fanout solver 4
-
-      # Warmup fills the kernel cache; measured runs are cache-hit.
-      - name: Pytest carrier A/B (coverage vs none)
-        shell: bash
-        env:
-          CUBIE_CUDA_BACKEND: numba-cuda
-          CUBIE_KERNEL_CACHE_DIR: ${{ github.workspace }}/probe-kernels
-          CUBIE_MAX_CACHE_ENTRIES: "0"
-          PYTHONPATH: ${{ github.workspace }}
-        run: |
-          TARGET="tests/integrated_numerical_tests/test_step_controllers.py"
-          FILTER="test_matches_cpu and pi"
-          echo "--- warmup (compiles, fills the kernel cache)"
-          time python -m pytest "$TARGET" -k "$FILTER" -n 4 --no-cov -q \
-            || echo "warmup rc=$?"
-          echo "--- measured, no coverage"
-          time python -m pytest "$TARGET" -k "$FILTER" -n 4 --no-cov -q \
-            -p tests.precompile_plugin --durations=25 --durations-min=0.2 \
-            || echo "no-coverage rc=$?"
-          echo "--- measured, coverage as in CI"
-          export COVERAGE_PROCESS_START=${{ github.workspace }}/pyproject.toml
-          time python -m coverage run -m pytest "$TARGET" -k "$FILTER" \
-            -n 4 --no-cov -q -p tests.precompile_plugin \
-            --durations=25 --durations-min=0.2 \
-            || echo "coverage rc=$?"
-
-      # Same tests against the full-suite kernel-cache artifact.
-      - name: Download full-suite kernel cache
-        if: matrix.os == 'windows'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          pattern: kernel-cache-windows-py3.14-cuda12-numba-cuda-cc*
-          path: full-kernel-cache
-          run-id: "30864720712"
-          repository: ${{ github.repository }}
-          github-token: ${{ github.token }}
-
-      - name: Pytest carrier with full-suite cache
-        if: matrix.os == 'windows'
-        shell: bash
-        env:
-          CUBIE_CUDA_BACKEND: numba-cuda
-          CUBIE_MAX_CACHE_ENTRIES: "0"
-          PYTHONPATH: ${{ github.workspace }}
-        run: |
-          cc=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1 | tr -d ' \r')
-          root="full-kernel-cache/kernel-cache-windows-py3.14-cuda12-numba-cuda-cc${cc}"
-          export CUBIE_KERNEL_CACHE_DIR="${GITHUB_WORKSPACE}/${root}/kernels"
-          echo "cc=${cc} cache=${CUBIE_KERNEL_CACHE_DIR}"
-          du -sh "${root}/kernels" || true
-          TARGET="tests/integrated_numerical_tests/test_step_controllers.py"
-          FILTER="test_matches_cpu and pi"
-          echo "--- measured, full-suite cache"
-          time python -m pytest "$TARGET" -k "$FILTER" -n 4 --no-cov -q \
-            -p tests.precompile_plugin --durations=25 --durations-min=0.2 \
-            || echo "full-cache rc=$?"
-
-      # Cold/disabled driver JIT cache vs the warm baseline above.
-      - name: Pytest carrier with cold driver JIT cache
-        if: matrix.os == 'windows'
-        shell: bash
-        env:
-          CUBIE_CUDA_BACKEND: numba-cuda
-          CUBIE_KERNEL_CACHE_DIR: ${{ github.workspace }}/probe-kernels
-          CUBIE_MAX_CACHE_ENTRIES: "0"
-          PYTHONPATH: ${{ github.workspace }}
-          CUBIE_PROBE_TIMING_FILE: ${{ github.workspace }}/probe-arm-timings.txt
-        run: |
-          TARGET="tests/integrated_numerical_tests/test_step_controllers.py"
-          FILTER="test_matches_cpu and pi"
-          for base in "$LOCALAPPDATA" "$APPDATA" "$USERPROFILE/AppData/Local"; do
-            du -sh "$base/NVIDIA/ComputeCache" 2>/dev/null \
-              && echo "jit cache at $base/NVIDIA/ComputeCache"
-          done
-          echo "--- arm 1: JIT cache disabled"
-          export CUDA_CACHE_DISABLE=1
-          time python -m pytest "$TARGET" -k "$FILTER" \
-            -n 4 --no-cov -q -p tests.precompile_plugin \
-            --durations=25 --durations-min=0.2 || echo "arm1 rc=$?"
-          unset CUDA_CACHE_DISABLE
-          echo "=== arm 1 phases ==="
-          cat probe-arm-timings.txt || true
-          rm -f probe-arm-timings.txt
-          echo "--- arm 2: JIT cache deleted, caching enabled"
-          rm -rf "$LOCALAPPDATA/NVIDIA/ComputeCache" \
-            "$APPDATA/NVIDIA/ComputeCache" 2>/dev/null || true
-          time python -m pytest "$TARGET" -k "$FILTER" -n 4 --no-cov -q \
-            -p tests.precompile_plugin --durations=25 --durations-min=0.2 \
-            || echo "arm2 rc=$?"
-          echo "=== arm 2 phases ==="
-          cat probe-arm-timings.txt || true
-          for base in "$LOCALAPPDATA" "$APPDATA"; do
-            du -sh "$base/NVIDIA/ComputeCache" 2>/dev/null \
-              && echo "jit cache regrown at $base/NVIDIA/ComputeCache"
-          done
+          src=$(python -c "import glob, sys; print(glob.glob(sys.prefix + '/Lib/site-packages/nvidia/**/nvvm64*.dll', recursive=True)[0])")
+          echo "source dll: $src"
+          ls -la "$src"
+          cp "$src" dll-control/nvvm-copy.dll
+          cp "$src" dll-excluded/nvvm-copy.dll
+          echo "--- control: fresh copy, no exclusion"
+          export CUBIE_PROBE_DLL="$PWD/dll-control/nvvm-copy.dll"
+          time python ci/tools/first_launch_split.py fanout dll 4
+          echo "--- treated: fresh copy, excluded path"
+          export CUBIE_PROBE_DLL="$PWD/dll-excluded/nvvm-copy.dll"
+          time python ci/tools/first_launch_split.py fanout dll 4
+          echo "--- original: first touch of the installed file"
+          export CUBIE_PROBE_DLL="$src"
+          time python ci/tools/first_launch_split.py fanout dll 4

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -66,6 +66,8 @@ jobs:
             echo "--- driver probe $i"
             time python ci/tools/first_launch_split.py driver
           done
+          echo "--- driver fanout 8"
+          time python ci/tools/first_launch_split.py fanout driver 8
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -84,7 +86,11 @@ jobs:
         env:
           CUBIE_CUDA_BACKEND: numba-cuda
         run: |
-          for mode in numba numba cupy cupy cubie cubie driver; do
+          for mode in numba numba cupy cupy cubie cubie kernel kernel driver; do
             echo "--- $mode probe"
             time python ci/tools/first_launch_split.py "$mode"
+          done
+          for spec in "numba 8" "kernel 4" "kernel 8"; do
+            echo "--- fanout $spec"
+            time python ci/tools/first_launch_split.py fanout $spec
           done

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -139,7 +139,7 @@ jobs:
         if: matrix.os == 'windows'
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kernel-cache-windows-py3.14-cuda12-numba-cuda
+          pattern: kernel-cache-windows-py3.14-cuda12-numba-cuda-cc*
           path: full-kernel-cache
           run-id: "30864720712"
           repository: ${{ github.repository }}
@@ -150,12 +150,14 @@ jobs:
         shell: bash
         env:
           CUBIE_CUDA_BACKEND: numba-cuda
-          CUBIE_KERNEL_CACHE_DIR: ${{ github.workspace }}/full-kernel-cache/kernels
           CUBIE_MAX_CACHE_ENTRIES: "0"
           PYTHONPATH: ${{ github.workspace }}
         run: |
-          du -sh full-kernel-cache/kernels || true
-          ls full-kernel-cache/kernels | head -5 || true
+          cc=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1 | tr -d ' \r')
+          root="full-kernel-cache/kernel-cache-windows-py3.14-cuda12-numba-cuda-cc${cc}"
+          export CUBIE_KERNEL_CACHE_DIR="${GITHUB_WORKSPACE}/${root}/kernels"
+          echo "cc=${cc} cache=${CUBIE_KERNEL_CACHE_DIR}"
+          du -sh "${root}/kernels" || true
           TARGET="tests/integrated_numerical_tests/test_step_controllers.py"
           FILTER="test_matches_cpu and pi"
           echo "--- measured, full-suite cache"

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -1,0 +1,100 @@
+name: GPU first-launch probe
+
+# Diagnostic for the ~12s per-process first-launch cost on the Windows
+# CI GPU legs (local Windows: 0.4s; Linux CI: 1-2s). Runs the phase
+# split at three layers, each in a fresh process: raw driver (ctypes,
+# before any CUDA package is installed), numba.cuda, cupy, and cubie.
+# The Linux leg runs the identical script as the contrast.
+on:
+  workflow_dispatch:
+  push:
+    branches: ["ci/gpu-first-launch-probe*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gpu-probe-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: probe (${{ matrix.os }})
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {os: windows, fleet: gpu-windows}
+          - {os: linux, fleet: gpu-linux}
+    runs-on: runs-on/fleet=${{ matrix.fleet }}/env=production
+    timeout-minutes: 30
+
+    steps:
+      # Pinned to commit SHAs: self-hosted AWS runners (see
+      # ci_cuda_tests.yml for the rationale).
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Same poll as ci_cuda_tests.yml: the baked GRID driver PnP-binds
+      # asynchronously on first boot atop a different GPU family.
+      - name: GPU sanity check
+        shell: bash
+        run: |
+          for attempt in $(seq 1 36); do
+            if nvidia-smi; then
+              exit 0
+            fi
+            command -v pnputil.exe >/dev/null 2>&1 && pnputil.exe /scan-devices || true
+            echo "nvidia-smi not ready (attempt ${attempt}/36); retrying in 5s"
+            sleep 5
+          done
+          echo "GPU driver never became available" >&2
+          exit 1
+
+      - name: Driver identity
+        shell: bash
+        run: |
+          nvidia-smi --query-gpu=name,driver_version,driver_model.current --format=csv || true
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.14"
+
+      # Pure ctypes against the driver library: no CUDA Python packages
+      # are installed yet, so whatever cost shows here is the driver
+      # path alone. Three fresh processes measure the per-process cost.
+      - name: Driver-level probes (pre-install)
+        shell: bash
+        run: |
+          for i in 1 2 3; do
+            echo "--- driver probe $i"
+            time python ci/tools/first_launch_split.py driver
+          done
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: true
+          cache-suffix: ${{ matrix.os }}-py3.14-cuda12-numba-cuda
+          cache-dependency-glob: pyproject.toml
+
+      - name: Install cubie (dev12)
+        shell: bash
+        run: uv pip install --system -e ".[dev12]"
+
+      # Each mode twice (per-process repeatability), then one more
+      # driver probe to show whether heavy prior GPU activity on the
+      # instance changes the raw driver cost.
+      - name: Stack-level probes
+        shell: bash
+        env:
+          CUBIE_CUDA_BACKEND: numba-cuda
+        run: |
+          for mode in numba numba cupy cupy cubie cubie driver; do
+            echo "--- $mode probe"
+            time python ci/tools/first_launch_split.py "$mode"
+          done

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -64,3 +64,7 @@ jobs:
           echo "--- second read after saturation"
           wait $SAT_PID
           time python ci/tools/first_launch_split.py read
+          echo "--- 4-way WinDLL under 4x2800MB memory balloons"
+          export CUBIE_PROBE_BALLOON_MB=2800
+          time python ci/tools/first_launch_split.py fanout dll 4
+          unset CUBIE_PROBE_BALLOON_MB

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -164,3 +164,42 @@ jobs:
           time python -m pytest "$TARGET" -k "$FILTER" -n 4 --no-cov -q \
             -p tests.precompile_plugin --durations=25 --durations-min=0.2 \
             || echo "full-cache rc=$?"
+
+      # Cold/disabled driver JIT cache vs the warm baseline above.
+      - name: Pytest carrier with cold driver JIT cache
+        if: matrix.os == 'windows'
+        shell: bash
+        env:
+          CUBIE_CUDA_BACKEND: numba-cuda
+          CUBIE_KERNEL_CACHE_DIR: ${{ github.workspace }}/probe-kernels
+          CUBIE_MAX_CACHE_ENTRIES: "0"
+          PYTHONPATH: ${{ github.workspace }}
+          CUBIE_PROBE_TIMING_FILE: ${{ github.workspace }}/probe-arm-timings.txt
+        run: |
+          TARGET="tests/integrated_numerical_tests/test_step_controllers.py"
+          FILTER="test_matches_cpu and pi"
+          for base in "$LOCALAPPDATA" "$APPDATA" "$USERPROFILE/AppData/Local"; do
+            du -sh "$base/NVIDIA/ComputeCache" 2>/dev/null \
+              && echo "jit cache at $base/NVIDIA/ComputeCache"
+          done
+          echo "--- arm 1: JIT cache disabled"
+          export CUDA_CACHE_DISABLE=1
+          time python -m pytest "$TARGET" -k "$FILTER" \
+            -n 4 --no-cov -q -p tests.precompile_plugin \
+            --durations=25 --durations-min=0.2 || echo "arm1 rc=$?"
+          unset CUDA_CACHE_DISABLE
+          echo "=== arm 1 phases ==="
+          cat probe-arm-timings.txt || true
+          rm -f probe-arm-timings.txt
+          echo "--- arm 2: JIT cache deleted, caching enabled"
+          rm -rf "$LOCALAPPDATA/NVIDIA/ComputeCache" \
+            "$APPDATA/NVIDIA/ComputeCache" 2>/dev/null || true
+          time python -m pytest "$TARGET" -k "$FILTER" -n 4 --no-cov -q \
+            -p tests.precompile_plugin --durations=25 --durations-min=0.2 \
+            || echo "arm2 rc=$?"
+          echo "=== arm 2 phases ==="
+          cat probe-arm-timings.txt || true
+          for base in "$LOCALAPPDATA" "$APPDATA"; do
+            du -sh "$base/NVIDIA/ComputeCache" 2>/dev/null \
+              && echo "jit cache regrown at $base/NVIDIA/ComputeCache"
+          done

--- a/.github/workflows/gpu_probe.yml
+++ b/.github/workflows/gpu_probe.yml
@@ -1,10 +1,6 @@
 name: GPU first-launch probe
 
-# Diagnostic for the ~12s per-process first-launch cost on the Windows
-# CI GPU legs (local Windows: 0.4s; Linux CI: 1-2s). Runs the phase
-# split at three layers, each in a fresh process: raw driver (ctypes,
-# before any CUDA package is installed), numba.cuda, cupy, and cubie.
-# The Linux leg runs the identical script as the contrast.
+# Phase-splits a fresh process's first CUDA launch per stack layer.
 on:
   workflow_dispatch:
   push:
@@ -32,14 +28,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      # Pinned to commit SHAs: self-hosted AWS runners (see
-      # ci_cuda_tests.yml for the rationale).
+      # Actions pinned to commit SHAs: self-hosted AWS runners.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      # Same poll as ci_cuda_tests.yml: the baked GRID driver PnP-binds
-      # asynchronously on first boot atop a different GPU family.
+      # Same driver-readiness poll as ci_cuda_tests.yml.
       - name: GPU sanity check
         shell: bash
         run: |
@@ -64,9 +58,7 @@ jobs:
         with:
           python-version: "3.14"
 
-      # Pure ctypes against the driver library: no CUDA Python packages
-      # are installed yet, so whatever cost shows here is the driver
-      # path alone. Three fresh processes measure the per-process cost.
+      # Before any CUDA package install: driver-path cost alone.
       - name: Driver-level probes (pre-install)
         shell: bash
         run: |
@@ -86,9 +78,7 @@ jobs:
         shell: bash
         run: uv pip install --system -e ".[dev12]"
 
-      # Each mode twice (per-process repeatability), then one more
-      # driver probe to show whether heavy prior GPU activity on the
-      # instance changes the raw driver cost.
+      # Each mode twice; a final driver probe after GPU activity.
       - name: Stack-level probes
         shell: bash
         env:

--- a/ci/tools/first_launch_split.py
+++ b/ci/tools/first_launch_split.py
@@ -258,13 +258,18 @@ def probe_saturate():
 def probe_dll():
     """Time a ctypes load of the library named by CUBIE_PROBE_DLL."""
     path = os.environ["CUBIE_PROBE_DLL"]
+    balloon_mb = int(os.environ.get("CUBIE_PROBE_BALLOON_MB", "0"))
+    balloon = bytearray(balloon_mb << 20) if balloon_mb else None
     t0 = perf_counter()
     if sys.platform == "win32":
         ctypes.WinDLL(path)
     else:
         ctypes.CDLL(path)
     t1 = perf_counter()
-    print(f"dll: load={t1 - t0:.3f}s path={path}")
+    print(
+        f"dll: load={t1 - t0:.3f}s balloon_mb={balloon_mb} path={path}"
+    )
+    del balloon
 
 
 PROBES = {

--- a/ci/tools/first_launch_split.py
+++ b/ci/tools/first_launch_split.py
@@ -1,0 +1,161 @@
+"""Split a fresh process's first CUDA launch cost into phases.
+
+Each invocation is one fresh process timing one layer of the stack;
+run it repeatedly to measure the per-process cost. Modes:
+
+- ``driver``: ctypes against the CUDA driver library directly (no
+  Python CUDA packages needed): library load, cuInit, device get,
+  primary-context retain, first allocation, first copies.
+- ``numba``: ``numba.cuda`` import, context, first transfer.
+- ``cupy``: ``cupy`` import, runtime query, first allocation.
+- ``cubie``: ``import cubie`` (the memory manager's device probe
+  creates the context during import), then first transfer.
+"""
+import ctypes
+import sys
+from time import perf_counter
+
+
+def _fail(name, detail):
+    print(f"{name} failed: {detail}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _check(return_code, name):
+    if return_code != 0:
+        _fail(name, f"CUresult {return_code}")
+
+
+def probe_driver():
+    """Time the raw driver path with ctypes; print per-phase seconds."""
+    t0 = perf_counter()
+    if sys.platform == "win32":
+        lib = ctypes.WinDLL("nvcuda.dll")
+    else:
+        lib = ctypes.CDLL("libcuda.so.1")
+    t1 = perf_counter()
+
+    _check(lib.cuInit(0), "cuInit")
+    t2 = perf_counter()
+
+    device = ctypes.c_int()
+    get_device = lib.cuDeviceGet
+    get_device.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.c_int]
+    _check(get_device(ctypes.byref(device), 0), "cuDeviceGet")
+    t3 = perf_counter()
+
+    context = ctypes.c_void_p()
+    retain = lib.cuDevicePrimaryCtxRetain
+    retain.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_int]
+    _check(retain(ctypes.byref(context), device), "cuDevicePrimaryCtxRetain")
+    set_current = lib.cuCtxSetCurrent
+    set_current.argtypes = [ctypes.c_void_p]
+    _check(set_current(context), "cuCtxSetCurrent")
+    t4 = perf_counter()
+
+    n_bytes = 4096
+    device_pointer = ctypes.c_uint64()
+    mem_alloc = lib.cuMemAlloc_v2
+    mem_alloc.argtypes = [ctypes.POINTER(ctypes.c_uint64), ctypes.c_size_t]
+    _check(mem_alloc(ctypes.byref(device_pointer), n_bytes), "cuMemAlloc")
+    t5 = perf_counter()
+
+    host_buffer = (ctypes.c_ubyte * n_bytes)()
+    host_to_device = lib.cuMemcpyHtoD_v2
+    host_to_device.argtypes = [
+        ctypes.c_uint64, ctypes.c_void_p, ctypes.c_size_t
+    ]
+    _check(
+        host_to_device(device_pointer, host_buffer, n_bytes),
+        "cuMemcpyHtoD",
+    )
+    t6 = perf_counter()
+
+    device_to_host = lib.cuMemcpyDtoH_v2
+    device_to_host.argtypes = [
+        ctypes.c_void_p, ctypes.c_uint64, ctypes.c_size_t
+    ]
+    _check(
+        device_to_host(host_buffer, device_pointer, n_bytes),
+        "cuMemcpyDtoH",
+    )
+    t7 = perf_counter()
+
+    print(
+        f"driver: lib_load={t1 - t0:.3f}s cuinit={t2 - t1:.3f}s "
+        f"device_get={t3 - t2:.3f}s primary_ctx={t4 - t3:.3f}s "
+        f"first_alloc={t5 - t4:.3f}s h2d={t6 - t5:.3f}s "
+        f"d2h={t7 - t6:.3f}s total={t7 - t0:.3f}s"
+    )
+
+
+def probe_numba():
+    """Time numba.cuda import, context creation, and first transfer."""
+    from numpy import zeros
+    host_array = zeros(8)
+    t0 = perf_counter()
+    from numba import cuda
+    t1 = perf_counter()
+    cuda.current_context()
+    t2 = perf_counter()
+    device_array = cuda.to_device(host_array)
+    t3 = perf_counter()
+    device_array.copy_to_host()
+    t4 = perf_counter()
+    print(
+        f"numba: import={t1 - t0:.3f}s context={t2 - t1:.3f}s "
+        f"to_device={t3 - t2:.3f}s copy_back={t4 - t3:.3f}s "
+        f"total={t4 - t0:.3f}s"
+    )
+
+
+def probe_cupy():
+    """Time cupy import, runtime query, and first pool allocation."""
+    import numpy  # noqa: F401  (untimed: shared with every mode)
+    t0 = perf_counter()
+    import cupy
+    t1 = perf_counter()
+    cupy.cuda.runtime.getDeviceCount()
+    t2 = perf_counter()
+    array = cupy.zeros(8)
+    cupy.cuda.Device().synchronize()
+    t3 = perf_counter()
+    array.get()
+    t4 = perf_counter()
+    print(
+        f"cupy: import={t1 - t0:.3f}s device_count={t2 - t1:.3f}s "
+        f"first_alloc={t3 - t2:.3f}s copy_back={t4 - t3:.3f}s "
+        f"total={t4 - t0:.3f}s"
+    )
+
+
+def probe_cubie():
+    """Time cubie import (context comes up inside) and first transfer."""
+    from numpy import zeros
+    host_array = zeros(8)
+    t0 = perf_counter()
+    import cubie  # noqa: F401
+    t1 = perf_counter()
+    from cubie.cuda_simsafe import cuda
+    device_array = cuda.to_device(host_array)
+    t2 = perf_counter()
+    device_array.copy_to_host()
+    t3 = perf_counter()
+    print(
+        f"cubie: import={t1 - t0:.3f}s to_device={t2 - t1:.3f}s "
+        f"copy_back={t3 - t2:.3f}s total={t3 - t0:.3f}s"
+    )
+
+
+PROBES = {
+    "driver": probe_driver,
+    "numba": probe_numba,
+    "cupy": probe_cupy,
+    "cubie": probe_cubie,
+}
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] not in PROBES:
+        _fail("usage", f"first_launch_split.py {{{'|'.join(PROBES)}}}")
+    PROBES[sys.argv[1]]()

--- a/ci/tools/first_launch_split.py
+++ b/ci/tools/first_launch_split.py
@@ -1,10 +1,12 @@
 """Time one layer of a fresh process's first CUDA launch, in phases.
 
 Modes: ``driver`` (ctypes, needs no CUDA packages), ``numba``,
-``cupy``, ``cubie``. One invocation is one process; repeat for
-per-process cost.
+``cupy``, ``cubie``, ``kernel``. One invocation is one process;
+repeat for per-process cost. ``fanout <mode> <n>`` starts ``n``
+fresh processes concurrently and prints each one's phase line.
 """
 import ctypes
+import subprocess
 import sys
 from time import perf_counter
 
@@ -140,15 +142,73 @@ def probe_cubie():
     )
 
 
+def probe_kernel():
+    """Time context, eager kernel compile, first launch, and sync."""
+    from numpy import zeros
+    host_array = zeros(8)
+    t0 = perf_counter()
+    from numba import cuda
+    t1 = perf_counter()
+    cuda.current_context()
+    device_array = cuda.to_device(host_array)
+    t2 = perf_counter()
+
+    @cuda.jit("void(float64[::1])")
+    def _bump(array):  # pragma: no cover
+        index = cuda.grid(1)
+        if index < array.size:
+            array[index] += 1.0
+
+    t3 = perf_counter()
+    _bump[1, 32](device_array)
+    t4 = perf_counter()
+    cuda.synchronize()
+    device_array.copy_to_host()
+    t5 = perf_counter()
+    print(
+        f"kernel: import={t1 - t0:.3f}s context={t2 - t1:.3f}s "
+        f"compile={t3 - t2:.3f}s launch={t4 - t3:.3f}s "
+        f"sync={t5 - t4:.3f}s total={t5 - t0:.3f}s"
+    )
+
+
+def fanout(mode, count):
+    """Start count fresh probe processes at once; print each output."""
+    t0 = perf_counter()
+    children = [
+        subprocess.Popen(
+            [sys.executable, __file__, mode],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        for _ in range(count)
+    ]
+    status = 0
+    for index, child in enumerate(children):
+        output, _ = child.communicate()
+        elapsed = perf_counter() - t0
+        status |= child.returncode
+        print(f"[{index}] done_at={elapsed:.3f}s {output.strip()}")
+    sys.exit(status)
+
+
 PROBES = {
     "driver": probe_driver,
     "numba": probe_numba,
     "cupy": probe_cupy,
     "cubie": probe_cubie,
+    "kernel": probe_kernel,
 }
 
 
 if __name__ == "__main__":
+    if len(sys.argv) == 4 and sys.argv[1] == "fanout":
+        fanout(sys.argv[2], int(sys.argv[3]))
     if len(sys.argv) != 2 or sys.argv[1] not in PROBES:
-        _fail("usage", f"first_launch_split.py {{{'|'.join(PROBES)}}}")
+        _fail(
+            "usage",
+            f"first_launch_split.py {{{'|'.join(PROBES)}}} "
+            "| fanout <mode> <n>",
+        )
     PROBES[sys.argv[1]]()

--- a/ci/tools/first_launch_split.py
+++ b/ci/tools/first_launch_split.py
@@ -221,6 +221,40 @@ def probe_read():
     print(f"read: load={t1 - t0:.3f}s bytes={n_bytes} path={path}")
 
 
+def probe_saturate():
+    """Read every large file under CUBIE_PROBE_DIR with 8 threads."""
+    from concurrent.futures import ThreadPoolExecutor
+    root = os.environ["CUBIE_PROBE_DIR"]
+    skip = os.environ.get("CUBIE_PROBE_SKIP", "\x00")
+    paths = []
+    for dirpath, _, names in os.walk(root):
+        for name in names:
+            path = os.path.join(dirpath, name)
+            try:
+                large = os.path.getsize(path) > 4 * 1024 * 1024
+            except OSError:
+                continue
+            if large and skip not in path.lower():
+                paths.append(path)
+
+    def _read(path):
+        try:
+            with open(path, "rb") as handle:
+                return len(handle.read())
+        except OSError:
+            return 0
+
+    t0 = perf_counter()
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        total = sum(pool.map(_read, paths))
+    t1 = perf_counter()
+    rate = total / (t1 - t0) / 1e6 if t1 > t0 else 0.0
+    print(
+        f"saturate: files={len(paths)} mb={total / 1e6:.0f} "
+        f"seconds={t1 - t0:.1f} mb_per_s={rate:.0f}"
+    )
+
+
 def probe_dll():
     """Time a ctypes load of the library named by CUBIE_PROBE_DLL."""
     path = os.environ["CUBIE_PROBE_DLL"]
@@ -242,6 +276,7 @@ PROBES = {
     "solver": probe_solver,
     "dll": probe_dll,
     "read": probe_read,
+    "saturate": probe_saturate,
 }
 
 

--- a/ci/tools/first_launch_split.py
+++ b/ci/tools/first_launch_split.py
@@ -187,12 +187,36 @@ def fanout(mode, count):
     sys.exit(status)
 
 
+def probe_solver():
+    """Time cubie import, system build, first solve, second solve."""
+    t0 = perf_counter()
+    from cubie import create_ODE_system, solve_ivp
+    t1 = perf_counter()
+    system = create_ODE_system(
+        dxdt=["dx = -k * x"],
+        states={"x": 1.0},
+        parameters={"k": 0.5},
+        name="first_launch_probe",
+    )
+    t2 = perf_counter()
+    solve_ivp(system, y0={"x": 1.0}, duration=0.1, dt=0.01)
+    t3 = perf_counter()
+    solve_ivp(system, y0={"x": 2.0}, duration=0.1, dt=0.01)
+    t4 = perf_counter()
+    print(
+        f"solver: import={t1 - t0:.3f}s build={t2 - t1:.3f}s "
+        f"first_solve={t3 - t2:.3f}s second_solve={t4 - t3:.3f}s "
+        f"total={t4 - t0:.3f}s"
+    )
+
+
 PROBES = {
     "driver": probe_driver,
     "numba": probe_numba,
     "cupy": probe_cupy,
     "cubie": probe_cubie,
     "kernel": probe_kernel,
+    "solver": probe_solver,
 }
 
 

--- a/ci/tools/first_launch_split.py
+++ b/ci/tools/first_launch_split.py
@@ -1,10 +1,4 @@
-"""Time one layer of a fresh process's first CUDA launch, in phases.
-
-Modes: ``driver`` (ctypes, needs no CUDA packages), ``numba``,
-``cupy``, ``cubie``, ``kernel``. One invocation is one process;
-repeat for per-process cost. ``fanout <mode> <n>`` starts ``n``
-fresh processes concurrently and prints each one's phase line.
-"""
+"""Phase-time a fresh process's first CUDA launch at one stack layer."""
 import ctypes
 import subprocess
 import sys

--- a/ci/tools/first_launch_split.py
+++ b/ci/tools/first_launch_split.py
@@ -211,6 +211,16 @@ def probe_solver():
     )
 
 
+def probe_read():
+    """Time a raw byte read of the file named by CUBIE_PROBE_DLL."""
+    path = os.environ["CUBIE_PROBE_DLL"]
+    t0 = perf_counter()
+    with open(path, "rb") as handle:
+        n_bytes = len(handle.read())
+    t1 = perf_counter()
+    print(f"read: load={t1 - t0:.3f}s bytes={n_bytes} path={path}")
+
+
 def probe_dll():
     """Time a ctypes load of the library named by CUBIE_PROBE_DLL."""
     path = os.environ["CUBIE_PROBE_DLL"]
@@ -231,6 +241,7 @@ PROBES = {
     "kernel": probe_kernel,
     "solver": probe_solver,
     "dll": probe_dll,
+    "read": probe_read,
 }
 
 

--- a/ci/tools/first_launch_split.py
+++ b/ci/tools/first_launch_split.py
@@ -1,5 +1,6 @@
 """Phase-time a fresh process's first CUDA launch at one stack layer."""
 import ctypes
+import os
 import subprocess
 import sys
 from time import perf_counter
@@ -210,6 +211,18 @@ def probe_solver():
     )
 
 
+def probe_dll():
+    """Time a ctypes load of the library named by CUBIE_PROBE_DLL."""
+    path = os.environ["CUBIE_PROBE_DLL"]
+    t0 = perf_counter()
+    if sys.platform == "win32":
+        ctypes.WinDLL(path)
+    else:
+        ctypes.CDLL(path)
+    t1 = perf_counter()
+    print(f"dll: load={t1 - t0:.3f}s path={path}")
+
+
 PROBES = {
     "driver": probe_driver,
     "numba": probe_numba,
@@ -217,6 +230,7 @@ PROBES = {
     "cubie": probe_cubie,
     "kernel": probe_kernel,
     "solver": probe_solver,
+    "dll": probe_dll,
 }
 
 

--- a/ci/tools/first_launch_split.py
+++ b/ci/tools/first_launch_split.py
@@ -1,15 +1,8 @@
-"""Split a fresh process's first CUDA launch cost into phases.
+"""Time one layer of a fresh process's first CUDA launch, in phases.
 
-Each invocation is one fresh process timing one layer of the stack;
-run it repeatedly to measure the per-process cost. Modes:
-
-- ``driver``: ctypes against the CUDA driver library directly (no
-  Python CUDA packages needed): library load, cuInit, device get,
-  primary-context retain, first allocation, first copies.
-- ``numba``: ``numba.cuda`` import, context, first transfer.
-- ``cupy``: ``cupy`` import, runtime query, first allocation.
-- ``cubie``: ``import cubie`` (the memory manager's device probe
-  creates the context during import), then first transfer.
+Modes: ``driver`` (ctypes, needs no CUDA packages), ``numba``,
+``cupy``, ``cubie``. One invocation is one process; repeat for
+per-process cost.
 """
 import ctypes
 import sys
@@ -111,7 +104,7 @@ def probe_numba():
 
 def probe_cupy():
     """Time cupy import, runtime query, and first pool allocation."""
-    import numpy  # noqa: F401  (untimed: shared with every mode)
+    import numpy  # noqa: F401  (untimed in every mode)
     t0 = perf_counter()
     import cupy
     t1 = perf_counter()
@@ -130,7 +123,7 @@ def probe_cupy():
 
 
 def probe_cubie():
-    """Time cubie import (context comes up inside) and first transfer."""
+    """Time cubie import (creates the context) and first transfer."""
     from numpy import zeros
     host_array = zeros(8)
     t0 = perf_counter()

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import attrs
 import math
+import os
 from functools import lru_cache
+from time import perf_counter
 from typing import Mapping, Optional, Union, Dict, Any, Callable
 
 import numpy as np
@@ -1716,11 +1718,21 @@ def run_controller_device_step(
     else:
         persistent_local = np.zeros(2, dtype=precision)
 
+    t0 = perf_counter()
     kernel = _controller_step_kernel(device_func)
+    t1 = perf_counter()
     kernel[1, 1](
         dt, state_arr, state_prev_arr, err, niters_val, truncated_val,
         accept, shared_scratch, persistent_local, status,
     )
+    t2 = perf_counter()
+    probe_file = os.environ.get("CUBIE_PROBE_TIMING_FILE")
+    if probe_file:
+        with open(probe_file, "a") as handle:
+            handle.write(
+                f"pid={os.getpid()} run_controller_device_step "
+                f"kernel_get={t1 - t0:.3f}s launch={t2 - t1:.3f}s\n"
+            )
     return StepResult(
         precision(dt[0]), int(accept[0]), persistent_local.copy(),
         int(status[0]),

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import attrs
 import math
 import os
+import sys
+import threading
+import traceback
 from functools import lru_cache
-from time import perf_counter, time as wall_time
+from time import perf_counter, process_time, time as wall_time
 from typing import Mapping, Optional, Union, Dict, Any, Callable
 
 import numpy as np
@@ -1735,10 +1738,27 @@ def run_controller_device_step(
         stamps.append(("h2d", perf_counter()))
         (d_dt, d_state, d_prev, d_err, d_accept,
          d_shared, d_local, d_status) = device_args
+        main_ident = threading.get_ident()
+
+        def _dump_midstall_stack():
+            frame = sys._current_frames().get(main_ident)
+            if frame is not None:
+                stack = "".join(traceback.format_stack(frame))
+                with open(probe_file, "a") as handle:
+                    handle.write(
+                        f"pid={os.getpid()} wall={wall_time():.3f} "
+                        f"midstall_stack\n{stack}\n"
+                    )
+
+        watchdog = threading.Timer(4.0, _dump_midstall_stack)
+        watchdog.start()
+        cpu_before = process_time()
         kernel[1, 1](
             d_dt, d_state, d_prev, d_err, niters_val, truncated_val,
             d_accept, d_shared, d_local, d_status,
         )
+        cpu_launch = process_time() - cpu_before
+        watchdog.cancel()
         stamps.append(("enqueue", perf_counter()))
         cuda.synchronize()
         stamps.append(("execute", perf_counter()))
@@ -1755,6 +1775,7 @@ def run_controller_device_step(
             handle.write(
                 f"pid={os.getpid()} wall={wall_time():.3f} "
                 f"step_phases {parts} "
+                f"cpu_enqueue={cpu_launch:.3f}s "
                 f"total={stamps[-1][1] - stamps[0][1]:.3f}s\n"
             )
     else:

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -4,7 +4,7 @@ import attrs
 import math
 import os
 from functools import lru_cache
-from time import perf_counter
+from time import perf_counter, time as wall_time
 from typing import Mapping, Optional, Union, Dict, Any, Callable
 
 import numpy as np
@@ -1718,20 +1718,25 @@ def run_controller_device_step(
     else:
         persistent_local = np.zeros(2, dtype=precision)
 
+    probe_file = os.environ.get("CUBIE_PROBE_TIMING_FILE")
     t0 = perf_counter()
-    kernel = _controller_step_kernel(device_func)
+    if probe_file:
+        cuda.synchronize()
     t1 = perf_counter()
+    kernel = _controller_step_kernel(device_func)
+    t2 = perf_counter()
     kernel[1, 1](
         dt, state_arr, state_prev_arr, err, niters_val, truncated_val,
         accept, shared_scratch, persistent_local, status,
     )
-    t2 = perf_counter()
-    probe_file = os.environ.get("CUBIE_PROBE_TIMING_FILE")
+    t3 = perf_counter()
     if probe_file:
         with open(probe_file, "a") as handle:
             handle.write(
-                f"pid={os.getpid()} run_controller_device_step "
-                f"kernel_get={t1 - t0:.3f}s launch={t2 - t1:.3f}s\n"
+                f"pid={os.getpid()} wall={wall_time():.3f} "
+                f"run_controller_device_step "
+                f"sync_before={t1 - t0:.3f}s "
+                f"kernel_get={t2 - t1:.3f}s launch={t3 - t2:.3f}s\n"
             )
     return StepResult(
         precision(dt[0]), int(accept[0]), persistent_local.copy(),

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1719,25 +1719,50 @@ def run_controller_device_step(
         persistent_local = np.zeros(2, dtype=precision)
 
     probe_file = os.environ.get("CUBIE_PROBE_TIMING_FILE")
-    t0 = perf_counter()
     if probe_file:
+        stamps = [("enter", perf_counter())]
         cuda.synchronize()
-    t1 = perf_counter()
-    kernel = _controller_step_kernel(device_func)
-    t2 = perf_counter()
-    kernel[1, 1](
-        dt, state_arr, state_prev_arr, err, niters_val, truncated_val,
-        accept, shared_scratch, persistent_local, status,
-    )
-    t3 = perf_counter()
-    if probe_file:
+        stamps.append(("sync_before", perf_counter()))
+        kernel = _controller_step_kernel(device_func)
+        stamps.append(("kernel_get", perf_counter()))
+        device_args = [
+            cuda.to_device(array)
+            for array in (
+                dt, state_arr, state_prev_arr, err, accept,
+                shared_scratch, persistent_local, status,
+            )
+        ]
+        stamps.append(("h2d", perf_counter()))
+        (d_dt, d_state, d_prev, d_err, d_accept,
+         d_shared, d_local, d_status) = device_args
+        kernel[1, 1](
+            d_dt, d_state, d_prev, d_err, niters_val, truncated_val,
+            d_accept, d_shared, d_local, d_status,
+        )
+        stamps.append(("enqueue", perf_counter()))
+        cuda.synchronize()
+        stamps.append(("execute", perf_counter()))
+        dt = d_dt.copy_to_host()
+        accept = d_accept.copy_to_host()
+        persistent_local = d_local.copy_to_host()
+        status = d_status.copy_to_host()
+        stamps.append(("d2h", perf_counter()))
+        parts = " ".join(
+            f"{label}={now - prev:.3f}s"
+            for (label, now), (_, prev) in zip(stamps[1:], stamps)
+        )
         with open(probe_file, "a") as handle:
             handle.write(
                 f"pid={os.getpid()} wall={wall_time():.3f} "
-                f"run_controller_device_step "
-                f"sync_before={t1 - t0:.3f}s "
-                f"kernel_get={t2 - t1:.3f}s launch={t3 - t2:.3f}s\n"
+                f"step_phases {parts} "
+                f"total={stamps[-1][1] - stamps[0][1]:.3f}s\n"
             )
+    else:
+        kernel = _controller_step_kernel(device_func)
+        kernel[1, 1](
+            dt, state_arr, state_prev_arr, err, niters_val, truncated_val,
+            accept, shared_scratch, persistent_local, status,
+        )
     return StepResult(
         precision(dt[0]), int(accept[0]), persistent_local.copy(),
         int(status[0]),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
+import ctypes
 import hashlib
 import os
+import sys
+from glob import glob
 from pathlib import Path
 from time import perf_counter, time as wall_time
 from types import SimpleNamespace
@@ -150,7 +153,7 @@ def pytest_configure(config):
 
     _probe_stamp("pytest_configure")
     if not IS_MLIR and not CUDA_SIMULATION:
-        # Load the NVVM DLL while the worker process is still small.
+        # Load launch-path DLLs while the worker process is still small.
         try:
             t0 = perf_counter()
             from cuda.pathfinder import load_nvidia_dynamic_lib
@@ -159,6 +162,20 @@ def pytest_configure(config):
             _probe_stamp(f"nvvm_preload {perf_counter() - t0:.3f}s")
         except Exception:
             _probe_stamp("nvvm_preload failed")
+        if sys.platform == "win32":
+            pattern = os.path.join(
+                sys.prefix, "Lib", "site-packages",
+                "nvidia", "**", "*nvJitLink*.dll",
+            )
+            for dll_path in glob(pattern, recursive=True):
+                try:
+                    t0 = perf_counter()
+                    ctypes.WinDLL(dll_path)
+                    _probe_stamp(
+                        f"nvjitlink_preload {perf_counter() - t0:.3f}s"
+                    )
+                except OSError:
+                    _probe_stamp("nvjitlink_preload failed")
     if IS_MLIR:
         config.addinivalue_line(
             "filterwarnings",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import hashlib
 import os
 from pathlib import Path
-from time import perf_counter
+from time import perf_counter, time as wall_time
 from types import SimpleNamespace
 
 import numpy as np
@@ -124,6 +124,19 @@ def _session_param_signature(item):
     return "; ".join(parts) if parts else None
 
 
+def _probe_stamp(label):
+    """Append a wall-clock stamp to the probe timing file, if set."""
+    probe_file = os.environ.get("CUBIE_PROBE_TIMING_FILE")
+    if probe_file:
+        with open(probe_file, "a") as handle:
+            handle.write(
+                f"pid={os.getpid()} wall={wall_time():.3f} {label}\n"
+            )
+
+
+_probe_stamp("conftest_imported")
+
+
 def pytest_configure(config):
     """Silence the vendored performance warning on the MLIR backend.
 
@@ -134,6 +147,7 @@ def pytest_configure(config):
     """
     from cubie.cuda_backend import IS_MLIR
 
+    _probe_stamp("pytest_configure")
     if IS_MLIR:
         config.addinivalue_line(
             "filterwarnings",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 from pathlib import Path
+from time import perf_counter
 from types import SimpleNamespace
 
 import numpy as np
@@ -1036,8 +1037,12 @@ def step_setup(request, precision, system):
 @pytest.fixture(scope="function")
 def device_step_results(step_controller, precision, step_setup):
     """Run the session controller's device function one step."""
-    return run_controller_device_step(
-        step_controller.device_function,
+    probe_file = os.environ.get("CUBIE_PROBE_TIMING_FILE")
+    t0 = perf_counter()
+    device_function = step_controller.device_function
+    t1 = perf_counter()
+    result = run_controller_device_step(
+        device_function,
         precision,
         step_setup["dt0"],
         step_setup["error"],
@@ -1045,6 +1050,15 @@ def device_step_results(step_controller, precision, step_setup):
         state_prev=step_setup["state_prev"],
         local_mem=step_setup["local_mem"],
     )
+    t2 = perf_counter()
+    if probe_file:
+        with open(probe_file, "a") as handle:
+            handle.write(
+                f"pid={os.getpid()} device_step_results "
+                f"device_function={t1 - t0:.3f}s "
+                f"run_step={t2 - t1:.3f}s\n"
+            )
+    return result
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,8 +146,19 @@ def pytest_configure(config):
     (the class path does not import under numba-cuda).
     """
     from cubie.cuda_backend import IS_MLIR
+    from cubie.cuda_simsafe import CUDA_SIMULATION
 
     _probe_stamp("pytest_configure")
+    if not IS_MLIR and not CUDA_SIMULATION:
+        # Load the NVVM DLL while the worker process is still small.
+        try:
+            t0 = perf_counter()
+            from cuda.pathfinder import load_nvidia_dynamic_lib
+
+            load_nvidia_dynamic_lib("nvvm")
+            _probe_stamp(f"nvvm_preload {perf_counter() - t0:.3f}s")
+        except Exception:
+            _probe_stamp("nvvm_preload failed")
     if IS_MLIR:
         config.addinivalue_line(
             "filterwarnings",


### PR DESCRIPTION
## What changed

Diagnostic tooling used to root-cause the ~12s per-worker first-launch stall on the Windows CI GPU legs; the fix it produced is PR 720. `ci/tools/first_launch_split.py` phase-times one layer of a fresh process''s first CUDA launch (modes: driver via ctypes, numba, cupy, cubie, kernel, solver, dll, read, saturate; `fanout <mode> <n>` runs n concurrent processes; balloon and DLL-path env knobs). `gpu_probe.yml` runs short single-job experiments on the fleet AMI. `ci_cuda_tests.yml` on this branch is trimmed to one Windows lane with `--pytest-durations=25`, a GPU-utilisation log, and env-gated fixture-phase instrumentation in `tests/_utils.py` / `tests/conftest.py` (per-phase launch splits, worker timeline stamps, a 4s watchdog that dumps the mid-stall stack and a process_time split).

Not intended to merge as-is; it is the reproducible harness behind the investigation''s falsifications (Defender absent from the AMI, driver JIT cache, cold-EBS file reads, hydration-bandwidth contention, memory pressure, process concurrency) and the validation runs cited in PR 720.

Co-authored by Chris'' bot