### PR TITLE
feat(integrators): DIRK defaults use OrdinaryDiffEq's PI law via order-callable gains; NLNewton bounds floored at precision noise

### DIFF
--- a/src/cubie/integrators/SingleIntegratorRunCore.py
+++ b/src/cubie/integrators/SingleIntegratorRunCore.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 from warnings import warn
 
 from attrs import define, field
-from numpy import finfo as np_finfo
+from numpy import asarray, finfo as np_finfo
 
 from cubie.CUDAFactory import CUDAFactory, CUDADispatcherCache
 from cubie._utils import PrecisionDType, unpack_dict_values
@@ -40,6 +40,21 @@ from cubie.integrators.step_control import get_controller
 
 if TYPE_CHECKING:  # pragma: no cover - imported for static typing only
     from cubie.odesystems.baseODE import BaseODE
+
+
+def warn_on_newton_rtol_inversion(newton_rtol, controller_rtol) -> None:
+    """Warn when the Newton rtol reaches the step controller's rtol."""
+    controller = asarray(controller_rtol)
+    newton = asarray(newton_rtol).reshape(-1, controller.size)
+    inverted = (controller > 0.0) & (newton >= controller)
+    if inverted.any():
+        warn(
+            "newton_rtol is at or above the step controller rtol: the "
+            "requested rtol is below what the working precision "
+            "resolves in the stage solves.",
+            UserWarning,
+            stacklevel=2,
+        )
 
 @define
 class SingleIntegratorRunCache(CUDADispatcherCache):
@@ -411,6 +426,11 @@ class SingleIntegratorRunCore(CUDAFactory):
         }
         if derived:
             self._algo_step.update(derived, silent=True)
+        if not self._algo_step.is_linear:
+            warn_on_newton_rtol_inversion(
+                self._algo_step.solver.rtol,
+                self._step_controller.rtol,
+            )
         return set(derived)
 
     @property

--- a/src/cubie/integrators/algorithms/AGENTS.md
+++ b/src/cubie/integrators/algorithms/AGENTS.md
@@ -70,11 +70,11 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
   **non-tableau methods** `"euler"`, `"backwards_euler"`, `"backwards_euler_pc"`,
   `"crank_nicolson"` are fixed schemes with no tableau.
 - `StepControlDefaults` are chosen from `tableau.has_error_estimate` (fixed when no
-  embedded estimate exists; otherwise PI for explicit RK and DIRK — DIRK uses
-  order-callable gains `kp = 0.7(q+1)/q`, `ki = -0.4(q+1)/q` with limits 0.2/10,
-  safety 0.9, no deadband, matching OrdinaryDiffEq.jl's PIController — and
-  Gustafsson for FIRK/Rosenbrock-W/Crank-Nicolson with RADAU5's gain limits and
-  deadband). **Errorless tableaus must use a fixed controller** — constructors enforce
+  embedded estimate exists; otherwise PI for explicit RK and DIRK — DIRK's gains are
+  the order callables `dirk_default_kp`/`dirk_default_ki` with limits 0.2/10, safety
+  0.9, no deadband — and Gustafsson for FIRK/Rosenbrock-W/Crank-Nicolson with
+  RADAU5's gain limits and deadband). **Errorless tableaus must use a fixed
+  controller** — constructors enforce
   this; never pair an adaptive controller with an errorless tableau. Controller-defaults
   dicts must never contain keys that are also algorithm parameters: on hot-swap
   the defaults merge into the shared `updates_dict`

--- a/src/cubie/integrators/algorithms/AGENTS.md
+++ b/src/cubie/integrators/algorithms/AGENTS.md
@@ -70,8 +70,10 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
   **non-tableau methods** `"euler"`, `"backwards_euler"`, `"backwards_euler_pc"`,
   `"crank_nicolson"` are fixed schemes with no tableau.
 - `StepControlDefaults` are chosen from `tableau.has_error_estimate` (fixed when no
-  embedded estimate exists; otherwise PI for explicit RK, Gustafsson for the implicit
-  families — DIRK/FIRK/Rosenbrock-W/Crank-Nicolson — with RADAU5's gain limits and
+  embedded estimate exists; otherwise PI for explicit RK and DIRK — DIRK uses
+  order-callable gains `kp = 0.7(q+1)/q`, `ki = -0.4(q+1)/q` with limits 0.2/10,
+  safety 0.9, no deadband, matching OrdinaryDiffEq.jl's PIController — and
+  Gustafsson for FIRK/Rosenbrock-W/Crank-Nicolson with RADAU5's gain limits and
   deadband). **Errorless tableaus must use a fixed controller** — constructors enforce
   this; never pair an adaptive controller with an errorless tableau. Controller-defaults
   dicts must never contain keys that are also algorithm parameters: on hot-swap

--- a/src/cubie/integrators/algorithms/AGENTS.md
+++ b/src/cubie/integrators/algorithms/AGENTS.md
@@ -70,11 +70,9 @@ attrs-config mechanics; CUDA-authoring *optimisation* patterns are in
   **non-tableau methods** `"euler"`, `"backwards_euler"`, `"backwards_euler_pc"`,
   `"crank_nicolson"` are fixed schemes with no tableau.
 - `StepControlDefaults` are chosen from `tableau.has_error_estimate` (fixed when no
-  embedded estimate exists; otherwise PI for explicit RK and DIRK — DIRK's gains are
-  the order callables `dirk_default_kp`/`dirk_default_ki` with limits 0.2/10, safety
-  0.9, no deadband — and Gustafsson for FIRK/Rosenbrock-W/Crank-Nicolson with
-  RADAU5's gain limits and deadband). **Errorless tableaus must use a fixed
-  controller** — constructors enforce
+  embedded estimate exists; otherwise PI for explicit RK, order-dependent PI
+  defaults for adaptive DIRK, and Gustafsson for FIRK/Rosenbrock-W/Crank-Nicolson).
+  **Errorless tableaus must use a fixed controller** — constructors enforce
   this; never pair an adaptive controller with an errorless tableau. Controller-defaults
   dicts must never contain keys that are also algorithm parameters: on hot-swap
   the defaults merge into the shared `updates_dict`

--- a/src/cubie/integrators/algorithms/generic_dirk.py
+++ b/src/cubie/integrators/algorithms/generic_dirk.py
@@ -12,7 +12,8 @@ Published Classes
 Constants
 ---------
 :data:`DIRK_ADAPTIVE_DEFAULTS`
-    Default Gustafsson controller settings for adaptive tableaus.
+    Default order-dependent PI controller settings for adaptive
+    tableaus.
 
 :data:`DIRK_FIXED_DEFAULTS`
     Default fixed-step settings for errorless tableaus.
@@ -21,8 +22,9 @@ Notes
 -----
 The step controller defaults are selected dynamically based on whether
 the tableau has an embedded error estimate. Tableaus with error
-estimates default to adaptive stepping (Gustafsson controller), while
-errorless tableaus default to fixed stepping.
+estimates default to adaptive stepping with order-dependent PI
+controller defaults, while errorless tableaus default to fixed
+stepping.
 
 See Also
 --------
@@ -88,7 +90,8 @@ DIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
         "safety": 0.9,
     }
 )
-"""OrdinaryDiffEq.jl PIController law for embedded-error DIRK tableaus."""
+"""Order-dependent PI controller defaults for embedded-error DIRK
+tableaus, originally modelled on OrdinaryDiffEq.jl's defaults."""
 
 
 DIRK_FIXED_DEFAULTS = StepControlDefaults(
@@ -197,8 +200,8 @@ class DIRKStep(ODEImplicitStep):
         This constructor creates a DIRK step object and automatically selects
         appropriate default step controller settings based on whether the
         tableau has an embedded error estimate. Tableaus with error estimates
-        default to adaptive stepping (Gustafsson controller), while
-        errorless tableaus default to fixed stepping.
+        default to adaptive stepping with order-dependent PI controller
+        defaults, while errorless tableaus default to fixed stepping.
 
         Parameters
         ----------
@@ -232,7 +235,8 @@ class DIRKStep(ODEImplicitStep):
         The step controller defaults are selected dynamically:
 
         - If ``tableau.has_error_estimate`` is ``True``:
-          Uses :data:`DIRK_ADAPTIVE_DEFAULTS` (Gustafsson controller)
+          Uses :data:`DIRK_ADAPTIVE_DEFAULTS` (order-dependent PI
+          controller defaults)
         - If ``tableau.has_error_estimate`` is ``False``:
           Uses :data:`DIRK_FIXED_DEFAULTS` (fixed-step controller)
 

--- a/src/cubie/integrators/algorithms/generic_dirk.py
+++ b/src/cubie/integrators/algorithms/generic_dirk.py
@@ -83,7 +83,9 @@ DIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
         "step_controller": "pi",
         "kp": dirk_default_kp,
         "ki": dirk_default_ki,
-        "deadband_min": 1.0,
+        # OrdinaryDiffEq's qsteady band [1, 1.2] holds dt on small
+        # proposed shrinks; in gain terms that is [1/1.2, 1].
+        "deadband_min": 1.0 / 1.2,
         "deadband_max": 1.0,
         "min_gain": 0.2,
         "max_gain": 10.0,

--- a/src/cubie/integrators/algorithms/generic_dirk.py
+++ b/src/cubie/integrators/algorithms/generic_dirk.py
@@ -83,8 +83,7 @@ DIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
         "step_controller": "pi",
         "kp": dirk_default_kp,
         "ki": dirk_default_ki,
-        # OrdinaryDiffEq's qsteady band [1, 1.2] holds dt on small
-        # proposed shrinks; in gain terms that is [1/1.2, 1].
+        # OrdinaryDiffEq's qsteady band [1, 1.2] in gain terms.
         "deadband_min": 1.0 / 1.2,
         "deadband_max": 1.0,
         "min_gain": 0.2,
@@ -92,8 +91,8 @@ DIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
         "safety": 0.9,
     }
 )
-"""Order-dependent PI controller defaults for embedded-error DIRK
-tableaus, originally modelled on OrdinaryDiffEq.jl's defaults."""
+"""Order-dependent PI controller defaults for adaptive DIRK tableaus,
+modelled on OrdinaryDiffEq.jl's defaults."""
 
 
 DIRK_FIXED_DEFAULTS = StepControlDefaults(

--- a/src/cubie/integrators/algorithms/generic_dirk.py
+++ b/src/cubie/integrators/algorithms/generic_dirk.py
@@ -88,23 +88,7 @@ DIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
         "safety": 0.9,
     }
 )
-"""Default step controller settings for adaptive DIRK tableaus.
-
-This configuration is used when the DIRK tableau has an embedded error
-estimate (``tableau.has_error_estimate == True``).
-
-The PI controller with these order-callable gains and limits applies
-OrdinaryDiffEq.jl's PIController law (``beta1 = 7/(10*order)``,
-``beta2 = 2/(5*order)``, ``qmin = 0.2``, ``qmax = 10``,
-``gamma = 0.9``) through the PI factory's ``1/(2*(order + 1))``
-exponent fold.
-
-Notes
------
-These defaults are applied automatically when creating a :class:`DIRKStep`
-with an adaptive tableau. Users can override any of these settings by
-explicitly specifying step controller parameters.
-"""
+"""OrdinaryDiffEq.jl PIController law for embedded-error DIRK tableaus."""
 
 
 DIRK_FIXED_DEFAULTS = StepControlDefaults(

--- a/src/cubie/integrators/algorithms/generic_dirk.py
+++ b/src/cubie/integrators/algorithms/generic_dirk.py
@@ -91,8 +91,7 @@ DIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
         "safety": 0.9,
     }
 )
-"""Order-dependent PI controller defaults for adaptive DIRK tableaus,
-modelled on OrdinaryDiffEq.jl's defaults."""
+"""Order-dependent PI controller defaults for adaptive DIRK tableaus."""
 
 
 DIRK_FIXED_DEFAULTS = StepControlDefaults(

--- a/src/cubie/integrators/algorithms/generic_dirk.py
+++ b/src/cubie/integrators/algorithms/generic_dirk.py
@@ -66,13 +66,25 @@ from cubie.integrators.stage_predictors import DenseStagePredictor
 from cubie.buffer_registry import buffer_registry
 
 
+def dirk_default_kp(order: int) -> float:
+    """Return the DIRK proportional gain for an algorithm order."""
+    return 0.7 * (order + 1) / order
+
+
+def dirk_default_ki(order: int) -> float:
+    """Return the DIRK integral gain for an algorithm order."""
+    return -0.4 * (order + 1) / order
+
+
 DIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
     step_controller={
-        "step_controller": "gustafsson",
+        "step_controller": "pi",
+        "kp": dirk_default_kp,
+        "ki": dirk_default_ki,
         "deadband_min": 1.0,
-        "deadband_max": 1.2,
+        "deadband_max": 1.0,
         "min_gain": 0.2,
-        "max_gain": 8.0,
+        "max_gain": 10.0,
         "safety": 0.9,
     }
 )
@@ -81,13 +93,11 @@ DIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
 This configuration is used when the DIRK tableau has an embedded error
 estimate (``tableau.has_error_estimate == True``).
 
-The Gustafsson predictive controller is the standard choice for
-implicit Runge--Kutta methods (Gustafsson 1994; the default for SDIRK
-families in OrdinaryDiffEq.jl). Step-ratio limits, deadband, and
-safety factor follow Hairer & Wanner's RADAU5 (``facl = 0.2``,
-``facr = 8``, ``quot1 = 1.0``, ``quot2 = 1.2``, ``safe = 0.9``); the
-deadband keeps the step unchanged for small gains so warp-coherent
-threads avoid needless step-size churn.
+The PI controller with these order-callable gains and limits applies
+OrdinaryDiffEq.jl's PIController law (``beta1 = 7/(10*order)``,
+``beta2 = 2/(5*order)``, ``qmin = 0.2``, ``qmax = 10``,
+``gamma = 0.9``) through the PI factory's ``1/(2*(order + 1))``
+exponent fold.
 
 Notes
 -----

