### PR TITLE
docs: README reflects current installation and capabilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,107 +1,104 @@
 # CuBIE
-## CUDA batch integration engine for python
 
-[![docs](https://github.com/ccam80/smc/actions/workflows/documentation.yml/badge.svg)](https://github.com/ccam80/smc/actions/workflows/documentation.yml) [![CUDA tests](https://github.com/ccam80/cubie/actions/workflows/ci_cuda_tests.yml/badge.svg)](https://github.com/ccam80/cubie/actions/workflows/ci_cuda_tests.yml)    [![Python Tests](https://github.com/ccam80/cubie/actions/workflows/ci_nocuda_tests.yml/badge.svg)](https://github.com/ccam80/cubie/actions/workflows/ci_nocuda_tests.yml)    [![codecov](https://codecov.io/gh/cubiepy/cubie/graph/badge.svg?token=SKJNOT6061)](https://codecov.io/gh/cubiepy/cubie)
-![PyPI - Version](https://img.shields.io/pypi/v/cubie)    [![test build](https://github.com/ccam80/cubie/actions/workflows/test_pypi.yml/badge.svg)](https://github.com/ccam80/cubie/actions/workflows/test_pypi.yml)
+## CUDA Batch Integration Engine for Python
 
-A batch integration system for numerically integarating many systems of ODEs in parallel, for when elegant solutions fail and you would like to simulate 
-1,000,000 systems, fast. Cubie is a tool that performs the equivalent of MATLABs ODE functions (ode45 and the like), Scipy's solve_ivp function,
-or some of the functions in Julia's SciML/OrdinaryDiffEq. This package was designed to simulate a large electrophysiological model as part of a 
-likelihood-free inference method (eventually, package [cubism]), but the machinery is domain-agnostic.
+[![Docs](https://github.com/cubiepy/cubie/actions/workflows/documentation.yml/badge.svg)](https://github.com/cubiepy/cubie/actions/workflows/documentation.yml)
+[![CUDA tests](https://github.com/cubiepy/cubie/actions/workflows/ci_cuda_tests.yml/badge.svg)](https://github.com/cubiepy/cubie/actions/workflows/ci_cuda_tests.yml)
+[![Python tests](https://github.com/cubiepy/cubie/actions/workflows/ci_nocuda_tests.yml/badge.svg)](https://github.com/cubiepy/cubie/actions/workflows/ci_nocuda_tests.yml)
+[![codecov](https://codecov.io/gh/cubiepy/cubie/graph/badge.svg?token=SKJNOT6061)](https://codecov.io/gh/cubiepy/cubie)
+![PyPI version](https://img.shields.io/pypi/v/cubie)
 
-This library uses Numba to JIT-compile CUDA kernels, allowing you the speed of compiled CUDA code without the headache
-of writing CUDA code. It is designed to have a reasonably MATLAB- or SciPy-like interface, so that you can get up and 
-running without having to figure out the intricacies of the internal mechanics.
+CuBIE JIT-compiles CUDA kernels with Numba to integrate large batches of
+ordinary differential equations (ODEs) and differential-algebraic equations
+(DAEs) on NVIDIA GPUs. It provides a SciPy-like `solve_ivp` function and a
+reusable `Solver` interface without requiring users to write CUDA code.
 
-The batch solving interface is not yet completely stable, and some parameters/arguments are likely to change further through to v1.0.
-The core (per-parameter-set) machinery is reasonably stable. As of v0.0.7, you can:
+CuBIE is pre-1.0, so its public interface may still change.
 
-- Set up and solve large parameter/initial condition sweeps of a system defined by a set of ODEs, entered either as:
-  - A string or list of strings containing the equations of the system
-  - A CellML model (tested on a subset of models in the CellML library so far)
-- Use any of a large set of explicit or implicit runge-kutta or rosenbrock methods to integrate the problem.
-- Extract the solution for any variable or ``observable`` at any time point, or extract summary statistics only to speed 
-  things up.
-- Provide ``forcing terms`` by including a function of _t_ in your equations, or by providing an array of values for the
-  system to interpolate.
-- Select from a handful of step-size control algorithms when using an adaptive-step algorithm like RK45 or RadauIIA5.
+## Capabilities
 
+- Build combinatorial parameter and initial-condition sweeps, or solve
+  verbatim batches from NumPy, CuPy, or Numba arrays.
+- Define systems with Python callables, equation strings, symbolic
+  expressions, or CellML 1.0/1.1 models.
+- Use fixed- or adaptive-step explicit Runge-Kutta, diagonally implicit
+  Runge-Kutta, fully implicit Runge-Kutta, and Rosenbrock-W methods.
+- Structurally simplify DAEs with alias elimination, index reduction, and
+  tearing before generating solver code.
+- Supply time-dependent drivers as functions or sampled arrays.
+- Save selected states and observables, or calculate summary metrics on the
+  GPU without storing complete trajectories.
+- Keep inputs and outputs on the GPU, automatically chunk batches that exceed
+  available VRAM, and spill very large host results to disk.
+- Cache generated source and compiled kernels between sessions.
 
+## Installation
 
-### Roadmap:
-- v0.1.0: 
-  - Documentation to match the API, organised in the sane way that a robot does not.
-  - User guide brought up-to-date with API, tracing an example through a few integration scenarios.
-  - Accept a python function as a system definition, to match Scipy and MATLAB interfaces.
-
-
-## Documentation:
-
-https://ccam80.github.io/cubie/
-
-## Installation:
-We recommend that you use a python virtual environment to install Cubie - some dependencies are pinned to a specific version,
-so installing it in it's own environment will avoid downgrading your system-wide packages and interfering with other projects.
-
-```
-python -m venv cubie_env
-./cubie_env/Scripts/activate # Windows
-# source cubie_env/bin/activate # Linux/Mac
-pip install cubie[mlir-cuda12]  # CUDA 12 toolkit
-# pip install cubie[mlir-cuda13]  # CUDA 13 toolkit
+```console
+pip install "cubie[mlir-cuda13]"
 ```
 
-The extra is required: it installs Cubie's CUDA backend (numba-cuda-mlir) alongside the
-matching toolkit wheels, and a bare `pip install cubie` has no backend to compile with
-(`import cubie` will stop with instructions). If your machine already has a system CUDA
-toolkit, `pip install cubie[mlir]` installs the backend without the toolkit wheels.
+The extra in square brackets installs the required CUDA dependencies. There
+are four options:
 
-The previous default backend (numba-cuda) is deprecated but still available via the
-`cuda12`/`cuda13` extras (or bare `cuda` for a system toolkit). MLIR is faster; try
-numba-cuda if you run into unexpected errors, or if you need Python 3.10 or the CUDA
-simulator (`NUMBA_ENABLE_CUDASIM=1`), which only exist on numba-cuda.
+- `mlir-cuda12`
+- `mlir-cuda13`
+- `cuda12`
+- `cuda13`
 
-Then, when you fire up your Cubie project, run
+We recommend `mlir-cuda13` unless you have a specific reason to use the older
+numba-cuda backend or the CUDA 12 toolkit.
 
+CuBIE requires Python 3.11-3.14, an up-to-date NVIDIA driver, and an NVIDIA GPU
+with compute capability 6.0 or later. Python 3.10 is supported only by the
+numba-cuda backend. Pandas and Matplotlib support can be installed with
+`pip install "cubie[optional]"`.
+
+## Quick start
+
+```python
+from cubie import solve_ivp
+
+
+with solve_ivp(
+    ["dx = v", "dv = mu * (1 - x*x) * v - x"],
+    y0={"x": [1.0, 2.0], "v": [0.0]},
+    parameters={"mu": [1.0, 1.5, 2.0]},
+    method="tsit5",
+    duration=20.0,
+    save_every=0.01,
+) as result:
+    trajectories = result.as_numpy["time_domain_array"]
 ```
-source cubie_env/bin/activate
-```
 
-Or set up your IDE to use the `python.exe` in `cubie_env/Scripts/activate` (Windows) or `cubie_env/bin/activate` (Linux/Mac) 
-as the project's interpreter so you don't have to worry about it.
+This integrates every combination of the supplied initial conditions and
+parameters. The first solve compiles and caches the CUDA kernels for reuse.
 
-## System Requirements:
-- Python 3.11 or later (3.10 works only with the deprecated numba-cuda backend)
-- Up-to-date NVIDIA driver
-- NVIDIA GPU with compute capability 6.0 or higher (i.e. GTX10-series or newer)
+## Documentation
 
-## Python Requirements
+The [documentation](https://cubiepy.github.io/cubie/) covers system creation,
+batching, solver configuration, outputs, and performance.
 
-* Python >= 3.11 (>= 3.10 with the deprecated numba-cuda backend)
-* NumPy>=2.0
-* Numba
-* numba-cuda-mlir (or the deprecated numba-cuda)
-* attrs
-* SymPy >= 1.13.0
+## Acknowledgements
 
-## Optional Dependencies
+- **[SciML/DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/stable/)**
+  — No code is directly ported from DifferentialEquations.jl, but I treat its
+  solver suite as the authority on numerical integration. I check CuBIE's
+  methods against it, and when an implementation is unclear I first look at
+  how DifferentialEquations.jl handles it. See
+  [Rackauckas and Nie (2017)](https://doi.org/10.5334/jors.151).
+- **[ModelingToolkit.jl](https://docs.sciml.ai/ModelingToolkit/stable/)** —
+  CuBIE's DAE tearing and structural-simplification implementation is a direct
+  port of ModelingToolkit.jl's approach, adapted to CuBIE's symbolic IR and
+  CUDA code generation. See
+  [Ma et al. (2021)](https://doi.org/10.48550/arXiv.2103.05244).
+- **[cellmlmanip](https://github.com/ModellingWebLab/cellmlmanip) and
+  [chaste_codegen](https://github.com/ModellingWebLab/chaste-codegen)** — Their
+  work is used to import CellML models and detect and repair removable
+  singularities in Goldman-Hodgkin-Katz-style equations. See
+  [Hendrix et al. (2022)](https://doi.org/10.12688/wellcomeopenres.17206.2).
 
-Install these using `pip install cubie[optional]`
+## Contributing
 
-* Pandas: For DataFrame output support
-* Matplotlib: For plotting support. Only used to plot an interpolated driver function for sanity-checks (see
-  :doc:`Drivers <user_guide/drivers>`), but generally useful for visualizing results.
-
-
-## Contributing:
-Pull requests are very, very welcome! Please open an issue if you would like to discuss a feature or bug before doing a 
-bunch of work on it, as I may have already partially implemented it or at least figured out where it might fit. 
-
-## Project Goals:
-
-- Make an engine and interface for batch integration that is close enough to MATLAB or SciPy that a Python beginner can
-  get integrating with the documentation alone in an hour or two. This also means staying Windows-compatible.
-- Perform integrations of 10 or more parallel systems faster than MATLAB or SciPy can
-- Enable extraction of summary variables only (rather than saving time-domain outputs) to facilitate use in algorithms 
-  like likelihood-free inference.
-- Be extensible enough that users can add their own systems and algorithms without needing to go near the core machinery.
+Pull requests are welcome. Please open an issue before starting a major change
+so that the design can be discussed first.

--- a/readme.md
+++ b/readme.md
@@ -8,10 +8,18 @@
 [![codecov](https://codecov.io/gh/cubiepy/cubie/graph/badge.svg?token=SKJNOT6061)](https://codecov.io/gh/cubiepy/cubie)
 ![PyPI version](https://img.shields.io/pypi/v/cubie)
 
-CuBIE JIT-compiles CUDA kernels with Numba to integrate large batches of
-ordinary differential equations (ODEs) and differential-algebraic equations
-(DAEs) on NVIDIA GPUs. It provides a SciPy-like `solve_ivp` function and a
-reusable `Solver` interface without requiring users to write CUDA code.
+CuBIE performs numerical integration in parallel on NVIDIA GPUs. It
+JIT-compiles ordinary differential equation (ODE) and differential-algebraic
+equation (DAE) systems into CUDA kernels, making large parameter and
+initial-condition sweeps much faster than calling SciPy's
+[`solve_ivp`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html)
+or MATLAB's [`ode45`](https://www.mathworks.com/help/matlab/ref/ode45.html)
+once per system.
+
+On an RTX 4070 SUPER, a cached run of the 1,048,576-system RK45 example below
+takes about 20 ms. Serial SciPy 1.18 calls at the same tolerances extrapolate
+to about 47 minutes: over 100,000 times slower. MATLAB `ode45` follows the same
+one-problem-per-call pattern; exact timings depend on the system and hardware.
 
 CuBIE is pre-1.0, so its public interface may still change.
 
@@ -57,22 +65,30 @@ numba-cuda backend. Pandas and Matplotlib support can be installed with
 ## Quick start
 
 ```python
-from cubie import solve_ivp
+import numpy as np
+from cubie import create_ODE_system, solve_ivp
 
 
-with solve_ivp(
+system = create_ODE_system(
     ["dx = v", "dv = mu * (1 - x*x) * v - x"],
-    y0={"x": [1.0, 2.0], "v": [0.0]},
-    parameters={"mu": [1.0, 1.5, 2.0]},
-    method="tsit5",
+    states={"x": 1.0, "v": 0.0},
+    parameters={"mu": 1.5},
+)
+
+result = solve_ivp(
+    system,
+    y0={"x": np.linspace(1.0, 2.0, 1024), "v": [0.0]},
+    parameters={"mu": np.linspace(1.0, 3.0, 1024)},
+    method="rk45",
     duration=20.0,
-    save_every=0.01,
-) as result:
-    trajectories = result.as_numpy["time_domain_array"]
+    atol=1e-6,
+    rtol=1e-3,
+)
 ```
 
-This integrates every combination of the supplied initial conditions and
-parameters. The first solve compiles and caches the CUDA kernels for reuse.
+This integrates all 1,048,576 combinations of the 1,024 initial values and
+1,024 parameter values. The first solve compiles and caches the CUDA kernels;
+later solves reuse them.
 
 ## Documentation
 

--- a/readme.md
+++ b/readme.md
@@ -8,37 +8,39 @@
 [![codecov](https://codecov.io/gh/cubiepy/cubie/graph/badge.svg?token=SKJNOT6061)](https://codecov.io/gh/cubiepy/cubie)
 ![PyPI version](https://img.shields.io/pypi/v/cubie)
 
-CuBIE performs numerical integration in parallel on NVIDIA GPUs. It
-JIT-compiles ordinary differential equation (ODE) and differential-algebraic
-equation (DAE) systems into CUDA kernels, making large parameter and
-initial-condition sweeps much faster than calling SciPy's
-[`solve_ivp`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html)
-or MATLAB's [`ode45`](https://www.mathworks.com/help/matlab/ref/ode45.html)
-once per system.
+CuBIE performs numerical integration in parallel on NVIDIA GPUs. It provides a ~100000x* 
+speedup over functions like MATLAB's `ode45` and SciPy's `solve_ivp` for parallel batch integrations, 
+while offering a similar interface to make it easy to switch from those environments.
 
-On an RTX 4070 SUPER, a cached run of the 1,048,576-system RK45 example below
-takes about 20 ms. Serial SciPy 1.18 calls at the same tolerances extrapolate
-to about 47 minutes: over 100,000 times slower. MATLAB `ode45` follows the same
-one-problem-per-call pattern; exact timings depend on the system and hardware.
+Under the hood, cubie uses [`numba-cuda`](https://nvidia.github.io/numba-cuda/) to compile
+python integration algorithms and your provided ODE/DAE systems into GPU code
+and ferry your data in between your computer and GPU. Python-side, it generates Jacobian-vector 
+product (JVP), residual, and preconditioner functions from your system of equations and folds those into
+iterative linear or nonlinear solvers (depending on the algorithm you choose) which are compiled
+into the final kernel. By treating the core math as code instead of evaluating it per-step,
+cubie achieves a low memory footprint on the GPU, allowing you to fit more integrations
+onto it at once. 
 
-CuBIE is pre-1.0, so its public interface may still change.
+\* On an RTX 4070 SUPER, the RK45 example in the readme takes about 20 ms for 1,048,576. The 
+same batch on SciPy 1.18 takes about 47 minutes.
 
 ## Capabilities
 
-- Build combinatorial parameter and initial-condition sweeps, or solve
-  verbatim batches from NumPy, CuPy, or Numba arrays.
-- Define systems with Python callables, equation strings, symbolic
+- Define systems of ODE/DAEs as either Python functions, strings, SymPy symbolic
   expressions, or CellML 1.0/1.1 models.
 - Use fixed- or adaptive-step explicit Runge-Kutta, diagonally implicit
   Runge-Kutta, fully implicit Runge-Kutta, and Rosenbrock-W methods.
 - Structurally simplify DAEs with alias elimination, index reduction, and
-  tearing before generating solver code.
-- Supply time-dependent drivers as functions or sampled arrays.
-- Save selected states and observables, or calculate summary metrics on the
-  GPU without storing complete trajectories.
-- Keep inputs and outputs on the GPU, automatically chunk batches that exceed
-  available VRAM, and spill very large host results to disk.
-- Cache generated source and compiled kernels between sessions.
+  tearing before generating solver code (logic taken almost verbatim from
+  [ModelingToolkit.jl](https://github.com/SciML/ModelingToolkit.jl)).
+- Supply time-dependent forcing terms as functions or sampled (measured) arrays.
+- Save selected states or algebraic variables (observables) to reduce result size
+- Discard trajectories and calculate summary metrics on the GPU to keep only the 
+relevant information and allow larger solves.
+- Automatically divide large solves into chunks that can fit into your GPU, and arrays
+that can fit into your computers RAM, to allow REALLY large solves.
+- Cache solvers between sessions, so you only pay the compile time once per config.
+- Build 
 
 ## Installation
 
@@ -87,8 +89,8 @@ result = solve_ivp(
 ```
 
 This integrates all 1,048,576 combinations of the 1,024 initial values and
-1,024 parameter values. The first solve compiles and caches the CUDA kernels;
-later solves reuse them.
+1,024 parameter values. The first solve compiles and caches the CUDA kernels (~0.1s);
+later solves reuse them (~0.025s).
 
 ## Documentation
 

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ relevant information and allow larger solves.
 - Automatically divide large solves into chunks that can fit into your GPU, and arrays
 that can fit into your computers RAM, to allow REALLY large solves.
 - Cache solvers between sessions, so you only pay the compile time once per config.
-- Build 
+- Build combinatorial grids of parameters/initial conditions to solve over.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- replace the v0.0.7-era description and v0.1.0 roadmap with a concise account of CuBIE's current ODE/DAE batch solver
- lead with fast, parallel numerical integration on NVIDIA GPUs and a bounded SciPy/MATLAB comparison
- document the four CUDA toolkit extras and recommend `mlir-cuda13`
- describe current callable, CellML, implicit-solver, structural-simplification, device-array, chunking, spilling, and caching capabilities
- add a real-GPU-tested, two-call quick start that integrates 1,048,576 systems without a context manager
- acknowledge DifferentialEquations.jl, ModelingToolkit.jl, cellmlmanip, and chaste_codegen with primary citations
- update badges and the documentation link to the `cubiepy` organization

## Root cause

The README remained anchored to v0.0.7 and a v0.1.0 roadmap while the package had advanced to v0.3.4. Implemented features still appeared as future work, current backend choices and solver capabilities were missing, and repository/documentation links still pointed at the previous owner. Its first example also introduced the reusable-result context-manager pattern before showing the simpler `create_ODE_system` and `solve_ivp` workflow.

## User impact

The README now gives readers the current installation command, supported CUDA choices, system requirements, solver capabilities, and a direct million-system example. It distinguishes the measured SciPy comparison from the unmeasured but equivalent serial MATLAB calling pattern.

## Verification

- independent verifier pass: PASS against the full README specification
- `git diff --check`: PASS
- exact README quick start on an RTX 4070 SUPER (compute capability 8.9): PASS, output shape `(2, 2, 1048576)`
- cached CuBIE benchmark: nine 1,048,576-system RK45 batches, median `0.018788 s`
- SciPy 1.18 comparison: 200 serial RK45 samples at matching tolerances, median `0.002678250 s/system`; extrapolated `46.8 min` and `149,473x`, conservatively reported in the README as about 20 ms versus about 47 minutes and over 100,000x
- all ten content and citation links: HTTP 200
- `python benchmarks/ab_gate.py --pairs 8`: INCONCLUSIVE because two rows split around zero; every delta remained within its gate threshold and no row reported a regression. The required one-retry result is published below as-is.

## Performance gate

Compile metrics were identical between A and B for every configuration on both backends.

| Backend | Configuration | Metric | A | B | Delta | Verdict |
|---|---|---:|---:|---:|---:|---|
| numba-cuda | fixed | kernel | 62.690 | 62.403 | -0.46% | ok |
| numba-cuda | fixed | wall | 76.922 | 72.753 | -5.46% | ok |
| numba-cuda | adaptive | kernel | 18.013 | 17.949 | -0.47% | ok |
| numba-cuda | adaptive | wall | 22.479 | 21.673 | -3.22% | ok |
| numba-cuda | host_overhead | wall | 1.205 | 0.697 | -0.430 ms | improvement |
| numba-cuda | chunked | kernel | 62.782 | 62.919 | +0.05% | ok, DISTRUST |
| numba-cuda | chunked | wall | 83.195 | 78.362 | -5.89% | ok |
| numba-cuda | wave | kernel | 25.672 | 25.706 | +0.06% | ok |
| numba-cuda | wave | wall | 28.208 | 28.413 | +0.38% | ok |
| mlir | fixed | kernel | 62.602 | 62.667 | +0.17% | ok |
| mlir | fixed | wall | 76.889 | 76.512 | -0.33% | ok |
| mlir | adaptive | kernel | 17.417 | 17.452 | +0.08% | ok |
| mlir | adaptive | wall | 21.647 | 21.846 | +0.85% | ok |
| mlir | host_overhead | wall | 1.029 | 1.070 | +0.005 ms | ok, DISTRUST |
| mlir | chunked | kernel | 63.113 | 62.906 | -0.23% | ok |
| mlir | chunked | wall | 78.712 | 78.297 | -0.44% | ok |
| mlir | wave | kernel | 25.905 | 25.773 | -0.56% | improvement |
| mlir | wave | wall | 29.284 | 28.780 | -1.79% | ok |

Gate thresholds: 0.50% kernel, 10.00% wall, and 0.25 ms host overhead. `DISTRUST` means the paired deltas crossed the regression threshold inconsistently, so the verdict is unreliable; these near-zero rows are retained exactly as required.