### PR TITLE
fix(ci): bake sysprep generalizes without shutting down the spot builder

### DIFF
--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -165,11 +165,11 @@ build {
     scripts = ["ci/tools/populate_uv_cache.ps1"]
   }
 
-  # EC2Launch reset + Sysprep shutdown; first boot reruns the RunsOn bootstrap.
+  # EC2Launch reset + Sysprep generalize; no --shutdown: guest shutdown terminates a one-time spot builder before capture.
   provisioner "powershell" {
     inline = [
-      "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' reset --block",
-      "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' sysprep --shutdown --block",
+      "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' reset",
+      "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' sysprep",
     ]
   }
 }


### PR DESCRIPTION
Run 30902074455 proved the whole Ohio bake path works — g5.xlarge spot landed first try, driver bound at bake, uv cache populated, reset and sysprep ran clean — then `CreateImage` failed with `context deadline exceeded`: a guest-initiated shutdown terminates a one-time spot instance, so `sysprep --shutdown` destroyed the builder ~3 minutes before Packer tried to image it.

The finalizer now runs `ec2launch reset` then `ec2launch sysprep` without `--shutdown`: Sysprep generalizes and quits, the instance stays running, and Packer's EC2-managed stop-snapshot-restart captures the generalized disk — the same capture path every previous successful bake used. The `--block` flags are gone (EC2Launch logs them as deprecated no-ops).

The failed run also gave the cleanup workflow its first live firing: it authenticated via OIDC and correctly no-op'd ("No leftover builder instances for run 30902074455").

ab_gate: not applicable — CI only, no device code changed.

Co-authored by Chris' bot