--- a/src/cubie/integrators/algorithms/generic_dirk.py
+++ b/src/cubie/integrators/algorithms/generic_dirk.py
@@ -83,7 +83,6 @@ DIRK_ADAPTIVE_DEFAULTS = StepControlDefaults(
         "step_controller": "pi",
         "kp": dirk_default_kp,
         "ki": dirk_default_ki,
-        # OrdinaryDiffEq's qsteady band [1, 1.2] in gain terms.
         "deadband_min": 1.0 / 1.2,
         "deadband_max": 1.0,
         "min_gain": 0.2,

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -107,7 +107,7 @@ compiled callable from `.device_function`.
   decides between convergence and divergence. Commits are gated on
   linear-solver success — a failed linear solve moves nothing and
   clears the in-solve contraction history.
-- Correction-norm `rtol` floors at 4 ULPs (warned); Krylov norms keep raw values.
+- Correction-norm `rtol` floors at 4 ULPs with a warning; Krylov norms keep raw values.
 - There is no line search: a diverging solve exits early with a
   nonzero status and the adaptive step controller rejects the step
   and shrinks `dt`.

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -104,9 +104,12 @@ compiled callable from `.device_function`.
   first iteration when `||dz|| < 1e-5`. `theta > 2` or a non-finite
   update norm exits with `NEWTON_DIVERGENCE=256`; at the
   floating-point stagnation limit (`theta ≈ 1`) the update norm alone
-  decides between convergence and divergence. Commits are gated on
-  linear-solver success — a failed linear solve moves nothing and
-  clears the in-solve contraction history.
+  decides between convergence and divergence. Both absolute bounds are
+  floored at `4*eps/min(newton_rtol)` (≈4 ULPs of the state), so a
+  correction at rounding-noise level converges instead of failing when
+  the tolerance is below what the precision can express. Commits are
+  gated on linear-solver success — a failed linear solve moves nothing
+  and clears the in-solve contraction history.
 - There is no line search: a diverging solve exits early with a
   nonzero status and the adaptive step controller rejects the step
   and shrinks `dt`.

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -105,9 +105,7 @@ compiled callable from `.device_function`.
   update norm exits with `NEWTON_DIVERGENCE=256`; at the
   floating-point stagnation limit (`theta ≈ 1`) the update norm alone
   decides between convergence and divergence. Both absolute bounds are
-  floored at `4*eps/min(newton_rtol)` (≈4 ULPs of the state), so a
-  correction at rounding-noise level converges instead of failing when
-  the tolerance is below what the precision can express. Commits are
+  floored at `4*eps/min(newton_rtol)`, ≈4 ULPs of the state. Commits are
   gated on linear-solver success — a failed linear solve moves nothing
   and clears the in-solve contraction history.
 - There is no line search: a diverging solve exits early with a

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -104,12 +104,11 @@ compiled callable from `.device_function`.
   first iteration when `||dz|| < 1e-5`. `theta > 2` or a non-finite
   update norm exits with `NEWTON_DIVERGENCE=256`; at the
   floating-point stagnation limit (`theta ≈ 1`) the update norm alone
-  decides between convergence and divergence. Nonzero Newton-norm
-  `rtol` components below 4 ULPs of the working precision are raised
-  to that floor at tolerance conversion, with a warning (correction
-  norms only; residual/Krylov norms keep the raw request). Commits are
-  gated on linear-solver success — a failed linear solve moves nothing
-  and clears the in-solve contraction history.
+  decides between convergence and divergence. Nonzero correction-norm
+  `rtol` components below 4 ULPs are floored at conversion with a
+  warning; Krylov norms keep the raw request. Commits are gated on
+  linear-solver success — a failed linear solve moves nothing and
+  clears the in-solve contraction history.
 - There is no line search: a diverging solve exits early with a
   nonzero status and the adaptive step controller rejects the step
   and shrinks `dt`.

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -104,11 +104,12 @@ compiled callable from `.device_function`.
   first iteration when `||dz|| < 1e-5`. `theta > 2` or a non-finite
   update norm exits with `NEWTON_DIVERGENCE=256`; at the
   floating-point stagnation limit (`theta ≈ 1`) the update norm alone
-  decides between convergence and divergence. Nonzero norm `rtol`
-  components below 4 ULPs of the working precision are raised to that
-  floor at tolerance conversion, with a warning. Commits are gated on
-  linear-solver success — a failed linear solve moves nothing and
-  clears the in-solve contraction history.
+  decides between convergence and divergence. Nonzero Newton-norm
+  `rtol` components below 4 ULPs of the working precision are raised
+  to that floor at tolerance conversion, with a warning (correction
+  norms only; residual/Krylov norms keep the raw request). Commits are
+  gated on linear-solver success — a failed linear solve moves nothing
+  and clears the in-solve contraction history.
 - There is no line search: a diverging solve exits early with a
   nonzero status and the adaptive step controller rejects the step
   and shrinks `dt`.

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -104,10 +104,11 @@ compiled callable from `.device_function`.
   first iteration when `||dz|| < 1e-5`. `theta > 2` or a non-finite
   update norm exits with `NEWTON_DIVERGENCE=256`; at the
   floating-point stagnation limit (`theta ≈ 1`) the update norm alone
-  decides between convergence and divergence. Both absolute bounds are
-  floored at `4*eps/min(newton_rtol)`, ≈4 ULPs of the state. Commits are
-  gated on linear-solver success — a failed linear solve moves nothing
-  and clears the in-solve contraction history.
+  decides between convergence and divergence. Nonzero norm `rtol`
+  components below 4 ULPs of the working precision are raised to that
+  floor at tolerance conversion, with a warning. Commits are gated on
+  linear-solver success — a failed linear solve moves nothing and
+  clears the in-solve contraction history.
 - There is no line search: a diverging solve exits early with a
   nonzero status and the adaptive step controller rejects the step
   and shrinks `dt`.

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -104,11 +104,10 @@ compiled callable from `.device_function`.
   first iteration when `||dz|| < 1e-5`. `theta > 2` or a non-finite
   update norm exits with `NEWTON_DIVERGENCE=256`; at the
   floating-point stagnation limit (`theta ≈ 1`) the update norm alone
-  decides between convergence and divergence. Nonzero correction-norm
-  `rtol` components below 4 ULPs are floored at conversion with a
-  warning; Krylov norms keep the raw request. Commits are gated on
-  linear-solver success — a failed linear solve moves nothing and
-  clears the in-solve contraction history.
+  decides between convergence and divergence. Correction-norm `rtol`
+  floors at 4 ULPs (warned); Krylov norms keep raw values. Commits are
+  gated on linear-solver success — a failed linear solve moves nothing
+  and clears the in-solve contraction history.
 - There is no line search: a diverging solve exits early with a
   nonzero status and the adaptive step controller rejects the step
   and shrinks `dt`.

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -104,10 +104,10 @@ compiled callable from `.device_function`.
   first iteration when `||dz|| < 1e-5`. `theta > 2` or a non-finite
   update norm exits with `NEWTON_DIVERGENCE=256`; at the
   floating-point stagnation limit (`theta ≈ 1`) the update norm alone
-  decides between convergence and divergence. Correction-norm `rtol`
-  floors at 4 ULPs (warned); Krylov norms keep raw values. Commits are
-  gated on linear-solver success — a failed linear solve moves nothing
-  and clears the in-solve contraction history.
+  decides between convergence and divergence. Commits are gated on
+  linear-solver success — a failed linear solve moves nothing and
+  clears the in-solve contraction history.
+- Correction-norm `rtol` floors at 4 ULPs (warned); Krylov norms keep raw values.
 - There is no line search: a diverging solve exits early with a
   nonzero status and the adaptive step controller rejects the step
   and shrinks `dt`.

--- a/src/cubie/integrators/matrix_free_solvers/newton_krylov.py
+++ b/src/cubie/integrators/matrix_free_solvers/newton_krylov.py
@@ -304,8 +304,16 @@ class NewtonKrylov(MatrixFreeSolver):
         typed_huge = numba_precision(float(np_finfo(config.precision).max))
         # Acceptance bound on eta * ||dz||.
         kappa = numba_precision(0.01)
+        # Scaled norm of a rounding-noise correction; bounds below it
+        # are unreachable in this precision.
+        rtol_values = self.norm.rtol
+        rtol_min = float(rtol_values.min()) if rtol_values.size else 0.0
+        eps_value = float(np_finfo(config.precision).eps)
+        dz_floor = 4.0 * eps_value / rtol_min if rtol_min > 0.0 else 0.0
         # First-iteration acceptance bound on ||dz||.
-        first_iteration_bound = numba_precision(1.0e-5)
+        first_iteration_bound = numba_precision(max(1.0e-5, dz_floor))
+        # Stagnation at theta ~ 1 converges at or below this bound.
+        stagnation_bound = numba_precision(max(1.0, dz_floor))
         # Decay floor on the carried contraction estimate.
         theta_decay = numba_precision(0.3)
         # Contraction estimate above this diverges.
@@ -468,10 +476,10 @@ class NewtonKrylov(MatrixFreeSolver):
                     | nonfinite
                 )
                 converged_stagnant = (
-                    stagnant & (ndz <= typed_one) & (not diverging)
+                    stagnant & (ndz <= stagnation_bound) & (not diverging)
                 )
                 failed_now = diverging | (
-                    stagnant & (ndz > typed_one)
+                    stagnant & (ndz > stagnation_bound)
                 )
                 failed = failed | failed_now
 

--- a/src/cubie/integrators/matrix_free_solvers/newton_krylov.py
+++ b/src/cubie/integrators/matrix_free_solvers/newton_krylov.py
@@ -304,8 +304,7 @@ class NewtonKrylov(MatrixFreeSolver):
         typed_huge = numba_precision(float(np_finfo(config.precision).max))
         # Acceptance bound on eta * ||dz||.
         kappa = numba_precision(0.01)
-        # Scaled norm of a rounding-noise correction; bounds below it
-        # are unreachable in this precision.
+        # Scaled norm of a rounding-noise correction (~4 ULPs).
         rtol_values = self.norm.rtol
         rtol_min = float(rtol_values.min()) if rtol_values.size else 0.0
         eps_value = float(np_finfo(config.precision).eps)

--- a/src/cubie/integrators/matrix_free_solvers/newton_krylov.py
+++ b/src/cubie/integrators/matrix_free_solvers/newton_krylov.py
@@ -304,15 +304,8 @@ class NewtonKrylov(MatrixFreeSolver):
         typed_huge = numba_precision(float(np_finfo(config.precision).max))
         # Acceptance bound on eta * ||dz||.
         kappa = numba_precision(0.01)
-        # Scaled norm of a rounding-noise correction (~4 ULPs).
-        rtol_values = self.norm.rtol
-        rtol_min = float(rtol_values.min()) if rtol_values.size else 0.0
-        eps_value = float(np_finfo(config.precision).eps)
-        dz_floor = 4.0 * eps_value / rtol_min if rtol_min > 0.0 else 0.0
         # First-iteration acceptance bound on ||dz||.
-        first_iteration_bound = numba_precision(max(1.0e-5, dz_floor))
-        # Stagnation at theta ~ 1 converges at or below this bound.
-        stagnation_bound = numba_precision(max(1.0, dz_floor))
+        first_iteration_bound = numba_precision(1.0e-5)
         # Decay floor on the carried contraction estimate.
         theta_decay = numba_precision(0.3)
         # Contraction estimate above this diverges.
@@ -475,10 +468,10 @@ class NewtonKrylov(MatrixFreeSolver):
                     | nonfinite
                 )
                 converged_stagnant = (
-                    stagnant & (ndz <= stagnation_bound) & (not diverging)
+                    stagnant & (ndz <= typed_one) & (not diverging)
                 )
                 failed_now = diverging | (
-                    stagnant & (ndz > stagnation_bound)
+                    stagnant & (ndz > typed_one)
                 )
                 failed = failed | failed_now
 

--- a/src/cubie/integrators/norms.py
+++ b/src/cubie/integrators/norms.py
@@ -1,6 +1,5 @@
 """CUDA factories for scaled norms."""
 
-import warnings
 from typing import Callable
 
 from numpy import asarray, finfo, ndarray
