### PR TITLE
test: NVVM library preloaded in each pytest worker at configure time

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,9 +130,18 @@ def pytest_configure(config):
     is importable on every backend; the MLIR frontend raises its own
     vendored class, registered here only when that backend is active
     (the class path does not import under numba-cuda).
+    numba-cuda workers also load the NVVM library here.
     """
     from cubie.cuda_backend import IS_MLIR
+    from cubie.cuda_simsafe import CUDA_SIMULATION
 
+    if not IS_MLIR and not CUDA_SIMULATION:
+        try:
+            from cuda.pathfinder import load_nvidia_dynamic_lib
+
+            load_nvidia_dynamic_lib("nvvm")
+        except Exception:
+            pass
     if IS_MLIR:
         config.addinivalue_line(
             "filterwarnings",


### PR DESCRIPTION
## What changed

On the numba-cuda backend, `pytest_configure` loads the NVVM library via `cuda.pathfinder.load_nvidia_dynamic_lib("nvvm")` in every pytest process (master and each xdist worker) before any test runs; the first kernel launch finds it already resident. The preload is skipped on the MLIR backend and under CUDASIM, and any load failure is swallowed so environments without the library behave as before.

## Why

On the Windows CI GPU legs, each xdist worker''s first kernel launch stalled 12.0-13.9s inside `LoadLibraryExW` of the 54MB NVVM DLL (numba-cuda runs NVVM at first launch even on a kernel-cache hit). Phase-instrumented single-lane CI runs located the stall via a mid-launch stack dump and a process_time split: blocked wait, own context idle, GPU at 0% utilisation, all four workers releasing within tens of milliseconds of each other. The identical load performed at configure time, while worker processes are small, costs 3.6-5s once in the master and ~6ms in each worker; the validated single-lane run drops the workers'' first-launch cost from 12.1s to 5.95s and the four ~12s `test_matches_cpu` outliers leave the durations profile. The residual ~6s sits inside `cuda.core` `Linker.link` (compiled extension, driver-side) and is unaffected by this change.

Verification: full CUDASIM suite 3082 passed; full real-GPU suite 3132 passed; instrumented single-lane CUDA runs 30880463946 / 30882175798 carry the before/after first-launch phase timings.

Co-authored by Chris'' bot