### PR TITLE
fix(ci): bake finalizes with EC2Launch reset only

### DIFF
--- a/packer/windows-gpu.pkr.hcl
+++ b/packer/windows-gpu.pkr.hcl
@@ -165,11 +165,13 @@ build {
     scripts = ["ci/tools/populate_uv_cache.ps1"]
   }
 
-  # EC2Launch reset + Sysprep generalize; no --shutdown: guest shutdown terminates a one-time spot builder before capture.
+  # WinRM off in the image, delayed stop frees this session, and EC2Launch reset re-arms the first-boot RunsOn bootstrap.
   provisioner "powershell" {
     inline = [
+      "Set-Service -Name WinRM -StartupType Disabled",
+      "$null = Start-Process -FilePath 'powershell.exe' -WindowStyle Hidden -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', \"Start-Sleep -Seconds 15; Stop-Service -Name WinRM -Force -ErrorAction SilentlyContinue\")",
       "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' reset",
-      "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' sysprep",
+      "exit 0",
     ]
   }
 }


### PR DESCRIPTION
Validation run 30955538046 showed every Windows leg booting in 375-466 s against 92-188 s on the pre-Sysprep image (run 30838868303, same g5.xlarge): the generalized AMI runs the Windows specialize/OOBE pass on every runner first boot, ~37 billed minutes per 8-leg run (~+$0.18) — and boot is billed where the spot waits it replaced were not. Driver binding does not need Sysprep: the fleet and bake share the g5 family, so the GRID driver is bound in the image itself.

The finalizer returns to the proven reset-only sequence (WinRM disabled in the image, delayed stop so Packer's session ends cleanly, EC2Launch reset to re-arm the first-boot RunsOn bootstrap) and Packer captures from the running instance.

ab_gate: not applicable — CI only.

Co-authored by Chris' bot