@@ -23,19 +22,11 @@ from cubie.CUDAFactory import (
 
 
 def rtol_floor_converter(value, self_) -> ndarray:
-    """Convert rtol, flooring nonzero components at 4 ULPs (warns)."""
+    """Convert rtol, flooring nonzero components at 4 ULPs."""
     tolerance = tol_converter(value, self_)
     floor = 4.0 * float(finfo(self_.precision).eps)
     below = (tolerance > 0.0) & (tolerance < floor)
     if below.any():
-        label = self_.instance_label or "norm"
-        warnings.warn(
-            f"{label} rtol components below {floor:.3e} (4 ULPs at "
-            "the working precision) cannot be met; they were raised "
-            "to that floor.",
-            UserWarning,
-            stacklevel=2,
-        )
         tolerance = tolerance.copy()
         tolerance[below] = floor
         tolerance.setflags(write=False)

--- a/src/cubie/integrators/norms.py
+++ b/src/cubie/integrators/norms.py
@@ -23,13 +23,8 @@ from cubie.CUDAFactory import (
 
 
 def rtol_floor_converter(value, self_) -> ndarray:
-    """Convert rtol and raise sub-noise components to a usable floor.
-
-    A relative tolerance below four ULPs of the working precision
-    asks the scaled norm to resolve corrections smaller than rounding
-    noise, which no iteration can achieve. Nonzero components below
-    ``4 * eps`` are normalized up to that floor with a warning; zero
-    components (relative control disabled) pass through unchanged.
+    """Convert rtol; nonzero components below ``4 * eps`` are raised
+    to that floor with a warning, zero components pass through.
     """
     tolerance = tol_converter(value, self_)
     floor = 4.0 * float(finfo(self_.precision).eps)
@@ -111,13 +106,8 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
 
 @frozen
 class CorrectionNormConfig(ScaledNormConfig):
-    """Configure a Newton correction norm.
-
-    The Newton solver's acceptance bounds compare against this norm,
-    so its ``rtol`` runs through :func:`rtol_floor_converter`:
-    nonzero components below four ULPs of the working precision are
-    raised to that floor with a warning. Residual norms (Krylov) keep
-    the raw request.
+    """Configure a Newton correction norm; ``rtol`` is floored at
+    4 ULPs via :func:`rtol_floor_converter`.
     """
 
     rtol: ndarray = field(

--- a/src/cubie/integrators/norms.py
+++ b/src/cubie/integrators/norms.py
@@ -1,8 +1,9 @@
 """CUDA factories for scaled norms."""
 
+import warnings
 from typing import Callable
 
-from numpy import asarray, ndarray
+from numpy import asarray, finfo, ndarray
 from cubie.cuda_simsafe import cuda, int32
 from attrs import define, field, Converter, frozen
 
@@ -19,6 +20,33 @@ from cubie.CUDAFactory import (
     MultipleInstanceCUDAFactoryConfig,
     MultipleInstanceCUDAFactory,
 )
+
+
+def rtol_floor_converter(value, self_) -> ndarray:
+    """Convert rtol and raise sub-noise components to a usable floor.
+
+    A relative tolerance below four ULPs of the working precision
+    asks the scaled norm to resolve corrections smaller than rounding
+    noise, which no iteration can achieve. Nonzero components below
+    ``4 * eps`` are normalized up to that floor with a warning; zero
+    components (relative control disabled) pass through unchanged.
+    """
+    tolerance = tol_converter(value, self_)
+    floor = 4.0 * float(finfo(self_.precision).eps)
+    below = (tolerance > 0.0) & (tolerance < floor)
+    if below.any():
+        label = self_.instance_label or "norm"
+        warnings.warn(
+            f"{label} rtol components below {floor:.3e} (4 ULPs at "
+            "the working precision) cannot be met; they were raised "
+            "to that floor.",
+            UserWarning,
+            stacklevel=2,
+        )
+        tolerance = tolerance.copy()
+        tolerance[below] = floor
+        tolerance.setflags(write=False)
+    return tolerance
 
 
 @frozen
@@ -42,7 +70,10 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
     broadcasts scalar or uniform-array specifications to shape
     ``(solver_width,)``. A non-uniform array of the wrong length
     raises at the write boundary; update ``solver_width`` and the
-    tolerance arrays together in one call.
+    tolerance arrays together in one call. Nonzero ``rtol``
+    components below four ULPs of the working precision are raised
+    to that floor with a warning (see
+    :func:`rtol_floor_converter`).
     """
 
     solver_width: int = field(
@@ -58,7 +89,7 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
     rtol: ndarray = field(
         default=asarray([1e-6]),
         validator=nonnegative_float_array_validator,
-        converter=Converter(tol_converter, takes_self=True),
+        converter=Converter(rtol_floor_converter, takes_self=True),
         metadata={"prefixed": True},
     )
 

--- a/src/cubie/integrators/norms.py
+++ b/src/cubie/integrators/norms.py
@@ -23,9 +23,7 @@ from cubie.CUDAFactory import (
 
 
 def rtol_floor_converter(value, self_) -> ndarray:
-    """Convert rtol; nonzero components below ``4 * eps`` are raised
-    to that floor with a warning, zero components pass through.
-    """
+    """Convert rtol, flooring nonzero components at 4 ULPs (warns)."""
     tolerance = tol_converter(value, self_)
     floor = 4.0 * float(finfo(self_.precision).eps)
     below = (tolerance > 0.0) & (tolerance < floor)
@@ -106,9 +104,7 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
 
 @frozen
 class CorrectionNormConfig(ScaledNormConfig):
-    """Configure a Newton correction norm; ``rtol`` is floored at
-    4 ULPs via :func:`rtol_floor_converter`.
-    """
+    """Newton correction norm config; ``rtol`` floors at 4 ULPs."""
 
     rtol: ndarray = field(
         default=asarray([1e-6]),

--- a/src/cubie/integrators/norms.py
+++ b/src/cubie/integrators/norms.py
@@ -70,10 +70,7 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
     broadcasts scalar or uniform-array specifications to shape
     ``(solver_width,)``. A non-uniform array of the wrong length
     raises at the write boundary; update ``solver_width`` and the
-    tolerance arrays together in one call. Nonzero ``rtol``
-    components below four ULPs of the working precision are raised
-    to that floor with a warning (see
-    :func:`rtol_floor_converter`).
+    tolerance arrays together in one call.
     """
 
     solver_width: int = field(
@@ -89,7 +86,7 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
     rtol: ndarray = field(
         default=asarray([1e-6]),
         validator=nonnegative_float_array_validator,
-        converter=Converter(rtol_floor_converter, takes_self=True),
+        converter=Converter(tol_converter, takes_self=True),
         metadata={"prefixed": True},
     )
 
@@ -113,7 +110,26 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
 
 
 @frozen
-class FIRKCorrectionNormConfig(ScaledNormConfig):
+class CorrectionNormConfig(ScaledNormConfig):
+    """Configure a Newton correction norm.
+
+    The Newton solver's acceptance bounds compare against this norm,
+    so its ``rtol`` runs through :func:`rtol_floor_converter`:
+    nonzero components below four ULPs of the working precision are
+    raised to that floor with a warning. Residual norms (Krylov) keep
+    the raw request.
+    """
+
+    rtol: ndarray = field(
+        default=asarray([1e-6]),
+        validator=nonnegative_float_array_validator,
+        converter=Converter(rtol_floor_converter, takes_self=True),
+        metadata={"prefixed": True},
+    )
+
+
+@frozen
+class FIRKCorrectionNormConfig(CorrectionNormConfig):
     """Configure a coupled FIRK correction norm.
 
     Attributes
@@ -363,6 +379,8 @@ class CorrectionNorm(ScaledNorm):
     compiled function takes ``(values, stage_increment, stage_base,
     step_start, a_ij)`` in place of the two-argument scaled norm.
     """
+
+    config_type = CorrectionNormConfig
 
 
 class DIRKCorrectionNorm(CorrectionNorm):

--- a/src/cubie/integrators/step_control/AGENTS.md
+++ b/src/cubie/integrators/step_control/AGENTS.md
@@ -22,8 +22,8 @@ controllers.
 | `adaptive_step_controller.py` | `BaseAdaptiveStepController` + `AdaptiveStepControlConfig` (shared adaptive config: `dt_min/max`, `atol/rtol`, `algorithm_order`, gain limits, deadband, safety); `_ensure_sane_bounds`. |
 | `fixed_step_controller.py` | `FixedStepController` — unconditional accept, returns `0`; no history. |
 | `adaptive_I_controller.py` | `AdaptiveIController` — integral-only; gain `safety·norm^(-1/(2(1+order)))`; no history. |
-| `adaptive_PI_controller.py` | `AdaptivePIController` (`kp=0.7`, `ki=-0.4`) — uses previous + current norm. |
-| `adaptive_PID_controller.py` | `AdaptivePIDController` (`PIDStepControlConfig` extends PI with `kd=0.0`) — uses two previous norms. |
+| `adaptive_PI_controller.py` | `AdaptivePIController` (`kp=0.7`, `ki=-0.4`) — uses previous + current norm. Gains accept a float or a callable of the algorithm order, re-resolved when `algorithm_order` updates. |
+| `adaptive_PID_controller.py` | `AdaptivePIDController` (`PIDStepControlConfig` extends PI with `kd=0.0`) — uses two previous norms; `kd` takes the same float-or-callable form. |
 | `gustafsson_controller.py` | `GustafssonController` (`safety=0.9`, `newton_target_iters=20`) — min of a basic gain and a Newton-iteration-aware predictive gain; stores previous `dt` + norm. |
 
 ## For AI Agents

--- a/src/cubie/integrators/step_control/AGENTS.md
+++ b/src/cubie/integrators/step_control/AGENTS.md
@@ -22,8 +22,8 @@ controllers.
 | `adaptive_step_controller.py` | `BaseAdaptiveStepController` + `AdaptiveStepControlConfig` (shared adaptive config: `dt_min/max`, `atol/rtol`, `algorithm_order`, gain limits, deadband, safety); `_ensure_sane_bounds`. |
 | `fixed_step_controller.py` | `FixedStepController` — unconditional accept, returns `0`; no history. |
 | `adaptive_I_controller.py` | `AdaptiveIController` — integral-only; gain `safety·norm^(-1/(2(1+order)))`; no history. |
-| `adaptive_PI_controller.py` | `AdaptivePIController` (`kp=0.7`, `ki=-0.4`) — uses previous + current norm. Gains accept a float or a callable of the algorithm order, re-resolved when `algorithm_order` updates. |
-| `adaptive_PID_controller.py` | `AdaptivePIDController` (`PIDStepControlConfig` extends PI with `kd=0.0`) — uses two previous norms; `kd` takes the same float-or-callable form. |
+| `adaptive_PI_controller.py` | `AdaptivePIController` (`kp=0.7`, `ki=-0.4`) — uses previous + current norm; gains take a float or callable(order), re-resolved on `algorithm_order` updates. |
+| `adaptive_PID_controller.py` | `AdaptivePIDController` (`PIDStepControlConfig` extends PI with `kd=0.0`) — uses two previous norms; `kd` is float-or-callable too. |
 | `gustafsson_controller.py` | `GustafssonController` (`safety=0.9`, `newton_target_iters=20`) — min of a basic gain and a Newton-iteration-aware predictive gain; stores previous `dt` + norm. |
 
 ## For AI Agents

--- a/src/cubie/integrators/step_control/AGENTS.md
+++ b/src/cubie/integrators/step_control/AGENTS.md
@@ -22,8 +22,8 @@ controllers.
 | `adaptive_step_controller.py` | `BaseAdaptiveStepController` + `AdaptiveStepControlConfig` (shared adaptive config: `dt_min/max`, `atol/rtol`, `algorithm_order`, gain limits, deadband, safety); `_ensure_sane_bounds`. |
 | `fixed_step_controller.py` | `FixedStepController` — unconditional accept, returns `0`; no history. |
 | `adaptive_I_controller.py` | `AdaptiveIController` — integral-only; gain `safety·norm^(-1/(2(1+order)))`; no history. |
-| `adaptive_PI_controller.py` | `AdaptivePIController` (`kp=0.7`, `ki=-0.4`) — uses previous + current norm; gains take a float or callable(order), re-resolved on `algorithm_order` updates. |
-| `adaptive_PID_controller.py` | `AdaptivePIDController` (`PIDStepControlConfig` extends PI with `kd=0.0`) — uses two previous norms; `kd` is float-or-callable too. |
+| `adaptive_PI_controller.py` | `AdaptivePIController` (`kp=0.7`, `ki=-0.4`) — uses previous + current norm; gains may be order-dependent and resolve through the config's float properties. |
+| `adaptive_PID_controller.py` | `AdaptivePIDController` (`PIDStepControlConfig` extends PI with `kd=0.0`) — uses two previous norms; `kd` likewise. |
 | `gustafsson_controller.py` | `GustafssonController` (`safety=0.9`, `newton_target_iters=20`) — min of a basic gain and a Newton-iteration-aware predictive gain; stores previous `dt` + norm. |
 
 ## For AI Agents

--- a/src/cubie/integrators/step_control/AGENTS.md
+++ b/src/cubie/integrators/step_control/AGENTS.md
@@ -22,7 +22,7 @@ controllers.
 | `adaptive_step_controller.py` | `BaseAdaptiveStepController` + `AdaptiveStepControlConfig` (shared adaptive config: `dt_min/max`, `atol/rtol`, `algorithm_order`, gain limits, deadband, safety); `_ensure_sane_bounds`. |
 | `fixed_step_controller.py` | `FixedStepController` — unconditional accept, returns `0`; no history. |
 | `adaptive_I_controller.py` | `AdaptiveIController` — integral-only; gain `safety·norm^(-1/(2(1+order)))`; no history. |
-| `adaptive_PI_controller.py` | `AdaptivePIController` (`kp=0.7`, `ki=-0.4`) — uses previous + current norm; gains may be order-dependent and resolve through the config's float properties. |
+| `adaptive_PI_controller.py` | `AdaptivePIController` (`kp=0.7`, `ki=-0.4`) — uses previous + current norm; gains take a float or callable of order. |
 | `adaptive_PID_controller.py` | `AdaptivePIDController` (`PIDStepControlConfig` extends PI with `kd=0.0`) — uses two previous norms; `kd` likewise. |
 | `gustafsson_controller.py` | `GustafssonController` (`safety=0.9`, `newton_target_iters=20`) — min of a basic gain and a Newton-iteration-aware predictive gain; stores previous `dt` + norm. |
 

--- a/src/cubie/integrators/step_control/adaptive_PID_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_PID_controller.py
@@ -28,16 +28,18 @@ See Also
     Parent configuration class.
 """
 
-from typing import Callable
+from typing import Any, Callable
 
 from numpy import ndarray
 from cubie.cuda_simsafe import cuda, int32
-from attrs import field, validators, frozen
+from attrs import field, frozen
 from math import isnan, isinf
-from cubie._utils import PrecisionDType, _expand_dtype
+from cubie._utils import PrecisionDType
 from cubie.buffer_registry import buffer_registry
 from cubie.integrators.step_control.adaptive_step_controller import (
     BaseAdaptiveStepController,
+    gain_spec_validator,
+    resolve_gain_spec,
 )
 from cubie.integrators.step_control.adaptive_PI_controller import (
     PIStepControlConfig,
@@ -51,18 +53,26 @@ from cubie.integrators.step_control.base_step_controller import ControllerCache
 class PIDStepControlConfig(PIStepControlConfig):
     """Configuration for a proportional–integral–derivative controller."""
 
-    _kd: float = field(
-        default=0.0,
-        validator=validators.instance_of(_expand_dtype(float)),
-    )
+    _kd: Any = field(default=0.0, validator=gain_spec_validator, eq=False)
+    _kd_resolved: float = field(init=False, default=0.0)
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
+        object.__setattr__(
+            self,
+            "_kd_resolved",
+            resolve_gain_spec(self._kd, self.algorithm_order),
+        )
 
     @property
     def kd(self) -> float:
-        """Return the derivative gain."""
-        return self.precision(self._kd)
+        """Return the derivative gain resolved at the current order."""
+        return self.precision(self._kd_resolved)
+
+    @property
+    def kd_spec(self) -> Any:
+        """Return the derivative gain as supplied (float or callable)."""
+        return self._kd
 
 
 class AdaptivePIDController(BaseAdaptiveStepController):
@@ -93,9 +103,9 @@ class AdaptivePIDController(BaseAdaptiveStepController):
         settings_dict = super().settings_dict
         settings_dict.update(
             {
-                "kp": self.kp,
-                "ki": self.ki,
-                "kd": self.kd,
+                "kp": self.compile_settings.kp_spec,
+                "ki": self.compile_settings.ki_spec,
+                "kd": self.compile_settings.kd_spec,
             }
         )
         return settings_dict

--- a/src/cubie/integrators/step_control/adaptive_PID_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_PID_controller.py
@@ -32,13 +32,13 @@ from typing import Any, Callable
 
 from numpy import ndarray
 from cubie.cuda_simsafe import cuda, int32
-from attrs import Converter, field, frozen
+from attrs import field, frozen
 from math import isnan, isinf
 from cubie._utils import PrecisionDType
 from cubie.buffer_registry import buffer_registry
 from cubie.integrators.step_control.adaptive_step_controller import (
     BaseAdaptiveStepController,
-    gain_value_converter,
+    gain_converter,
 )
 from cubie.integrators.step_control.adaptive_PI_controller import (
     PIStepControlConfig,
@@ -52,21 +52,18 @@ from cubie.integrators.step_control.base_step_controller import ControllerCache
 class PIDStepControlConfig(PIStepControlConfig):
     """Configuration for a proportional–integral–derivative controller."""
 
-    _kd: Any = field(
-        default=0.0,
-        converter=Converter(gain_value_converter, takes_self=True),
-    )
+    _kd: Any = field(default=0.0, converter=gain_converter)
 
     @property
     def kd(self) -> float:
         """Return the derivative gain resolved at the current order."""
-        return self.precision(self._kd.resolved)
+        return self._resolve_gain(self._kd)
 
     @property
     def settings_dict(self) -> dict[str, object]:
         """Return the configuration as a dictionary."""
         settings_dict = super().settings_dict
-        settings_dict.update({"kd": self._kd.spec})
+        settings_dict.update({"kd": self._kd})
         return settings_dict
 
 

--- a/src/cubie/integrators/step_control/adaptive_PID_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_PID_controller.py
@@ -32,14 +32,13 @@ from typing import Any, Callable
 
 from numpy import ndarray
 from cubie.cuda_simsafe import cuda, int32
-from attrs import field, frozen
+from attrs import Converter, field, frozen
 from math import isnan, isinf
 from cubie._utils import PrecisionDType
 from cubie.buffer_registry import buffer_registry
 from cubie.integrators.step_control.adaptive_step_controller import (
     BaseAdaptiveStepController,
-    gain_spec_validator,
-    resolve_gain_spec,
+    gain_value_converter,
 )
 from cubie.integrators.step_control.adaptive_PI_controller import (
     PIStepControlConfig,
@@ -53,26 +52,22 @@ from cubie.integrators.step_control.base_step_controller import ControllerCache
 class PIDStepControlConfig(PIStepControlConfig):
     """Configuration for a proportional–integral–derivative controller."""
 
-    _kd: Any = field(default=0.0, validator=gain_spec_validator, eq=False)
-    _kd_resolved: float = field(init=False, default=0.0)
-
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        object.__setattr__(
-            self,
-            "_kd_resolved",
-            resolve_gain_spec(self._kd, self.algorithm_order),
-        )
+    _kd: Any = field(
+        default=0.0,
+        converter=Converter(gain_value_converter, takes_self=True),
+    )
 
     @property
     def kd(self) -> float:
         """Return the derivative gain resolved at the current order."""
-        return self.precision(self._kd_resolved)
+        return self.precision(self._kd.resolved)
 
     @property
-    def kd_spec(self) -> Any:
-        """Return the derivative gain as supplied (float or callable)."""
-        return self._kd
+    def settings_dict(self) -> dict[str, object]:
+        """Return the configuration as a dictionary."""
+        settings_dict = super().settings_dict
+        settings_dict.update({"kd": self._kd.spec})
+        return settings_dict
 
 
 class AdaptivePIDController(BaseAdaptiveStepController):
@@ -96,19 +91,6 @@ class AdaptivePIDController(BaseAdaptiveStepController):
         return self.compile_settings.kd
 
     _timestep_buffer_elements = 2  # previous two error norms
-
-    @property
-    def settings_dict(self) -> dict[str, object]:
-        """Return the configuration as a dictionary."""
-        settings_dict = super().settings_dict
-        settings_dict.update(
-            {
-                "kp": self.compile_settings.kp_spec,
-                "ki": self.compile_settings.ki_spec,
-                "kd": self.compile_settings.kd_spec,
-            }
-        )
-        return settings_dict
 
     def build_controller(
         self,

--- a/src/cubie/integrators/step_control/adaptive_PI_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_PI_controller.py
@@ -30,7 +30,7 @@ from typing import Any, Callable
 
 from cubie.cuda_simsafe import cuda, int32
 from numpy import ndarray
-from attrs import Converter, field, frozen
+from attrs import field, frozen
 from math import isnan, isinf
 
 from cubie._utils import PrecisionDType
@@ -38,7 +38,7 @@ from cubie.buffer_registry import buffer_registry
 from cubie.integrators.step_control.adaptive_step_controller import (
     AdaptiveStepControlConfig,
     BaseAdaptiveStepController,
-    gain_value_converter,
+    gain_converter,
 )
 from cubie.cuda_simsafe import selp
 from cubie.result_codes import CUBIE_RESULT_CODES
@@ -55,35 +55,24 @@ class PIStepControlConfig(AdaptiveStepControlConfig):
     systems than a pure integral controller.
     """
 
-    _kp: Any = field(
-        default=0.7,
-        converter=Converter(gain_value_converter, takes_self=True),
-    )
-    _ki: Any = field(
-        default=-0.4,
-        converter=Converter(gain_value_converter, takes_self=True),
-    )
+    _kp: Any = field(default=0.7, converter=gain_converter)
+    _ki: Any = field(default=-0.4, converter=gain_converter)
 
     @property
     def kp(self) -> float:
         """Return the proportional gain resolved at the current order."""
-        return self.precision(self._kp.resolved)
+        return self._resolve_gain(self._kp)
 
     @property
     def ki(self) -> float:
         """Return the integral gain resolved at the current order."""
-        return self.precision(self._ki.resolved)
+        return self._resolve_gain(self._ki)
 
     @property
     def settings_dict(self) -> dict[str, object]:
         """Return the configuration as a dictionary."""
         settings_dict = super().settings_dict
-        settings_dict.update(
-            {
-                "kp": self._kp.spec,
-                "ki": self._ki.spec,
-            }
-        )
+        settings_dict.update({"kp": self._kp, "ki": self._ki})
         return settings_dict
 
 

--- a/src/cubie/integrators/step_control/adaptive_PI_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_PI_controller.py
@@ -26,18 +26,20 @@ See Also
     Parent configuration class.
 """
 
-from typing import Callable
+from typing import Any, Callable
 
 from cubie.cuda_simsafe import cuda, int32
 from numpy import ndarray
-from attrs import field, validators, frozen
+from attrs import field, frozen
 from math import isnan, isinf
 
-from cubie._utils import PrecisionDType, _expand_dtype
+from cubie._utils import PrecisionDType
 from cubie.buffer_registry import buffer_registry
 from cubie.integrators.step_control.adaptive_step_controller import (
     AdaptiveStepControlConfig,
     BaseAdaptiveStepController,
+    gain_spec_validator,
+    resolve_gain_spec,
 )
 from cubie.cuda_simsafe import selp
 from cubie.result_codes import CUBIE_RESULT_CODES
@@ -54,25 +56,43 @@ class PIStepControlConfig(AdaptiveStepControlConfig):
     systems than a pure integral controller.
     """
 
-    _kp: float = field(
-        default=0.7, validator=validators.instance_of(_expand_dtype(float))
-    )
-    _ki: float = field(
-        default=-0.4, validator=validators.instance_of(_expand_dtype(float))
-    )
+    _kp: Any = field(default=0.7, validator=gain_spec_validator, eq=False)
+    _ki: Any = field(default=-0.4, validator=gain_spec_validator, eq=False)
+    _kp_resolved: float = field(init=False, default=0.7)
+    _ki_resolved: float = field(init=False, default=-0.4)
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
+        object.__setattr__(
+            self,
+            "_kp_resolved",
+            resolve_gain_spec(self._kp, self.algorithm_order),
+        )
+        object.__setattr__(
+            self,
+            "_ki_resolved",
+            resolve_gain_spec(self._ki, self.algorithm_order),
+        )
 
     @property
     def kp(self) -> float:
-        """Return the proportional gain."""
-        return self.precision(self._kp)
+        """Return the proportional gain resolved at the current order."""
+        return self.precision(self._kp_resolved)
 
     @property
     def ki(self) -> float:
-        """Return the integral gain."""
-        return self.precision(self._ki)
+        """Return the integral gain resolved at the current order."""
+        return self.precision(self._ki_resolved)
+
+    @property
+    def kp_spec(self) -> Any:
+        """Return the proportional gain as supplied (float or callable)."""
+        return self._kp
+
+    @property
+    def ki_spec(self) -> Any:
+        """Return the integral gain as supplied (float or callable)."""
+        return self._ki
 
 
 class AdaptivePIController(BaseAdaptiveStepController):
@@ -96,7 +116,12 @@ class AdaptivePIController(BaseAdaptiveStepController):
     def settings_dict(self) -> dict[str, object]:
         """Return the configuration as a dictionary."""
         settings_dict = super().settings_dict
-        settings_dict.update({"kp": self.kp, "ki": self.ki})
+        settings_dict.update(
+            {
+                "kp": self.compile_settings.kp_spec,
+                "ki": self.compile_settings.ki_spec,
+            }
+        )
         return settings_dict
 
     def build_controller(

--- a/src/cubie/integrators/step_control/adaptive_PI_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_PI_controller.py
@@ -30,7 +30,7 @@ from typing import Any, Callable
 
 from cubie.cuda_simsafe import cuda, int32
 from numpy import ndarray
-from attrs import field, frozen
+from attrs import Converter, field, frozen
 from math import isnan, isinf
 
 from cubie._utils import PrecisionDType
@@ -38,8 +38,7 @@ from cubie.buffer_registry import buffer_registry
 from cubie.integrators.step_control.adaptive_step_controller import (
     AdaptiveStepControlConfig,
     BaseAdaptiveStepController,
-    gain_spec_validator,
-    resolve_gain_spec,
+    gain_value_converter,
 )
 from cubie.cuda_simsafe import selp
 from cubie.result_codes import CUBIE_RESULT_CODES
@@ -56,43 +55,36 @@ class PIStepControlConfig(AdaptiveStepControlConfig):
     systems than a pure integral controller.
     """
 
-    _kp: Any = field(default=0.7, validator=gain_spec_validator, eq=False)
-    _ki: Any = field(default=-0.4, validator=gain_spec_validator, eq=False)
-    _kp_resolved: float = field(init=False, default=0.7)
-    _ki_resolved: float = field(init=False, default=-0.4)
-
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        object.__setattr__(
-            self,
-            "_kp_resolved",
-            resolve_gain_spec(self._kp, self.algorithm_order),
-        )
-        object.__setattr__(
-            self,
-            "_ki_resolved",
-            resolve_gain_spec(self._ki, self.algorithm_order),
-        )
+    _kp: Any = field(
+        default=0.7,
+        converter=Converter(gain_value_converter, takes_self=True),
+    )
+    _ki: Any = field(
+        default=-0.4,
+        converter=Converter(gain_value_converter, takes_self=True),
+    )
 
     @property
     def kp(self) -> float:
         """Return the proportional gain resolved at the current order."""
-        return self.precision(self._kp_resolved)
+        return self.precision(self._kp.resolved)
 
     @property
     def ki(self) -> float:
         """Return the integral gain resolved at the current order."""
-        return self.precision(self._ki_resolved)
+        return self.precision(self._ki.resolved)
 
     @property
-    def kp_spec(self) -> Any:
-        """Return the proportional gain as supplied (float or callable)."""
-        return self._kp
-
-    @property
-    def ki_spec(self) -> Any:
-        """Return the integral gain as supplied (float or callable)."""
-        return self._ki
+    def settings_dict(self) -> dict[str, object]:
+        """Return the configuration as a dictionary."""
+        settings_dict = super().settings_dict
+        settings_dict.update(
+            {
+                "kp": self._kp.spec,
+                "ki": self._ki.spec,
+            }
+        )
+        return settings_dict
 
 
 class AdaptivePIController(BaseAdaptiveStepController):
@@ -111,18 +103,6 @@ class AdaptivePIController(BaseAdaptiveStepController):
         return self.compile_settings.ki
 
     _timestep_buffer_elements = 1  # previous error norm
-
-    @property
-    def settings_dict(self) -> dict[str, object]:
-        """Return the configuration as a dictionary."""
-        settings_dict = super().settings_dict
-        settings_dict.update(
-            {
-                "kp": self.compile_settings.kp_spec,
-                "ki": self.compile_settings.ki_spec,
-            }
-        )
-        return settings_dict
 
     def build_controller(
         self,

--- a/src/cubie/integrators/step_control/adaptive_step_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_step_controller.py
@@ -48,15 +48,53 @@ def resolve_gain_spec(spec, order: int) -> float:
     return float(spec)
 
 
-def gain_spec_validator(instance, attribute, value) -> None:
-    """Reject gain values that are neither floats nor callables."""
-    if not callable(value) and not isinstance(
-        value, _expand_dtype(float)
-    ):
-        raise TypeError(
-            f"{attribute.name} must be a float or a callable taking "
-            f"the algorithm order, got {type(value)!r}"
-        )
+class GainValue:
+    """Controller gain supplied as a constant or a callable of order.
+
+    Wraps the raw user-supplied value together with the float it
+    resolves to at the owning config's ``algorithm_order``. Equality,
+    hashing, and canonical serialization all key on the resolved
+    float, so a callable and its equivalent constant share a cache
+    identity.
+    """
+
+    __slots__ = ("spec", "resolved")
+
+    def __init__(self, spec, order: int) -> None:
+        if isinstance(spec, GainValue):
+            spec = spec.spec
+        if not callable(spec) and not isinstance(
+            spec, _expand_dtype(float)
+        ):
+            raise TypeError(
+                "gain must be a float or a callable taking the "
+                f"algorithm order, got {type(spec)!r}"
+            )
+        self.spec = spec
+        self.resolved = resolve_gain_spec(spec, order)
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, GainValue):
+            return self.resolved == other.resolved
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self.resolved)
+
+    def __repr__(self) -> str:
+        return f"GainValue({self.spec!r}, resolved={self.resolved!r})"
+
+    def _cubie_canonical_(self) -> float:
+        return self.resolved
+
+
+def gain_value_converter(value, self_) -> GainValue:
+    """Wrap a gain at the config's current algorithm order.
+
+    Re-runs on every snapshot rebuild, so ``algorithm_order`` updates
+    re-resolve callable gains without any stored resolved field.
+    """
+    return GainValue(value, self_.algorithm_order)
 
 
 @frozen

--- a/src/cubie/integrators/step_control/adaptive_step_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_step_controller.py
@@ -49,13 +49,10 @@ def resolve_gain_spec(spec, order: int) -> float:
 
 
 class GainValue:
-    """Controller gain supplied as a constant or a callable of order.
+    """Gain given as a float or a callable of the algorithm order.
 
-    Wraps the raw user-supplied value together with the float it
-    resolves to at the owning config's ``algorithm_order``. Equality,
-    hashing, and canonical serialization all key on the resolved
-    float, so a callable and its equivalent constant share a cache
-    identity.
+    Holds the raw spec and its float resolved at ``order``; equality,
+    hashing, and canonical serialization use the resolved float.
     """
 
     __slots__ = ("spec", "resolved")
@@ -89,11 +86,7 @@ class GainValue:
 
 
 def gain_value_converter(value, self_) -> GainValue:
-    """Wrap a gain at the config's current algorithm order.
-
-    Re-runs on every snapshot rebuild, so ``algorithm_order`` updates
-    re-resolve callable gains without any stored resolved field.
-    """
+    """Wrap a gain as a GainValue at the config's algorithm order."""
     return GainValue(value, self_.algorithm_order)
 
 

--- a/src/cubie/integrators/step_control/adaptive_step_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_step_controller.py
@@ -29,6 +29,7 @@ from attrs import field, frozen
 
 from cubie._utils import (
     PrecisionDType,
+    _expand_dtype,
     clamp_factory,
     getype_validator,
     inrangetype_validator,
@@ -38,6 +39,24 @@ from cubie.integrators.step_control.base_step_controller import (
     BaseStepControllerConfig,
     ControllerCache,
 )
+
+
+def resolve_gain_spec(spec, order: int) -> float:
+    """Return the gain value, calling ``spec`` with ``order`` if callable."""
+    if callable(spec):
+        return float(spec(order))
+    return float(spec)
+
+
+def gain_spec_validator(instance, attribute, value) -> None:
+    """Reject gain values that are neither floats nor callables."""
+    if not callable(value) and not isinstance(
+        value, _expand_dtype(float)
+    ):
+        raise TypeError(
+            f"{attribute.name} must be a float or a callable taking "
+            f"the algorithm order, got {type(value)!r}"
+        )
 
 
 @frozen

--- a/src/cubie/integrators/step_control/adaptive_step_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_step_controller.py
@@ -42,12 +42,10 @@ from cubie.integrators.step_control.base_step_controller import (
 
 
 class OrderDependentGain:
-    """A controller gain given as a pure callable of algorithm order.
+    """A controller gain as a pure callable of the algorithm order.
 
-    Wrapping the callable admits it to the canonical serialization
-    domain: identity is the callable's source text, so the config
-    hash keys on the gain rule and the separately stored
-    ``algorithm_order`` field.
+    Equality, hashing, and canonical identity key on the callable's
+    source text.
     """
 
     __slots__ = ("fn", "source")

--- a/src/cubie/integrators/step_control/adaptive_step_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_step_controller.py
@@ -49,11 +49,7 @@ def resolve_gain_spec(spec, order: int) -> float:
 
 
 class GainValue:
-    """Gain given as a float or a callable of the algorithm order.
-
-    Holds the raw spec and its float resolved at ``order``; equality,
-    hashing, and canonical serialization use the resolved float.
-    """
+    """Gain spec plus its float at ``order``; identity is the float."""
 
     __slots__ = ("spec", "resolved")
 

--- a/src/cubie/integrators/step_control/adaptive_step_controller.py
+++ b/src/cubie/integrators/step_control/adaptive_step_controller.py
@@ -22,6 +22,7 @@ See Also
 """
 
 from abc import abstractmethod
+from inspect import getsource
 from typing import Callable, Optional
 
 from numpy import ndarray, sqrt
@@ -29,7 +30,6 @@ from attrs import field, frozen
 
 from cubie._utils import (
     PrecisionDType,
-    _expand_dtype,
     clamp_factory,
     getype_validator,
     inrangetype_validator,
@@ -41,49 +41,46 @@ from cubie.integrators.step_control.base_step_controller import (
 )
 
 
-def resolve_gain_spec(spec, order: int) -> float:
-    """Return the gain value, calling ``spec`` with ``order`` if callable."""
-    if callable(spec):
-        return float(spec(order))
-    return float(spec)
+class OrderDependentGain:
+    """A controller gain given as a pure callable of algorithm order.
 
+    Wrapping the callable admits it to the canonical serialization
+    domain: identity is the callable's source text, so the config
+    hash keys on the gain rule and the separately stored
+    ``algorithm_order`` field.
+    """
 
-class GainValue:
-    """Gain spec plus its float at ``order``; identity is the float."""
+    __slots__ = ("fn", "source")
 
-    __slots__ = ("spec", "resolved")
+    def __init__(self, fn: Callable[[int], float]) -> None:
+        self.fn = fn
+        self.source = getsource(fn)
 
-    def __init__(self, spec, order: int) -> None:
-        if isinstance(spec, GainValue):
-            spec = spec.spec
-        if not callable(spec) and not isinstance(
-            spec, _expand_dtype(float)
-        ):
-            raise TypeError(
-                "gain must be a float or a callable taking the "
-                f"algorithm order, got {type(spec)!r}"
-            )
-        self.spec = spec
-        self.resolved = resolve_gain_spec(spec, order)
+    def __call__(self, order: int) -> float:
+        return float(self.fn(order))
 
     def __eq__(self, other) -> bool:
-        if isinstance(other, GainValue):
-            return self.resolved == other.resolved
+        if isinstance(other, OrderDependentGain):
+            return self.source == other.source
         return NotImplemented
 
     def __hash__(self) -> int:
-        return hash(self.resolved)
+        return hash(self.source)
 
     def __repr__(self) -> str:
-        return f"GainValue({self.spec!r}, resolved={self.resolved!r})"
+        return f"OrderDependentGain({self.fn!r})"
 
-    def _cubie_canonical_(self) -> float:
-        return self.resolved
+    def _cubie_canonical_(self) -> str:
+        return self.source
 
 
-def gain_value_converter(value, self_) -> GainValue:
-    """Wrap a gain as a GainValue at the config's algorithm order."""
-    return GainValue(value, self_.algorithm_order)
+def gain_converter(value):
+    """Coerce a gain spec to a float or an order-dependent gain."""
+    if isinstance(value, OrderDependentGain):
+        return value
+    if callable(value):
+        return OrderDependentGain(value)
+    return float(value)
 
 
 @frozen
@@ -121,6 +118,12 @@ class AdaptiveStepControlConfig(BaseStepControllerConfig):
         default=1.2,
         validator=getype_validator(float, 1.0),
     )
+
+    def _resolve_gain(self, gain) -> float:
+        """Return a gain as a precision float at the algorithm order."""
+        if isinstance(gain, OrderDependentGain):
+            gain = gain(self.algorithm_order)
+        return self.precision(gain)
 
     @property
     def dt_min(self) -> float:

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -13,6 +13,9 @@ from cubie.memory.mem_manager import MemoryManager
 from numpy.testing import assert_allclose
 
 from cubie.integrators.SingleIntegratorRun import SingleIntegratorRun
+from cubie.integrators.step_control.adaptive_step_controller import (
+    resolve_gain_spec,
+)
 from cubie.odesystems.symbolic import SymbolicODE
 from cubie.batchsolving.solver import Solver
 from cubie.outputhandling import OutputFunctions
@@ -1362,13 +1365,24 @@ def _build_cpu_step_controller(
             "newton_target_iters"
         ],
     )
+    order = step_controller_settings["algorithm_order"]
     if kind == "pi":
-        controller.kp = step_controller_settings["kp"]
-        controller.ki = step_controller_settings["ki"]
+        controller.kp = resolve_gain_spec(
+            step_controller_settings["kp"], order
+        )
+        controller.ki = resolve_gain_spec(
+            step_controller_settings["ki"], order
+        )
     elif kind == "pid":
-        controller.kp = step_controller_settings["kp"]
-        controller.ki = step_controller_settings["ki"]
-        controller.kd = step_controller_settings["kd"]
+        controller.kp = resolve_gain_spec(
+            step_controller_settings["kp"], order
+        )
+        controller.ki = resolve_gain_spec(
+            step_controller_settings["ki"], order
+        )
+        controller.kd = resolve_gain_spec(
+            step_controller_settings["kd"], order
+        )
     return controller
 
 

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -2087,12 +2087,15 @@ DENSE_PREDICTION_ITERATION_CASES = [
         },
         id="dirk-explicit-first-stage",
     ),
+    # rtol=0 skips the correction-norm floor so counts stay strict.
     pytest.param(
         {
             **LORENZ_ITERATION_BASE,
             "algorithm": "kvaerno3",
             "step_controller": "fixed",
             "dt": 0.005,
+            "newton_atol": 1e-7,
+            "newton_rtol": 0.0,
         },
         id="dirk-repeated-nodes",
     ),

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -13,9 +13,6 @@ from cubie.memory.mem_manager import MemoryManager
 from numpy.testing import assert_allclose
 
 from cubie.integrators.SingleIntegratorRun import SingleIntegratorRun
-from cubie.integrators.step_control.adaptive_step_controller import (
-    resolve_gain_spec,
-)
 from cubie.odesystems.symbolic import SymbolicODE
 from cubie.batchsolving.solver import Solver
 from cubie.outputhandling import OutputFunctions
@@ -1366,23 +1363,20 @@ def _build_cpu_step_controller(
         ],
     )
     order = step_controller_settings["algorithm_order"]
+
+    def resolve_gain(spec):
+        # Gains arrive as floats or callables of the algorithm order.
+        if callable(spec):
+            return float(spec(order))
+        return float(spec)
+
     if kind == "pi":
-        controller.kp = resolve_gain_spec(
-            step_controller_settings["kp"], order
-        )
-        controller.ki = resolve_gain_spec(
-            step_controller_settings["ki"], order
-        )
+        controller.kp = resolve_gain(step_controller_settings["kp"])
+        controller.ki = resolve_gain(step_controller_settings["ki"])
     elif kind == "pid":
-        controller.kp = resolve_gain_spec(
-            step_controller_settings["kp"], order
-        )
-        controller.ki = resolve_gain_spec(
-            step_controller_settings["ki"], order
-        )
-        controller.kd = resolve_gain_spec(
-            step_controller_settings["kd"], order
-        )
+        controller.kp = resolve_gain(step_controller_settings["kp"])
+        controller.ki = resolve_gain(step_controller_settings["ki"])
+        controller.kd = resolve_gain(step_controller_settings["kd"])
     return controller
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -688,6 +688,9 @@ def solver_settings(solver_settings_override, system, precision):
                 # Handle None values for optional float parameters
                 if value is None:
                     defaults[key] = None
+                elif callable(value):
+                    # Order-callable gains pass through uncast.
+                    defaults[key] = value
                 else:
                     defaults[key] = precision(value)
             else:

--- a/tests/integrators/algorithms/test_step_algorithms.py
+++ b/tests/integrators/algorithms/test_step_algorithms.py
@@ -748,9 +748,9 @@ def test_implicit_algorithm_selects_correction_norm(
         # DIRK without an error estimate defaults to fixed
         (DIRKStep, DIRK_TABLEAU_REGISTRY["sdirk_2_2"],
          {"step_controller": "fixed"}),
-        # DIRK with an embedded error estimate defaults to Gustafsson
+        # DIRK with an embedded error estimate defaults to PI
         (DIRKStep, DIRK_TABLEAU_REGISTRY["l_stable_sdirk_4"],
-         {"step_controller": "gustafsson"}),
+         {"step_controller": "pi"}),
         # FIRK with error estimate defaults to Gustafsson
         (FIRKStep, FIRK_TABLEAU_REGISTRY["radau"],
          {"step_controller": "gustafsson"}),

--- a/tests/integrators/algorithms/test_step_algorithms.py
+++ b/tests/integrators/algorithms/test_step_algorithms.py
@@ -625,8 +625,7 @@ def test_algorithm(
                 rel=tolerance.rel_tight,
                 abs=tolerance.abs_tight,
             ), "newton_atol set"
-            # The correction norm raises nonzero rtol requests below
-            # 4 ULPs of the working precision to that floor.
+            # Nonzero newton_rtol reads back at the 4-ULP floor.
             requested_newton_rtol = solver_settings["newton_rtol"]
             newton_rtol_floor = 4.0 * np.finfo(precision).eps
             if requested_newton_rtol > 0.0:
@@ -708,8 +707,7 @@ def test_algorithm(
                 rel=tolerance.rel_tight,
                 abs=tolerance.abs_tight,
             ), "newton_atol update"
-            # The correction norm raises nonzero rtol requests below
-            # 4 ULPs of the working precision to that floor.
+            # Nonzero newton_rtol reads back at the 4-ULP floor.
             updated_newton_rtol = updates["newton_rtol"]
             newton_rtol_floor = 4.0 * np.finfo(precision).eps
             if updated_newton_rtol > 0.0:

--- a/tests/integrators/algorithms/test_step_algorithms.py
+++ b/tests/integrators/algorithms/test_step_algorithms.py
@@ -625,8 +625,18 @@ def test_algorithm(
                 rel=tolerance.rel_tight,
                 abs=tolerance.abs_tight,
             ), "newton_atol set"
+            # The correction norm raises nonzero rtol requests below
+            # 4 ULPs of the working precision to that floor.
+            requested_newton_rtol = solver_settings["newton_rtol"]
+            newton_rtol_floor = 4.0 * np.finfo(precision).eps
+            if requested_newton_rtol > 0.0:
+                expected_newton_rtol = max(
+                    requested_newton_rtol, newton_rtol_floor
+                )
+            else:
+                expected_newton_rtol = requested_newton_rtol
             assert step_object.newton_rtol == pytest.approx(
-                solver_settings["newton_rtol"],
+                expected_newton_rtol,
                 rel=tolerance.rel_tight,
                 abs=tolerance.abs_tight,
             ), "newton_rtol set"
@@ -698,8 +708,18 @@ def test_algorithm(
                 rel=tolerance.rel_tight,
                 abs=tolerance.abs_tight,
             ), "newton_atol update"
+            # The correction norm raises nonzero rtol requests below
+            # 4 ULPs of the working precision to that floor.
+            updated_newton_rtol = updates["newton_rtol"]
+            newton_rtol_floor = 4.0 * np.finfo(precision).eps
+            if updated_newton_rtol > 0.0:
+                expected_newton_rtol = max(
+                    updated_newton_rtol, newton_rtol_floor
+                )
+            else:
+                expected_newton_rtol = updated_newton_rtol
             assert step_object.newton_rtol == pytest.approx(
-                updates["newton_rtol"],
+                expected_newton_rtol,
                 rel=tolerance.rel_tight,
                 abs=tolerance.abs_tight,
             ), "newton_rtol update"

--- a/tests/integrators/cpu_reference/cpu_utils.py
+++ b/tests/integrators/cpu_reference/cpu_utils.py
@@ -87,6 +87,21 @@ def euclidean_norm(
     return _euclidean_norm_impl(array)
 
 
+def floored_rtol(rtol: np.floating, dtype: np.dtype) -> np.floating:
+    """Mirror the device norm config's rtol floor.
+
+    Nonzero relative tolerances below 4 ULPs of the working
+    precision are normalized up at conversion on the device; apply
+    the same normalization before a CPU-reference scaled norm.
+    """
+
+    scalar_type = np.dtype(dtype).type
+    rtol_floor = scalar_type(4.0 * np.finfo(dtype).eps)
+    if rtol > 0.0:
+        return scalar_type(max(rtol, rtol_floor))
+    return scalar_type(rtol)
+
+
 @njit(cache=True)
 def _scaled_norm_impl(
     values: Array,
@@ -96,7 +111,7 @@ def _scaled_norm_impl(
 ) -> np.floating:
     """Return ``sum((|values[i]| / tol_i)^2) / n`` with
     ``tol_i = max(atol + rtol * |reference[i]|, 1e-16)``; <= 1.0 is
-    converged.
+    converged. Callers floor ``rtol`` via :func:`floored_rtol`.
     """
 
     size = values.shape[0]
@@ -130,6 +145,7 @@ def correction_norm_reference(
     """
 
     reference = np.maximum(np.abs(stage_state), np.abs(step_start))
+    rtol = floored_rtol(rtol, update.dtype)
     return _scaled_norm_impl(update, reference, atol, rtol)
 
 
@@ -149,7 +165,7 @@ def scaled_norm(
         values_array,
         reference_array,
         scalar_type(atol),
-        scalar_type(rtol),
+        floored_rtol(scalar_type(rtol), dtype),
     )
 
 @njit(cache=True)
@@ -442,14 +458,8 @@ def newton_solve(
     typed_tiny = scalar_type(np.finfo(dtype).tiny)
     typed_huge = scalar_type(np.finfo(dtype).max)
     kappa = scalar_type(0.01)
-    # Scaled norm of a rounding-noise correction (~4 ULPs).
-    eps_value = scalar_type(np.finfo(dtype).eps)
-    if rtol_value > typed_zero:
-        dz_floor = scalar_type(4.0 * eps_value / rtol_value)
-    else:
-        dz_floor = typed_zero
-    first_iteration_bound = scalar_type(max(1.0e-5, dz_floor))
-    stagnation_bound = scalar_type(max(1.0, dz_floor))
+    rtol_value = floored_rtol(rtol_value, dtype)
+    first_iteration_bound = scalar_type(1.0e-5)
     theta_decay = scalar_type(0.3)
     theta_divergence_bound = scalar_type(2.0)
     stagnation_eps = scalar_type(100.0 * np.sqrt(np.finfo(dtype).eps))
@@ -525,9 +535,9 @@ def newton_solve(
             or nonfinite
         )
         converged_stagnant = (
-            stagnant and ndz <= stagnation_bound and not diverging
+            stagnant and ndz <= typed_one and not diverging
         )
-        failed_now = diverging or (stagnant and ndz > stagnation_bound)
+        failed_now = diverging or (stagnant and ndz > typed_one)
         failed = failed or failed_now
 
         commit = judged and not failed_now and not converged_stagnant
@@ -792,7 +802,7 @@ def krylov_solve(
 
     minimal_residual = correction_type == "minimal_residual"
     tol_value = scalar_type(tolerance)
-    rtol_value = scalar_type(rtol)
+    rtol_value = floored_rtol(scalar_type(rtol), dtype)
     iteration_limit = int(max_iterations)
     order = int(neumann_order)
 

--- a/tests/integrators/cpu_reference/cpu_utils.py
+++ b/tests/integrators/cpu_reference/cpu_utils.py
@@ -442,7 +442,15 @@ def newton_solve(
     typed_tiny = scalar_type(np.finfo(dtype).tiny)
     typed_huge = scalar_type(np.finfo(dtype).max)
     kappa = scalar_type(0.01)
-    first_iteration_bound = scalar_type(1.0e-5)
+    # Scaled norm of a rounding-noise correction; bounds below it
+    # are unreachable in this precision.
+    eps_value = scalar_type(np.finfo(dtype).eps)
+    if rtol_value > typed_zero:
+        dz_floor = scalar_type(4.0 * eps_value / rtol_value)
+    else:
+        dz_floor = typed_zero
+    first_iteration_bound = scalar_type(max(1.0e-5, dz_floor))
+    stagnation_bound = scalar_type(max(1.0, dz_floor))
     theta_decay = scalar_type(0.3)
     theta_divergence_bound = scalar_type(2.0)
     stagnation_eps = scalar_type(100.0 * np.sqrt(np.finfo(dtype).eps))
@@ -518,9 +526,9 @@ def newton_solve(
             or nonfinite
         )
         converged_stagnant = (
-            stagnant and ndz <= typed_one and not diverging
+            stagnant and ndz <= stagnation_bound and not diverging
         )
-        failed_now = diverging or (stagnant and ndz > typed_one)
+        failed_now = diverging or (stagnant and ndz > stagnation_bound)
         failed = failed or failed_now
 
         commit = judged and not failed_now and not converged_stagnant

--- a/tests/integrators/cpu_reference/cpu_utils.py
+++ b/tests/integrators/cpu_reference/cpu_utils.py
@@ -88,13 +88,7 @@ def euclidean_norm(
 
 
 def floored_rtol(rtol: np.floating, dtype: np.dtype) -> np.floating:
-    """Mirror the device correction-norm config's rtol floor.
-
-    Nonzero relative tolerances below 4 ULPs of the working
-    precision are normalized up at conversion on the device; apply
-    the same normalization before a CPU-reference correction norm.
-    Residual (Krylov) norms keep the raw request.
-    """
+    """Raise a nonzero rtol below 4 ULPs of ``dtype`` to that floor."""
 
     scalar_type = np.dtype(dtype).type
     rtol_floor = scalar_type(4.0 * np.finfo(dtype).eps)
@@ -112,7 +106,7 @@ def _scaled_norm_impl(
 ) -> np.floating:
     """Return ``sum((|values[i]| / tol_i)^2) / n`` with
     ``tol_i = max(atol + rtol * |reference[i]|, 1e-16)``; <= 1.0 is
-    converged. Callers floor ``rtol`` via :func:`floored_rtol`.
+    converged.
     """
 
     size = values.shape[0]

--- a/tests/integrators/cpu_reference/cpu_utils.py
+++ b/tests/integrators/cpu_reference/cpu_utils.py
@@ -104,10 +104,7 @@ def _scaled_norm_impl(
     atol: np.floating,
     rtol: np.floating,
 ) -> np.floating:
-    """Return ``sum((|values[i]| / tol_i)^2) / n`` with
-    ``tol_i = max(atol + rtol * |reference[i]|, 1e-16)``; <= 1.0 is
-    converged.
-    """
+    """Mean squared scaled norm; tol_i = max(atol+rtol*|ref_i|, 1e-16)."""
 
     size = values.shape[0]
     zero = values.dtype.type(0.0)

--- a/tests/integrators/cpu_reference/cpu_utils.py
+++ b/tests/integrators/cpu_reference/cpu_utils.py
@@ -442,8 +442,7 @@ def newton_solve(
     typed_tiny = scalar_type(np.finfo(dtype).tiny)
     typed_huge = scalar_type(np.finfo(dtype).max)
     kappa = scalar_type(0.01)
-    # Scaled norm of a rounding-noise correction; bounds below it
-    # are unreachable in this precision.
+    # Scaled norm of a rounding-noise correction (~4 ULPs).
     eps_value = scalar_type(np.finfo(dtype).eps)
     if rtol_value > typed_zero:
         dz_floor = scalar_type(4.0 * eps_value / rtol_value)

--- a/tests/integrators/cpu_reference/cpu_utils.py
+++ b/tests/integrators/cpu_reference/cpu_utils.py
@@ -88,11 +88,12 @@ def euclidean_norm(
 
 
 def floored_rtol(rtol: np.floating, dtype: np.dtype) -> np.floating:
-    """Mirror the device norm config's rtol floor.
+    """Mirror the device correction-norm config's rtol floor.
 
     Nonzero relative tolerances below 4 ULPs of the working
     precision are normalized up at conversion on the device; apply
-    the same normalization before a CPU-reference scaled norm.
+    the same normalization before a CPU-reference correction norm.
+    Residual (Krylov) norms keep the raw request.
     """
 
     scalar_type = np.dtype(dtype).type
@@ -165,7 +166,7 @@ def scaled_norm(
         values_array,
         reference_array,
         scalar_type(atol),
-        floored_rtol(scalar_type(rtol), dtype),
+        scalar_type(rtol),
     )
 
 @njit(cache=True)
@@ -802,7 +803,7 @@ def krylov_solve(
 
     minimal_residual = correction_type == "minimal_residual"
     tol_value = scalar_type(tolerance)
-    rtol_value = floored_rtol(scalar_type(rtol), dtype)
+    rtol_value = scalar_type(rtol)
     iteration_limit = int(max_iterations)
     order = int(neumann_order)
 

--- a/tests/integrators/matrix_free_solvers/conftest.py
+++ b/tests/integrators/matrix_free_solvers/conftest.py
@@ -152,6 +152,26 @@ NEWTON_CONVERGENCE_EDGE_CASES = {
         expected_finals=(0.0, 0.0),
         final_tolerance=0.0,
     ),
+    # Residual pinned at 2 ULPs of the state: the scaled correction
+    # sits between 1e-5 and 4*eps/rtol, so the first iteration
+    # converges at the precision floor instead of stagnating.
+    "tolerance-floor-accept": dict(
+        kind="noise",
+        n=1,
+        newton_atol=1e-30,
+        newton_rtol=1e-7,
+        newton_max_iters=4,
+        krylov_atol=1e-20,
+        krylov_max_iters=8,
+        initials=(1.0, 1.0),
+        expected_statuses=(
+            CUBIE_RESULT_CODES.SUCCESS,
+            CUBIE_RESULT_CODES.SUCCESS,
+        ),
+        expected_counts=(1, 1),
+        expected_finals=(1.0, 1.0),
+        final_tolerance=1e-5,
+    ),
 }
 
 
@@ -166,6 +186,7 @@ def newton_edge_system(newton_edge_case, precision):
     """Compile the residual and operator for one edge case."""
     kind = newton_edge_case["kind"]
     target = precision(4.0)
+    noise = precision(2.0 * float(np.finfo(precision).eps))
 
     @cuda.jit(device=True)
     def residual(
@@ -173,6 +194,8 @@ def newton_edge_system(newton_edge_case, precision):
     ):
         if kind == "zero":
             out[0] = precision(0.0)
+        elif kind == "noise":
+            out[0] = noise
         elif kind == "linear":
             out[0] = target - state[0]
         elif kind == "constant" or kind == "zero-operator":
@@ -233,7 +256,7 @@ def newton_edge_solver(newton_edge_case, newton_edge_system, precision):
         solver_width=case["n"],
         linear_solver=linear_solver,
         newton_atol=case["newton_atol"],
-        newton_rtol=0.0,
+        newton_rtol=case.get("newton_rtol", 0.0),
         newton_max_iters=case["newton_max_iters"],
     )
     newton.update(residual_function=newton_edge_system["residual"])

--- a/tests/integrators/matrix_free_solvers/conftest.py
+++ b/tests/integrators/matrix_free_solvers/conftest.py
@@ -152,9 +152,7 @@ NEWTON_CONVERGENCE_EDGE_CASES = {
         expected_finals=(0.0, 0.0),
         final_tolerance=0.0,
     ),
-    # Residual pinned at 2 ULPs of the state: the scaled correction
-    # sits between 1e-5 and 4*eps/rtol, so the first iteration
-    # converges at the precision floor instead of stagnating.
+    # Residual pinned at 2 ULPs: converges at the precision floor.
     "tolerance-floor-accept": dict(
         kind="noise",
         n=1,

--- a/tests/integrators/matrix_free_solvers/conftest.py
+++ b/tests/integrators/matrix_free_solvers/conftest.py
@@ -40,6 +40,7 @@ NEWTON_CONVERGENCE_EDGE_CASES = {
         kind="zero",
         n=1,
         newton_atol=1e-6,
+        newton_rtol=0.0,
         newton_max_iters=4,
         krylov_atol=1e-6,
         krylov_max_iters=8,
@@ -56,6 +57,7 @@ NEWTON_CONVERGENCE_EDGE_CASES = {
         kind="linear",
         n=1,
         newton_atol=1e-2,
+        newton_rtol=0.0,
         newton_max_iters=8,
         krylov_atol=1e-6,
         krylov_max_iters=8,
@@ -72,6 +74,7 @@ NEWTON_CONVERGENCE_EDGE_CASES = {
         kind="constant",
         n=1,
         newton_atol=1e-2,
+        newton_rtol=0.0,
         newton_max_iters=4,
         krylov_atol=1e-6,
         krylov_max_iters=8,
@@ -88,6 +91,7 @@ NEWTON_CONVERGENCE_EDGE_CASES = {
         kind="root",
         n=1,
         newton_atol=1e-2,
+        newton_rtol=0.0,
         newton_max_iters=4,
         krylov_atol=1e-6,
         krylov_max_iters=8,
@@ -104,6 +108,7 @@ NEWTON_CONVERGENCE_EDGE_CASES = {
         kind="mixed-diag",
         n=2,
         newton_atol=1e-3,
+        newton_rtol=0.0,
         newton_max_iters=32,
         krylov_atol=1e-12,
         krylov_max_iters=1,
@@ -122,6 +127,7 @@ NEWTON_CONVERGENCE_EDGE_CASES = {
         kind="cubic",
         n=1,
         newton_atol=1e-20,
+        newton_rtol=0.0,
         newton_max_iters=1,
         krylov_atol=1e-8,
         krylov_max_iters=20,
@@ -138,6 +144,7 @@ NEWTON_CONVERGENCE_EDGE_CASES = {
         kind="zero-operator",
         n=1,
         newton_atol=1e-8,
+        newton_rtol=0.0,
         newton_max_iters=4,
         krylov_atol=1e-20,
         krylov_max_iters=8,
@@ -152,12 +159,15 @@ NEWTON_CONVERGENCE_EDGE_CASES = {
         expected_finals=(0.0, 0.0),
         final_tolerance=0.0,
     ),
-    # Residual pinned at 2 ULPs: converges at the precision floor.
+    # Residual pinned at 2 ULPs with a sub-noise rtol request: the
+    # norm config floors rtol at 4 ULPs (with a warning) so the
+    # noise-level correction converges via stagnation instead of
+    # feeding the fail loop.
     "tolerance-floor-accept": dict(
         kind="noise",
         n=1,
         newton_atol=1e-30,
-        newton_rtol=1e-7,
+        newton_rtol=1e-30,
         newton_max_iters=4,
         krylov_atol=1e-20,
         krylov_max_iters=8,
@@ -166,7 +176,7 @@ NEWTON_CONVERGENCE_EDGE_CASES = {
             CUBIE_RESULT_CODES.SUCCESS,
             CUBIE_RESULT_CODES.SUCCESS,
         ),
-        expected_counts=(1, 1),
+        expected_counts=(2, 2),
         expected_finals=(1.0, 1.0),
         final_tolerance=1e-5,
     ),
@@ -254,7 +264,7 @@ def newton_edge_solver(newton_edge_case, newton_edge_system, precision):
         solver_width=case["n"],
         linear_solver=linear_solver,
         newton_atol=case["newton_atol"],
-        newton_rtol=case.get("newton_rtol", 0.0),
+        newton_rtol=case["newton_rtol"],
         newton_max_iters=case["newton_max_iters"],
     )
     newton.update(residual_function=newton_edge_system["residual"])

--- a/tests/integrators/matrix_free_solvers/conftest.py
+++ b/tests/integrators/matrix_free_solvers/conftest.py
@@ -159,10 +159,7 @@ NEWTON_CONVERGENCE_EDGE_CASES = {
         expected_finals=(0.0, 0.0),
         final_tolerance=0.0,
     ),
-    # Residual pinned at 2 ULPs with a sub-noise rtol request: the
-    # norm config floors rtol at 4 ULPs (with a warning) so the
-    # noise-level correction converges via stagnation instead of
-    # feeding the fail loop.
+    # Floored rtol lets the 2-ULP residual converge via stagnation.
     "tolerance-floor-accept": dict(
         kind="noise",
         n=1,

--- a/tests/integrators/matrix_free_solvers/test_newton_krylov.py
+++ b/tests/integrators/matrix_free_solvers/test_newton_krylov.py
@@ -34,6 +34,7 @@ def test_newton_krylov_update_with_no_changes_returns_empty_set(precision):
         "small-first-step",
         "stagnation-divergence",
         "theta-growth-divergence",
+        "tolerance-floor-accept",
         "warm-start",
     ],
     indirect=True,

--- a/tests/integrators/step_control/test_gain_specs.py
+++ b/tests/integrators/step_control/test_gain_specs.py
@@ -110,7 +110,7 @@ def test_dirk_adaptive_defaults_use_order_callable_pi():
     assert defaults["min_gain"] == 0.2
     assert defaults["max_gain"] == 10.0
     assert defaults["safety"] == 0.9
-    assert defaults["deadband_min"] == 1.0
+    assert defaults["deadband_min"] == pytest.approx(1.0 / 1.2)
     assert defaults["deadband_max"] == 1.0
     assert dirk_default_kp(3) == pytest.approx(0.7 * 4 / 3)
     assert dirk_default_ki(5) == pytest.approx(-0.4 * 6 / 5)

--- a/tests/integrators/step_control/test_gain_specs.py
+++ b/tests/integrators/step_control/test_gain_specs.py
@@ -16,14 +16,18 @@ from cubie.integrators.step_control.adaptive_PID_controller import (
     PIDStepControlConfig,
 )
 from cubie.integrators.step_control.adaptive_step_controller import (
-    resolve_gain_spec,
+    OrderDependentGain,
+    gain_converter,
 )
 
 
-def test_resolve_gain_spec_constant_and_callable():
-    """resolve_gain_spec passes floats through and calls callables."""
-    assert resolve_gain_spec(0.7, 3) == 0.7
-    assert resolve_gain_spec(lambda order: 0.1 * order, 5) == 0.5
+def test_gain_converter_constant_and_callable():
+    """gain_converter passes floats through and wraps callables."""
+    assert gain_converter(0.7) == 0.7
+    wrapped = gain_converter(dirk_default_kp)
+    assert isinstance(wrapped, OrderDependentGain)
+    assert wrapped(3) == pytest.approx(0.7 * 4 / 3)
+    assert gain_converter(wrapped) is wrapped
 
 
 def test_pi_config_resolves_callable_gains_at_order():
@@ -36,7 +40,7 @@ def test_pi_config_resolves_callable_gains_at_order():
     )
     assert cfg.kp == pytest.approx(0.7 * 4 / 3)
     assert cfg.ki == pytest.approx(-0.4 * 4 / 3)
-    assert cfg.settings_dict["kp"] is dirk_default_kp
+    assert cfg.settings_dict["kp"].fn is dirk_default_kp
 
 
 def test_pid_config_resolves_callable_kd():
@@ -50,24 +54,28 @@ def test_pid_config_resolves_callable_kd():
 
 
 def test_pi_config_rejects_non_numeric_non_callable():
-    """A gain that is neither float nor callable raises TypeError."""
-    with pytest.raises(TypeError):
-        PIStepControlConfig(precision=np.float64, kp="0.7")
+    """A gain that is neither float nor callable raises."""
+    with pytest.raises((TypeError, ValueError)):
+        PIStepControlConfig(precision=np.float64, kp="not a gain")
 
 
-def test_callable_gain_hashes_as_resolved_value():
-    """values_hash keys on the resolved gain, not the spec object."""
-    from_callable = PIStepControlConfig(
+def test_callable_gain_hashes_by_rule_and_order():
+    """values_hash keys on the gain rule and the algorithm order."""
+    base = PIStepControlConfig(
         precision=np.float64, algorithm_order=3, kp=dirk_default_kp
     )
-    from_constant = PIStepControlConfig(
-        precision=np.float64, algorithm_order=3, kp=0.7 * 4 / 3
+    same_rule = PIStepControlConfig(
+        precision=np.float64, algorithm_order=3, kp=dirk_default_kp
     )
-    different = PIStepControlConfig(
-        precision=np.float64, algorithm_order=3, kp=0.9
+    other_order = PIStepControlConfig(
+        precision=np.float64, algorithm_order=5, kp=dirk_default_kp
     )
-    assert from_callable.values_hash == from_constant.values_hash
-    assert from_callable.values_hash != different.values_hash
+    other_rule = PIStepControlConfig(
+        precision=np.float64, algorithm_order=3, kp=dirk_default_ki
+    )
+    assert base.values_hash == same_rule.values_hash
+    assert base.values_hash != other_order.values_hash
+    assert base.values_hash != other_rule.values_hash
 
 
 def test_controller_reresolves_gains_on_order_update():
@@ -87,7 +95,7 @@ def test_controller_reresolves_gains_on_order_update():
 
 
 def test_controller_settings_dict_preserves_gain_specs():
-    """settings_dict carries the supplied spec, not the resolved value."""
+    """settings_dict carries the supplied rule, not a resolved float."""
     controller = AdaptivePIController(
         precision=np.float64,
         n=3,
@@ -97,8 +105,29 @@ def test_controller_settings_dict_preserves_gain_specs():
         ki=-0.4,
     )
     settings = controller.settings_dict
-    assert settings["kp"] is dirk_default_kp
+    assert settings["kp"].fn is dirk_default_kp
     assert settings["ki"] == pytest.approx(-0.4)
+
+
+def test_settings_dict_round_trips_through_reconstruction():
+    """A config rebuilt from settings_dict keeps order tracking."""
+    controller = AdaptivePIController(
+        precision=np.float64,
+        n=3,
+        dt=0.01,
+        algorithm_order=3,
+        kp=dirk_default_kp,
+        ki=dirk_default_ki,
+    )
+    settings = controller.settings_dict
+    rebuilt = PIStepControlConfig(
+        precision=np.float64,
+        algorithm_order=5,
+        kp=settings["kp"],
+        ki=settings["ki"],
+    )
+    assert rebuilt.kp == pytest.approx(0.7 * 6 / 5)
+    assert rebuilt.ki == pytest.approx(-0.4 * 6 / 5)
 
 
 def test_dirk_adaptive_defaults_use_order_callable_pi():

--- a/tests/integrators/step_control/test_gain_specs.py
+++ b/tests/integrators/step_control/test_gain_specs.py
@@ -1,6 +1,5 @@
 """Tests for float-or-callable controller gain specifications."""
 
-import numpy as np
 import pytest
 
 from cubie.integrators.algorithms.generic_dirk import (
@@ -8,17 +7,28 @@ from cubie.integrators.algorithms.generic_dirk import (
     dirk_default_ki,
     dirk_default_kp,
 )
-from cubie.integrators.step_control.adaptive_PI_controller import (
-    AdaptivePIController,
-    PIStepControlConfig,
-)
-from cubie.integrators.step_control.adaptive_PID_controller import (
-    PIDStepControlConfig,
-)
 from cubie.integrators.step_control.adaptive_step_controller import (
     OrderDependentGain,
     gain_converter,
 )
+
+
+def half_over_order(order):
+    """Reference kd callable for the PID case."""
+    return 0.05 / order
+
+
+PI_CALLABLE_GAINS = {
+    "step_controller": "pi",
+    "kp": dirk_default_kp,
+    "ki": dirk_default_ki,
+}
+PID_CALLABLE_GAINS = {
+    "step_controller": "pid",
+    "kp": dirk_default_kp,
+    "ki": dirk_default_ki,
+    "kd": half_over_order,
+}
 
 
 def test_gain_converter_constant_and_callable():
@@ -30,108 +40,86 @@ def test_gain_converter_constant_and_callable():
     assert gain_converter(wrapped) is wrapped
 
 
-def test_pi_config_resolves_callable_gains_at_order():
-    """Callable kp/ki resolve against the config's algorithm order."""
-    cfg = PIStepControlConfig(
-        precision=np.float64,
-        algorithm_order=3,
-        kp=dirk_default_kp,
-        ki=dirk_default_ki,
-    )
-    assert cfg.kp == pytest.approx(0.7 * 4 / 3)
-    assert cfg.ki == pytest.approx(-0.4 * 4 / 3)
-    assert cfg.settings_dict["kp"].fn is dirk_default_kp
-
-
-def test_pid_config_resolves_callable_kd():
-    """PID's kd accepts a callable of the order."""
-    cfg = PIDStepControlConfig(
-        precision=np.float64,
-        algorithm_order=4,
-        kd=lambda order: 0.05 / order,
-    )
-    assert cfg.kd == pytest.approx(0.05 / 4)
-
-
-def test_pi_config_rejects_non_numeric_non_callable():
+def test_gain_converter_rejects_non_numeric_non_callable():
     """A gain that is neither float nor callable raises."""
     with pytest.raises((TypeError, ValueError)):
-        PIStepControlConfig(precision=np.float64, kp="not a gain")
+        gain_converter("not a gain")
 
 
-def test_callable_gain_hashes_by_rule_and_order():
-    """values_hash keys on the gain rule and the algorithm order."""
-    base = PIStepControlConfig(
-        precision=np.float64, algorithm_order=3, kp=dirk_default_kp
-    )
-    same_rule = PIStepControlConfig(
-        precision=np.float64, algorithm_order=3, kp=dirk_default_kp
-    )
-    other_order = PIStepControlConfig(
-        precision=np.float64, algorithm_order=5, kp=dirk_default_kp
-    )
-    other_rule = PIStepControlConfig(
-        precision=np.float64, algorithm_order=3, kp=dirk_default_ki
-    )
-    assert base.values_hash == same_rule.values_hash
-    assert base.values_hash != other_order.values_hash
-    assert base.values_hash != other_rule.values_hash
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [PI_CALLABLE_GAINS],
+    ids=["pi-callable-gains"],
+    indirect=True,
+)
+class TestPICallableGains:
+    def test_config_resolves_callable_gains_at_order(
+        self, step_controller
+    ):
+        """Callable kp/ki resolve at the config's algorithm order."""
+        cfg = step_controller.compile_settings
+        order = cfg.algorithm_order
+        assert cfg.kp == pytest.approx(0.7 * (order + 1) / order)
+        assert cfg.ki == pytest.approx(-0.4 * (order + 1) / order)
+
+    def test_settings_dict_preserves_gain_specs(self, step_controller):
+        """settings_dict carries the supplied rule, not a float."""
+        settings = step_controller.settings_dict
+        assert settings["kp"].fn is dirk_default_kp
+        assert settings["ki"].fn is dirk_default_ki
+
+    def test_hash_keys_on_rule_and_order(self, step_controller):
+        """values_hash keys on the gain rule and the order."""
+        cfg = step_controller.compile_settings
+        base_hash = cfg.values_hash
+        same_rule, _, changed = cfg.update({"kp": dirk_default_kp})
+        assert changed == set()
+        assert same_rule.values_hash == base_hash
+        other_order, _, changed = cfg.update(
+            {"algorithm_order": cfg.algorithm_order + 2}
+        )
+        assert "algorithm_order" in changed
+        assert other_order.values_hash != base_hash
+        other_rule, _, _ = cfg.update({"kp": dirk_default_ki})
+        assert other_rule.values_hash != base_hash
+
+    def test_order_update_reresolves_gains(
+        self, step_controller_mutable
+    ):
+        """An algorithm_order update re-evaluates callable gains."""
+        controller = step_controller_mutable
+        order = controller.algorithm_order + 2
+        controller.update_compile_settings({"algorithm_order": order})
+        assert controller.kp == pytest.approx(
+            0.7 * (order + 1) / order
+        )
+        assert controller.ki == pytest.approx(
+            -0.4 * (order + 1) / order
+        )
+
+    def test_settings_dict_round_trips(self, step_controller):
+        """The exported spec re-enters the config unchanged."""
+        cfg = step_controller.compile_settings
+        settings = step_controller.settings_dict
+        replacement, _, changed = cfg.update({"kp": settings["kp"]})
+        assert changed == set()
+        assert replacement.kp == cfg.kp
 
 
-def test_controller_reresolves_gains_on_order_update():
-    """An algorithm_order update re-evaluates callable gains."""
-    controller = AdaptivePIController(
-        precision=np.float64,
-        n=3,
-        dt=0.01,
-        algorithm_order=3,
-        kp=dirk_default_kp,
-        ki=dirk_default_ki,
-    )
-    assert controller.kp == pytest.approx(0.7 * 4 / 3)
-    controller.update_compile_settings({"algorithm_order": 5})
-    assert controller.kp == pytest.approx(0.7 * 6 / 5)
-    assert controller.ki == pytest.approx(-0.4 * 6 / 5)
-
-
-def test_controller_settings_dict_preserves_gain_specs():
-    """settings_dict carries the supplied rule, not a resolved float."""
-    controller = AdaptivePIController(
-        precision=np.float64,
-        n=3,
-        dt=0.01,
-        algorithm_order=3,
-        kp=dirk_default_kp,
-        ki=-0.4,
-    )
-    settings = controller.settings_dict
-    assert settings["kp"].fn is dirk_default_kp
-    assert settings["ki"] == pytest.approx(-0.4)
-
-
-def test_settings_dict_round_trips_through_reconstruction():
-    """A config rebuilt from settings_dict keeps order tracking."""
-    controller = AdaptivePIController(
-        precision=np.float64,
-        n=3,
-        dt=0.01,
-        algorithm_order=3,
-        kp=dirk_default_kp,
-        ki=dirk_default_ki,
-    )
-    settings = controller.settings_dict
-    rebuilt = PIStepControlConfig(
-        precision=np.float64,
-        algorithm_order=5,
-        kp=settings["kp"],
-        ki=settings["ki"],
-    )
-    assert rebuilt.kp == pytest.approx(0.7 * 6 / 5)
-    assert rebuilt.ki == pytest.approx(-0.4 * 6 / 5)
+@pytest.mark.parametrize(
+    "solver_settings_override",
+    [PID_CALLABLE_GAINS],
+    ids=["pid-callable-gains"],
+    indirect=True,
+)
+def test_pid_config_resolves_callable_kd(step_controller):
+    """PID's kd accepts a callable of the order."""
+    cfg = step_controller.compile_settings
+    assert cfg.kd == pytest.approx(0.05 / cfg.algorithm_order)
 
 
 def test_dirk_adaptive_defaults_use_order_callable_pi():
-    """DIRK adaptive defaults select PI with the order-callable gains."""
+    """DIRK adaptive defaults select PI with the order callables."""
     defaults = DIRK_ADAPTIVE_DEFAULTS.step_controller
     assert defaults["step_controller"] == "pi"
     assert defaults["kp"] is dirk_default_kp

--- a/tests/integrators/step_control/test_gain_specs.py
+++ b/tests/integrators/step_control/test_gain_specs.py
@@ -1,0 +1,116 @@
+"""Tests for float-or-callable controller gain specifications."""
+
+import numpy as np
+import pytest
+
+from cubie.integrators.algorithms.generic_dirk import (
+    DIRK_ADAPTIVE_DEFAULTS,
+    dirk_default_ki,
+    dirk_default_kp,
+)
+from cubie.integrators.step_control.adaptive_PI_controller import (
+    AdaptivePIController,
+    PIStepControlConfig,
+)
+from cubie.integrators.step_control.adaptive_PID_controller import (
+    PIDStepControlConfig,
+)
+from cubie.integrators.step_control.adaptive_step_controller import (
+    resolve_gain_spec,
+)
+
+
+def test_resolve_gain_spec_constant_and_callable():
+    """resolve_gain_spec passes floats through and calls callables."""
+    assert resolve_gain_spec(0.7, 3) == 0.7
+    assert resolve_gain_spec(lambda order: 0.1 * order, 5) == 0.5
+
+
+def test_pi_config_resolves_callable_gains_at_order():
+    """Callable kp/ki resolve against the config's algorithm order."""
+    cfg = PIStepControlConfig(
+        precision=np.float64,
+        algorithm_order=3,
+        kp=dirk_default_kp,
+        ki=dirk_default_ki,
+    )
+    assert cfg.kp == pytest.approx(0.7 * 4 / 3)
+    assert cfg.ki == pytest.approx(-0.4 * 4 / 3)
+    assert cfg.kp_spec is dirk_default_kp
+
+
+def test_pid_config_resolves_callable_kd():
+    """PID's kd accepts a callable of the order."""
+    cfg = PIDStepControlConfig(
+        precision=np.float64,
+        algorithm_order=4,
+        kd=lambda order: 0.05 / order,
+    )
+    assert cfg.kd == pytest.approx(0.05 / 4)
+
+
+def test_pi_config_rejects_non_numeric_non_callable():
+    """A gain that is neither float nor callable raises TypeError."""
+    with pytest.raises(TypeError):
+        PIStepControlConfig(precision=np.float64, kp="0.7")
+
+
+def test_callable_gain_hashes_as_resolved_value():
+    """values_hash keys on the resolved gain, not the spec object."""
+    from_callable = PIStepControlConfig(
+        precision=np.float64, algorithm_order=3, kp=dirk_default_kp
+    )
+    from_constant = PIStepControlConfig(
+        precision=np.float64, algorithm_order=3, kp=0.7 * 4 / 3
+    )
+    different = PIStepControlConfig(
+        precision=np.float64, algorithm_order=3, kp=0.9
+    )
+    assert from_callable.values_hash == from_constant.values_hash
+    assert from_callable.values_hash != different.values_hash
+
+
+def test_controller_reresolves_gains_on_order_update():
+    """An algorithm_order update re-evaluates callable gains."""
+    controller = AdaptivePIController(
+        precision=np.float64,
+        n=3,
+        dt=0.01,
+        algorithm_order=3,
+        kp=dirk_default_kp,
+        ki=dirk_default_ki,
+    )
+    assert controller.kp == pytest.approx(0.7 * 4 / 3)
+    controller.update_compile_settings({"algorithm_order": 5})
+    assert controller.kp == pytest.approx(0.7 * 6 / 5)
+    assert controller.ki == pytest.approx(-0.4 * 6 / 5)
+
+
+def test_controller_settings_dict_preserves_gain_specs():
+    """settings_dict carries the supplied spec, not the resolved value."""
+    controller = AdaptivePIController(
+        precision=np.float64,
+        n=3,
+        dt=0.01,
+        algorithm_order=3,
+        kp=dirk_default_kp,
+        ki=-0.4,
+    )
+    settings = controller.settings_dict
+    assert settings["kp"] is dirk_default_kp
+    assert settings["ki"] == pytest.approx(-0.4)
+
+
+def test_dirk_adaptive_defaults_use_order_callable_pi():
+    """DIRK adaptive defaults select PI with the order-callable gains."""
+    defaults = DIRK_ADAPTIVE_DEFAULTS.step_controller
+    assert defaults["step_controller"] == "pi"
+    assert defaults["kp"] is dirk_default_kp
+    assert defaults["ki"] is dirk_default_ki
+    assert defaults["min_gain"] == 0.2
+    assert defaults["max_gain"] == 10.0
+    assert defaults["safety"] == 0.9
+    assert defaults["deadband_min"] == 1.0
+    assert defaults["deadband_max"] == 1.0
+    assert dirk_default_kp(3) == pytest.approx(0.7 * 4 / 3)
+    assert dirk_default_ki(5) == pytest.approx(-0.4 * 6 / 5)

--- a/tests/integrators/step_control/test_gain_specs.py
+++ b/tests/integrators/step_control/test_gain_specs.py
@@ -36,7 +36,7 @@ def test_pi_config_resolves_callable_gains_at_order():
     )
     assert cfg.kp == pytest.approx(0.7 * 4 / 3)
     assert cfg.ki == pytest.approx(-0.4 * 4 / 3)
-    assert cfg.kp_spec is dirk_default_kp
+    assert cfg.settings_dict["kp"] is dirk_default_kp
 
 
 def test_pid_config_resolves_callable_kd():

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -85,6 +85,41 @@ def test_construction_explicit_settings(
     )
 
 
+def test_newton_rtol_inversion_warns(
+    system,
+    driver_array,
+    output_settings,
+    loop_settings,
+):
+    """A sub-floor controller rtol warns of the Newton inversion.
+
+    Constructor-shape test: the chain fixtures cannot express a
+    per-test controller tolerance, so this builds directly.
+    """
+    def build(rtol):
+        return SingleIntegratorRun(
+            system=system,
+            loop_settings=dict(loop_settings),
+            evaluate_driver_at_t=_get_evaluate_driver_at_t(driver_array),
+            step_control_settings={
+                "step_controller": "pi",
+                "rtol": rtol,
+            },
+            algorithm_settings={"algorithm": "dirk"},
+            output_settings=dict(output_settings),
+        )
+
+    with pytest.warns(UserWarning, match="newton_rtol"):
+        build(1e-10)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        build(1e-4)
+    assert not [
+        w for w in caught if "newton_rtol" in str(w.message)
+    ]
+
+
 def test_default_controller_settings_from_algorithm(
     system,
     driver_array,

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -947,8 +947,7 @@ def test_explicit_inner_tolerance_survives_derivation(
     assert np.allclose(
         np.asarray(algo.krylov_rtol), np.asarray(controller.rtol)
     )
-    # Derived Newton tolerances sit at or below the controller's,
-    # up to the correction norm's 4-ULP rtol floor.
+    # Derived Newton rtol caps at max(controller rtol, 4-ULP floor).
     assert not np.allclose(algo.newton_atol, 1e-6)
     assert np.all(
         np.asarray(algo.newton_atol) <= np.asarray(controller.atol)

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -947,14 +947,16 @@ def test_explicit_inner_tolerance_survives_derivation(
     assert np.allclose(
         np.asarray(algo.krylov_rtol), np.asarray(controller.rtol)
     )
-    # Unset Newton tolerances leave the solver defaults and end up at
-    # least as tight as the controller's error tolerance.
+    # Derived Newton tolerances sit at or below the controller's,
+    # up to the correction norm's 4-ULP rtol floor.
     assert not np.allclose(algo.newton_atol, 1e-6)
     assert np.all(
         np.asarray(algo.newton_atol) <= np.asarray(controller.atol)
     )
+    newton_rtol_floor = 4.0 * np.finfo(run.precision).eps
     assert np.all(
-        np.asarray(algo.newton_rtol) <= np.asarray(controller.rtol)
+        np.asarray(algo.newton_rtol)
+        <= np.maximum(np.asarray(controller.rtol), newton_rtol_floor)
     )
     # Newton-owned linear solves retain the controller's rtol directly.
     expected_reduction = run.precision(

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -91,11 +91,7 @@ def test_newton_rtol_inversion_warns(
     output_settings,
     loop_settings,
 ):
-    """A sub-floor controller rtol warns of the Newton inversion.
-
-    Constructor-shape test: the chain fixtures cannot express a
-    per-test controller tolerance, so this builds directly.
-    """
+    """A sub-floor controller rtol warns of the Newton inversion."""
     def build(rtol):
         return SingleIntegratorRun(
             system=system,

--- a/tests/integrators/test_norms.py
+++ b/tests/integrators/test_norms.py
@@ -473,15 +473,17 @@ def test_device_function_forwards_cache():
     assert fn is factory.get_cached_output("scaled_norm")
 
 
-# ── rtol precision floor ─────────────────────────────────── #
+# ── correction-norm rtol precision floor ─────────────────── #
 
 
-def test_rtol_below_noise_floor_raised_with_warning():
-    """Nonzero rtol below 4 ULPs is floored, per component."""
+def test_correction_rtol_below_noise_floor_raised_with_warning():
+    """Nonzero correction rtol below 4 ULPs floors per component."""
+    from cubie.integrators.norms import CorrectionNormConfig
+
     floor32 = 4.0 * np.finfo(np.float32).eps
     rtol = np.array([1e-15, 0.0, 1e-3], dtype=np.float32)
     with pytest.warns(UserWarning, match="4 ULPs"):
-        cfg = ScaledNormConfig(
+        cfg = CorrectionNormConfig(
             precision=np.float32, solver_width=3, rtol=rtol
         )
     assert_allclose(
@@ -489,13 +491,27 @@ def test_rtol_below_noise_floor_raised_with_warning():
     )
 
 
-def test_rtol_at_or_above_floor_unchanged():
+def test_correction_rtol_at_or_above_floor_unchanged():
     """rtol at or above the floor passes through without warning."""
+    import warnings as warnings_module
+
+    from cubie.integrators.norms import CorrectionNormConfig
+
+    with warnings_module.catch_warnings():
+        warnings_module.simplefilter("error")
+        cfg = CorrectionNormConfig(
+            precision=np.float64, solver_width=2, rtol=1e-9
+        )
+    assert_allclose(cfg.rtol, [1e-9, 1e-9])
+
+
+def test_residual_norm_rtol_not_floored():
+    """Plain scaled norms keep sub-ULP rtol requests unchanged."""
     import warnings as warnings_module
 
     with warnings_module.catch_warnings():
         warnings_module.simplefilter("error")
         cfg = ScaledNormConfig(
-            precision=np.float64, solver_width=2, rtol=1e-9
+            precision=np.float32, solver_width=2, rtol=1e-15
         )
-    assert_allclose(cfg.rtol, [1e-9, 1e-9])
+    assert_allclose(cfg.rtol, np.array([1e-15, 1e-15], np.float32))

--- a/tests/integrators/test_norms.py
+++ b/tests/integrators/test_norms.py
@@ -471,3 +471,31 @@ def test_device_function_forwards_cache():
     factory = ScaledNorm(precision=np.float64, solver_width=2)
     fn = factory.device_function
     assert fn is factory.get_cached_output("scaled_norm")
+
+
+# ── rtol precision floor ─────────────────────────────────── #
+
+
+def test_rtol_below_noise_floor_raised_with_warning():
+    """Nonzero rtol below 4 ULPs is floored, per component."""
+    floor32 = 4.0 * np.finfo(np.float32).eps
+    rtol = np.array([1e-15, 0.0, 1e-3], dtype=np.float32)
+    with pytest.warns(UserWarning, match="4 ULPs"):
+        cfg = ScaledNormConfig(
+            precision=np.float32, solver_width=3, rtol=rtol
+        )
+    assert_allclose(
+        cfg.rtol, np.array([floor32, 0.0, 1e-3], dtype=np.float32)
+    )
+
+
+def test_rtol_at_or_above_floor_unchanged():
+    """rtol at or above the floor passes through without warning."""
+    import warnings as warnings_module
+
+    with warnings_module.catch_warnings():
+        warnings_module.simplefilter("error")
+        cfg = ScaledNormConfig(
+            precision=np.float64, solver_width=2, rtol=1e-9
+        )
+    assert_allclose(cfg.rtol, [1e-9, 1e-9])

--- a/tests/integrators/test_norms.py
+++ b/tests/integrators/test_norms.py
@@ -640,7 +640,7 @@ def test_correction_rtol_below_noise_floor_raised_silently():
     with warnings_module.catch_warnings():
         warnings_module.simplefilter("error")
         cfg = CorrectionNormConfig(
-            precision=np.float32, solver_width=3, rtol=rtol
+            precision=np.float32, solver_width=3, n=3, rtol=rtol
         )
     assert_allclose(
         cfg.rtol, np.array([floor32, 0.0, 1e-3], dtype=np.float32)
@@ -656,7 +656,7 @@ def test_correction_rtol_at_or_above_floor_unchanged():
     with warnings_module.catch_warnings():
         warnings_module.simplefilter("error")
         cfg = CorrectionNormConfig(
-            precision=np.float64, solver_width=2, rtol=1e-9
+            precision=np.float64, solver_width=2, n=2, rtol=1e-9
         )
     assert_allclose(cfg.rtol, [1e-9, 1e-9])
 
@@ -668,6 +668,6 @@ def test_residual_norm_rtol_not_floored():
     with warnings_module.catch_warnings():
         warnings_module.simplefilter("error")
         cfg = ScaledNormConfig(
-            precision=np.float32, solver_width=2, rtol=1e-15
+            precision=np.float32, solver_width=2, n=2, rtol=1e-15
         )
     assert_allclose(cfg.rtol, np.array([1e-15, 1e-15], np.float32))

--- a/tests/integrators/test_norms.py
+++ b/tests/integrators/test_norms.py
@@ -476,13 +476,16 @@ def test_device_function_forwards_cache():
 # ── correction-norm rtol precision floor ─────────────────── #
 
 
-def test_correction_rtol_below_noise_floor_raised_with_warning():
+def test_correction_rtol_below_noise_floor_raised_silently():
     """Nonzero correction rtol below 4 ULPs floors per component."""
+    import warnings as warnings_module
+
     from cubie.integrators.norms import CorrectionNormConfig
 
     floor32 = 4.0 * np.finfo(np.float32).eps
     rtol = np.array([1e-15, 0.0, 1e-3], dtype=np.float32)
-    with pytest.warns(UserWarning, match="4 ULPs"):
+    with warnings_module.catch_warnings():
+        warnings_module.simplefilter("error")
         cfg = CorrectionNormConfig(
             precision=np.float32, solver_width=3, rtol=rtol
         )


### PR DESCRIPTION
Two changes from the DIRK-vs-DiffEqGPU per-factor ablation (supersedes #714, which is closed unmerged), reworked after review:

**Order-callable controller gains.** `kp`/`ki` (and PID's `kd`) accept a float or a callable of the algorithm order. The config stores the raw spec: floats stay floats, callables wrap in `OrderDependentGain`, whose canonical identity is the callable's source text. The `kp`/`ki`/`kd` properties resolve on demand at the stored `algorithm_order` through a shared `AdaptiveStepControlConfig._resolve_gain`, so cache identity is the (spec, order) field pair with no stored resolved values and no post-init mutation; an order update (algorithm hot-swap included) changes the hash and the resolved gains. A callable and the constant it resolves to are distinct identities. The PI/PID configs export the stored spec through their own `settings_dict`, so hot-swap preserves order-tracking.

**DIRK adaptive defaults** are order-dependent PI controller defaults, originally modelled on OrdinaryDiffEq.jl's implicit-method PIController: `kp = 0.7(q+1)/q`, `ki = -0.4(q+1)/q` (module callables `dirk_default_kp`/`dirk_default_ki`), limits 0.2/10, safety 0.9, and the qsteady deadband `q in [1, 1.2]` (gain band `[1/1.2, 1]` holds dt on small proposed shrinks). Through the PI factory's `1/(2(q+1))` exponent fold the accepted-step exponents equal `beta1 = 7/(10q)`, `beta2 = 2/(5q)`; the rejection path still differs (CuBIE keeps the previous-error term). On the numerical-equivalence sweep the defaults now reproduce the matched-Julia-constants tier exactly. FIRK/Rosenbrock-W/Crank-Nicolson keep Gustafsson.

**NLNewton precision floor.** The acceptance bounds keep NLNewton's constants (first-iteration `1e-5`, stagnation `1.0`). Newton correction-norm `rtol` components that are nonzero and below `4*eps` of the working precision are floored silently at tolerance conversion; the stored `newton_rtol` reflects the floored value. `SingleIntegratorRunCore.warn_on_newton_rtol_inversion` is the single comparison point, called from `_apply_inner_tolerance_defaults` on construction and on controller-tolerance or algorithm updates: it warns only when the effective `newton_rtol` reaches the step controller's `rtol`. The controller rtol is never floored. A rounding-noise-level correction converges through the ordinary acceptance path instead of feeding the fail→reject→shrink loop; achievable tolerances and all residual/Krylov norms are untouched. Mirrored in the CPU reference.

**Numerical-equivalence protocol** (Lorenz f32, N=1024 rho-sweep, T=1, error vs Float64 golden, mean accepted steps; A = main, B = this branch with its new DIRK defaults; Julia = OrdinaryDiffEq recorded dataset):

| alg | tol | A err | A steps | B err | B steps | Julia err | Julia steps |
|---|---|---:|---:|---:|---:|---:|---:|
| kv3 | 1e-2 | 7.0e-2 | 17.9 | 7.7e-2 | 23.0 | 6.5e-1 | 11.9 |
| kv3 | 1e-4 | 6.9e-4 | 75.7 | 9.4e-4 | 77.2 | 5.8e-2 | 25.5 |
| kv3 | 1e-6 | 8.0e-6 | 352.3 | 9.7e-6 | 344.3 | 1.9e-3 | 66.4 |
| kv5 | 1e-2 | 4.8e-1 | 6.5 | 5.1e-2 | 12.7 | 3.1e-1 | 7.4 |
| kv5 | 1e-4 | 5.0e-3 | 13.1 | 3.7e-3 | 19.0 | 4.1e-2 | 11.5 |
| kv5 | 1e-6 | 6.2e-5 | 30.6 | 7.9e-5 | 35.9 | 3.2e-3 | 19.4 |
| radau | 1e-3 | 1.6e-5 | 26.2 | 1.6e-5 | 26.2 | 5.4e-4 | 15.1 |
| radau | 1e-6 | 5.1e-6 | 237.7 | 4.9e-6 | 237.6 | 6.1e-6 | 41.6 |

radau (Gustafsson, untouched by this PR) is numerically identical to main across the grid: the earlier draft's "adaptive −13%" gate improvement was radau Newton solves accepting first-iteration corrections at half tolerance under the old norm-derived bound, which also regressed radau error against golden (4.3e-2 at tol 1e-3 in the regenerated dataset); with the floor moved to tolerance conversion the errors are back at main's values (1.6e-5 at 1e-3).

The gate's adaptive (radau + PID, f32, tol 1e-6) improvement survives through the visible mechanism: the derived `newton_rtol = 1e-7` sits below the f32 4-ULP floor, so it normalizes to 4.77e-7 (with the warning) and Newton stops iterating on rounding noise — per-trajectory Newton iterations drop 3081 → 2029 at identical step counts (2008.5), identical rejections, and final states equal to 1 part in 1e7. No config under-solves its requested tolerance.

The residual step-count gap against Julia at equal tolerance is Julia-side: OrdinaryDiffEq's in-place ESDIRK estimate smooths `btilde·z` against the transformed Newton `W` (`J − I/(γdt)`) without the `invγdt` premultiplication, so its `EEst` carries a hidden `≈ γ·dt` factor (~200x at dt 0.01). A numpy kv3 model with that estimate reproduces Julia's recorded per-trajectory counts exactly (96/35/15 accepted steps at rho=21 for tol 1e-6/1e-4/1e-2 vs Julia's 95/34/15); its achieved error at tol 1e-6 is ~1000x above the request. CuBIE's raw embedded estimate is honest against the stated tolerance and is not changed to match.

Full CUDASIM suite: 3096 passed. Full real-GPU suite: 3146 passed.

## Performance gate

Retry run (`--pairs 8`), published as-is. The REGRESSION row is
DISTRUST-flagged on the fixed config (classical-rk4, no gains or
Newton compiled); compile metrics are identical for every config.

```
A = origin/main (844b98fb)   B = feat/dirk-pi-defaults-newton-floor (working tree)   backends: numba-cuda, mlir   (8 block pairs x 15 solves/block/side)

numba-cuda fixed          kernel  A    63.146  B    63.109   +0.63%  REGRESSION  DISTRUST
numba-cuda fixed          wall    A    77.069  B    73.449   -4.52%  ok
numba-cuda adaptive       kernel  A    18.076  B    14.195  -21.29%  improvement
numba-cuda adaptive       wall    A    22.566  B    17.483  -22.85%  improvement
numba-cuda host_overhead  wall    A     1.102  B     0.724   -0.435ms  improvement
numba-cuda chunked        kernel  A    63.162  B    63.322   -0.16%  ok  DISTRUST
numba-cuda chunked        wall    A    78.580  B    78.996   +0.03%  ok
numba-cuda wave           kernel  A    26.189  B    25.914   -0.54%  improvement
numba-cuda wave           wall    A    28.274  B    27.978   -0.89%  ok

mlir       fixed          kernel  A    62.707  B    62.692   -0.34%  ok
mlir       fixed          wall    A    77.402  B    77.241   -1.12%  ok
mlir       adaptive       kernel  A    17.400  B    13.636  -21.50%  improvement
mlir       adaptive       wall    A    22.148  B    18.147  -18.09%  improvement
mlir       host_overhead  wall    A     1.333  B     1.209   -0.024ms  ok  DISTRUST
mlir       chunked        kernel  A    62.754  B    62.900   -0.38%  ok  DISTRUST
mlir       chunked        wall    A    78.529  B    78.545   -0.29%  ok
mlir       wave           kernel  A    25.789  B    25.814   -0.06%  ok  DISTRUST
mlir       wave           wall    A    28.661  B    28.547   -0.47%  ok

GATE: REGRESSION (kernel threshold 0.50%, wall threshold 10.00%, host-overhead threshold 0.25 ms)
DISTRUST = the pairs split on the regression call, so that verdict is unreliable; rerun, with more --pairs or a quieter GPU, before acting on it.
```

Co-authored by Chris' bot
