### PR TITLE
fix(fleet): dashboard prices each leg in its availability zone's region

### DIFF
--- a/infra/fleet/cost_dashboard.py
+++ b/infra/fleet/cost_dashboard.py
@@ -772,13 +772,18 @@ def parse_log(text):
 
 
 # --------------------------------------------------------------------- aws
+def az_region(az):
+    """Return the region an availability zone belongs to."""
+    return az.rstrip("abcdef") if az else REGION
+
+
 def spot_price(itype, az, at, platform):
     prod = "Windows" if (platform or "").startswith("win") else "Linux/UNIX"
     ok, res = aws(
         "ec2",
         "describe-spot-price-history",
         "--region",
-        REGION,
+        az_region(az),
         "--instance-types",
         itype,
         "--availability-zone",
@@ -821,7 +826,7 @@ def _launch_details(event, iid):
     return None
 
 
-def instance_history(iid, around):
+def instance_history(iid, around, region):
     """Return one instance's launch record and termination time.
 
     The RunInstances event carries the instance type, availability zone
@@ -834,7 +839,7 @@ def instance_history(iid, around):
         "cloudtrail",
         "lookup-events",
         "--region",
-        REGION,
+        region,
         "--lookup-attributes",
         f"AttributeKey=ResourceName,AttributeValue={iid}",
         "--start-time",
@@ -872,7 +877,9 @@ def _enrich_leg(leg):
     log = parse_log(fetch_log(leg["job_id"]))
     leg.update(log)
     anchor = log["running_start"] or leg["job_start"]
-    launch, term = instance_history(leg["instance_id"], anchor)
+    launch, term = instance_history(
+        leg["instance_id"], anchor, az_region(log["az"])
+    )
     launch = launch or {}
     # The log is authoritative where it exists; the launch record only
     # ever adds identity the banner left out.

--- a/infra/fleet/cost_dashboard.py
+++ b/infra/fleet/cost_dashboard.py
@@ -827,14 +827,7 @@ def _launch_details(event, iid):
 
 
 def instance_history(iid, around, region):
-    """Return one instance's launch record and termination time.
-
-    The RunInstances event carries the instance type, availability zone
-    and platform that the RunsOn log banner also reports, so a leg whose
-    runner died before its log was archived still prices. Launch always
-    precedes the anchor, so the widened window adds no termination event
-    that the anchored window would not already have returned first.
-    """
+    """Return one instance's launch record and termination time."""
     ok, res = aws(
         "cloudtrail",
         "lookup-events",


### PR DESCRIPTION
`spot_price` and `instance_history` derive the query region from the leg's availability zone (`az_region`: the AZ minus its trailing letter) instead of the `REGION` constant, which is now only the no-log fallback. A Sydney-run leg viewed after the Ohio move queried `--region us-east-2` with `--availability-zone ap-southeast-2c`, and the resulting InvalidParameterValue raised through `aws()` as an error banner; with the region derived, in-region legs price normally and cross-region legs the credentials cannot read return AccessDenied, which is already the graceful incomplete-telemetry path. The CloudTrail lookup previously searched the wrong region's event history for cross-region instances and silently found nothing.

ab_gate: not applicable — dashboard tooling only.

Co-authored by Chris' bot