### PR TITLE
fix(fleet): deployer policy covers the security-group-rule ARN leg

### DIFF
--- a/infra/fleet/bootstrap/cloudshell-iam.sh
+++ b/infra/fleet/bootstrap/cloudshell-iam.sh
@@ -54,7 +54,7 @@ ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 #   create (tag specifications), so an apply can immediately modify
 #   what it just created, and the module tags every SG and launch
 #   template with stack=<stack_name>.
-# - Ec2SgRuleLeg: the security-group-rule ARN leg of rule calls; the group leg stays tag-scoped in Ec2StackMutate.
+# - Ec2SgRuleLeg: security-group rule actions on the rule ARN.
 # - Ec2ScopedDestroy: terminate/delete only for EC2 resources tagged
 #   stack=cubie-fleet, so the credentials cannot touch instances,
 #   VPCs, or security groups belonging to anything else.

--- a/infra/fleet/bootstrap/cloudshell-iam.sh
+++ b/infra/fleet/bootstrap/cloudshell-iam.sh
@@ -54,6 +54,7 @@ ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 #   create (tag specifications), so an apply can immediately modify
 #   what it just created, and the module tags every SG and launch
 #   template with stack=<stack_name>.
+# - Ec2SgRuleLeg: the security-group-rule ARN leg of rule calls; the group leg stays tag-scoped in Ec2StackMutate.
 # - Ec2ScopedDestroy: terminate/delete only for EC2 resources tagged
 #   stack=cubie-fleet, so the credentials cannot touch instances,
 #   VPCs, or security groups belonging to anything else.
@@ -176,7 +177,9 @@ cat > /tmp/cubie-fleet-deployer-policy.json <<EOF
             "CreateRouteTable",
             "CreateSecurityGroup",
             "CreateLaunchTemplate",
-            "CreateLaunchTemplateVersion"
+            "CreateLaunchTemplateVersion",
+            "AuthorizeSecurityGroupIngress",
+            "AuthorizeSecurityGroupEgress"
           ]
         }
       }
@@ -211,6 +214,18 @@ cat > /tmp/cubie-fleet-deployer-policy.json <<EOF
           "aws:ResourceTag/stack": "cubie-fleet"
         }
       }
+    },
+    {
+      "Sid": "Ec2SgRuleLeg",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:ModifySecurityGroupRules"
+      ],
+      "Resource": "arn:aws:ec2:${REGION}:${ACCOUNT_ID}:security-group-rule/*"
     },
     {
       "Sid": "Ec2ScopedDestroy",


### PR DESCRIPTION
The Ohio apply failed at `aws_vpc_security_group_egress_rule` with UnauthorizedOperation: modern SG-rule resources evaluate `ec2:AuthorizeSecurityGroup*` against both the security-group ARN and a `security-group-rule/*` ARN, and a new rule has no `stack` tag for the tag-scoped Ec2StackMutate statement to match. A new Ec2SgRuleLeg statement grants the five rule actions on the rule ARN — unconditioned is safe because the same call must still pass the tag-scoped group leg. The provider also tags rules inside the Authorize call, so both Authorize actions join Ec2TagOnCreate's `ec2:CreateAction` list.

The live policy was patched to match via CloudShell (v9); this PR records the same change in the bootstrap script.

ab_gate: not applicable — infra only.

Co-authored by Chris' bot