### PR TITLE
fix(integrators): per-state tolerances size by n across tiled FIRK norms

### DIFF
--- a/src/cubie/integrators/SingleIntegratorRunCore.py
+++ b/src/cubie/integrators/SingleIntegratorRunCore.py
@@ -364,10 +364,10 @@ class SingleIntegratorRunCore(CUDAFactory):
         divided by one hundred for linearly-implicit (``is_linear``)
         steps; non-adaptive runs default to machine epsilon, leaving
         the floor governing.  Values the user set explicitly (tracked in
-        ``_user_given_inner_tols``) are preserved.  The solver norms'
-        tolerance converter broadcasts uniform arrays to their own
-        vector length; a non-uniform per-state vector must match the
-        solver vector exactly.
+        ``_user_given_inner_tols``) are preserved.  Solver-norm
+        tolerances take the controller's per-state length, coupled
+        FIRK solves included, so a non-uniform vector carries through
+        unchanged.
 
         Every controller carries ``atol``/``rtol`` — fixed-step
         included — so the defaults apply whenever the algorithm is

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -85,11 +85,9 @@ compiled callable from `.device_function`.
   `FIRKCorrectionNorm`, whose whole-vector function scales the update
   by `atol + rtol * max(|stage_value|, |step_start|)` (DIRK: one
   diagonal coefficient; FIRK: the full tableau row).
-- **Norm tolerances are per physical state** — `n` entries, the same
-  length the step controller takes. The stage-tiled norms
-  (`TiledScaledNorm`, `FIRKCorrectionNorm`) read entry `i mod n` for
-  stacked value `i`. `ScaledNormConfig.n` defaults to `solver_width`,
-  which is one entry per solver element for the whole-vector norms.
+- **Norm tolerances are per physical state** (`n` entries, the length
+  the step controller takes); stage-tiled norms read entry `i mod n`.
+  `n` defaults to `solver_width` at norm construction.
 - **Every linear solve (MR, SD, BiCGSTAB; Newton-owned or direct)
   stops on** `||r|| <= krylov_residual_floor +
   krylov_residual_reduction * ||b||`. `||.||` = the solver's

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -85,6 +85,11 @@ compiled callable from `.device_function`.
   `FIRKCorrectionNorm`, whose whole-vector function scales the update
   by `atol + rtol * max(|stage_value|, |step_start|)` (DIRK: one
   diagonal coefficient; FIRK: the full tableau row).
+- **Norm tolerances are per physical state** — `n` entries, the same
+  length the step controller takes. The stage-tiled norms
+  (`TiledScaledNorm`, `FIRKCorrectionNorm`) read entry `i mod n` for
+  stacked value `i`. `ScaledNormConfig.n` defaults to `solver_width`,
+  which is one entry per solver element for the whole-vector norms.
 - **Every linear solve (MR, SD, BiCGSTAB; Newton-owned or direct)
   stops on** `||r|| <= krylov_residual_floor +
   krylov_residual_reduction * ||b||`. `||.||` = the solver's

--- a/src/cubie/integrators/matrix_free_solvers/AGENTS.md
+++ b/src/cubie/integrators/matrix_free_solvers/AGENTS.md
@@ -87,7 +87,7 @@ compiled callable from `.device_function`.
   diagonal coefficient; FIRK: the full tableau row).
 - **Norm tolerances are per physical state** (`n` entries, the length
   the step controller takes); stage-tiled norms read entry `i mod n`.
-  `n` defaults to `solver_width` at norm construction.
+  `n` is a required norm-constructor argument.
 - **Every linear solve (MR, SD, BiCGSTAB; Newton-owned or direct)
   stops on** `||r|| <= krylov_residual_floor +
   krylov_residual_reduction * ||b||`. `||.||` = the solver's

--- a/src/cubie/integrators/matrix_free_solvers/base_solver.py
+++ b/src/cubie/integrators/matrix_free_solvers/base_solver.py
@@ -129,6 +129,7 @@ class MatrixFreeSolver(MultipleInstanceCUDAFactory):
             norm = ScaledNorm(
                 precision=precision,
                 solver_width=solver_width,
+                n=solver_width,
                 instance_label=solver_type,
                 **kwargs,
             )

--- a/src/cubie/integrators/matrix_free_solvers/newton_krylov.py
+++ b/src/cubie/integrators/matrix_free_solvers/newton_krylov.py
@@ -207,6 +207,7 @@ class NewtonKrylov(MatrixFreeSolver):
             norm = DIRKCorrectionNorm(
                 precision=precision,
                 solver_width=solver_width,
+                n=solver_width,
                 instance_label="newton",
                 **kwargs,
             )

--- a/src/cubie/integrators/norms.py
+++ b/src/cubie/integrators/norms.py
@@ -147,6 +147,7 @@ class ScaledNorm(MultipleInstanceCUDAFactory):
         self,
         precision: PrecisionDType,
         solver_width: int,
+        n: int,
         instance_label: str = "",
         **kwargs,
     ) -> None:
@@ -158,23 +159,24 @@ class ScaledNorm(MultipleInstanceCUDAFactory):
             Numerical precision for computations.
         solver_width : int
             Length of the solver vectors the norm reduces over.
+        n : int
+            Number of physical states per stage; equals
+            ``solver_width`` for whole-vector norms.
         instance_label : str, optional
             Prefix label for parameter names when used as a nested factory.
         **kwargs
             Optional parameters passed to ScaledNormConfig including
-            ``n``, atol and rtol. None values are ignored. ``atol``
-            and ``rtol`` hold one entry per physical state; ``n``
-            defaults to ``solver_width``.
+            atol and rtol. None values are ignored. ``atol`` and
+            ``rtol`` hold one entry per physical state.
         """
         super().__init__(instance_label=instance_label)
 
-        if kwargs.get("n") is None:
-            kwargs["n"] = solver_width
         config = build_config(
             self.config_type,
             required={
                 "precision": precision,
                 "solver_width": solver_width,
+                "n": n,
             },
             instance_label=instance_label,
             **kwargs,

--- a/src/cubie/integrators/norms.py
+++ b/src/cubie/integrators/norms.py
@@ -1,6 +1,6 @@
 """CUDA factories for scaled norms."""
 
-from typing import Callable
+from typing import Callable, Optional
 
 from numpy import asarray, ndarray
 from cubie.cuda_simsafe import cuda, int32
@@ -12,6 +12,7 @@ from cubie._utils import (
     getype_validator,
     nonnegative_float_array_validator,
     is_device_validator,
+    opt_getype_validator,
     tol_converter,
 )
 from cubie.CUDAFactory import (
@@ -29,25 +30,30 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
     ----------
     solver_width : int
         Length of the solver vectors the norm reduces over.
+    n : int, optional
+        Number of physical states per stage. Unset, it tracks
+        ``solver_width``.
     atol : ndarray
-        Absolute tolerance array of shape (solver_width,).
+        Absolute tolerance array of shape (n,).
     rtol : ndarray
-        Relative tolerance array of shape (solver_width,).
+        Relative tolerance array of shape (n,).
 
     Notes
     -----
-    Tolerance sizing follows ``solver_width`` through the
-    converter: every snapshot (construction or update-derived
-    replacement) re-runs :func:`cubie._utils.tol_converter`, which
-    broadcasts scalar or uniform-array specifications to shape
-    ``(solver_width,)``. A non-uniform array of the wrong length
-    raises at the write boundary; update ``solver_width`` and the
-    tolerance arrays together in one call.
+    Every snapshot re-runs :func:`cubie._utils.tol_converter`, which
+    broadcasts scalar or uniform-array tolerances to shape ``(n,)``.
+    A non-uniform array of another length raises, so change ``n`` and
+    the tolerance arrays in one call. ``n`` is declared before the
+    tolerance fields because the converter reads it.
     """
 
     solver_width: int = field(
         default=1,
         validator=getype_validator(int, 1),
+    )
+    _n: Optional[int] = field(
+        default=None,
+        validator=opt_getype_validator(int, 1),
     )
     atol: ndarray = field(
         default=asarray([1e-6]),
@@ -64,6 +70,22 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
+        self._check_widths()
+
+    def _check_widths(self) -> None:
+        """Require one tolerance per solver-vector entry."""
+        if self.n != self.solver_width:
+            raise ValueError(
+                "n must equal solver_width for a whole-vector norm; "
+                "use a tiled norm config for stage-blocked tolerances"
+            )
+
+    @property
+    def n(self) -> int:
+        """Return the number of physical states per stage."""
+        if self._n is None:
+            return self.solver_width
+        return self._n
 
     @property
     def inv_n(self) -> float:
@@ -73,7 +95,7 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
     @property
     def tol_length(self) -> int:
         """Return the tolerance-array length for tol_converter."""
-        return self.solver_width
+        return self.n
 
     @property
     def tol_floor(self) -> float:
@@ -88,25 +110,28 @@ class FIRKCorrectionNormConfig(ScaledNormConfig):
     Attributes
     ----------
     n : int
-        Number of physical states per stage.
+        Number of physical states per stage. The tolerance arrays hold
+        one entry per physical state, reused for every stage block.
     stage_coefficients : tuple
         Row-major flattened Butcher ``a`` matrix, as produced by
         ``tableau.a_flat``.
     """
 
-    n: int = field(default=1, validator=getype_validator(int, 1))
     stage_coefficients: tuple = field(default=(1.0,))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        if self.solver_width % self.n != 0:
-            raise ValueError(
-                "solver_width must be a multiple of n"
-            )
-        stage_count = self.solver_width // self.n
+        stage_count = self.stage_count
         if len(self.stage_coefficients) != stage_count * stage_count:
             raise ValueError(
                 "stage_coefficients must hold stage_count**2 values"
+            )
+
+    def _check_widths(self) -> None:
+        """Require whole stage blocks of ``n`` physical states."""
+        if self.solver_width % self.n != 0:
+            raise ValueError(
+                "solver_width must be a multiple of n"
             )
 
     @property
@@ -146,7 +171,8 @@ class ScaledNorm(MultipleInstanceCUDAFactory):
             Prefix label for parameter names when used as a nested factory.
         **kwargs
             Optional parameters passed to ScaledNormConfig including
-            atol and rtol. None values are ignored.
+            ``n``, atol and rtol. None values are ignored. ``atol``
+            and ``rtol`` hold one entry per physical state.
         """
         super().__init__(instance_label=instance_label)
 
@@ -257,15 +283,13 @@ class TiledScaledNormConfig(ScaledNormConfig):
     Attributes
     ----------
     n : int
-        Number of physical states per stage. The reference vector
-        holds one entry per physical state and is reused for every
-        stage block of the ``solver_width``-element value vector.
+        Number of physical states per stage. The reference and
+        tolerance vectors hold one entry per physical state, reused
+        for every stage block.
     """
 
-    n: int = field(default=1, validator=getype_validator(int, 1))
-
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
+    def _check_widths(self) -> None:
+        """Require whole stage blocks of ``n`` physical states."""
         if self.solver_width % self.n != 0:
             raise ValueError(
                 "solver_width must be a multiple of n"
@@ -276,10 +300,9 @@ class TiledScaledNorm(ScaledNorm):
     """Compile a scaled norm whose reference tiles across stages.
 
     Coupled FIRK solves stack ``solver_width = stage_count * n``
-    values, but the physical reference vector holds only ``n``
-    entries. The compiled function reads the reference entry for
-    value ``i`` at ``i mod n`` so callers pass the single-stage
-    reference directly.
+    values. The compiled function reads the reference and tolerance
+    entries for value ``i`` at ``i mod n``, so callers pass the
+    single-stage reference and the per-state tolerances directly.
     """
 
     config_type = TiledScaledNormConfig
@@ -311,8 +334,8 @@ class TiledScaledNorm(ScaledNorm):
                 stage_index = index // state_n
                 state_index = index - stage_index * state_n
                 tol_i = (
-                    atol[index]
-                    + rtol[index] * abs(reference[state_index])
+                    atol[state_index]
+                    + rtol[state_index] * abs(reference[state_index])
                 )
                 tol_i = max(tol_i, tol_floor)
                 ratio = abs(values[index]) / tol_i
@@ -425,7 +448,9 @@ class FIRKCorrectionNorm(CorrectionNorm):
                 reference = max(
                     abs(stage_value), abs(step_start[state_index])
                 )
-                tolerance = atol[index] + rtol[index] * reference
+                tolerance = (
+                    atol[state_index] + rtol[state_index] * reference
+                )
                 tolerance = max(tolerance, tol_floor)
                 ratio = values[index] / tolerance
                 nrm2 += ratio * ratio

--- a/src/cubie/integrators/norms.py
+++ b/src/cubie/integrators/norms.py
@@ -160,8 +160,7 @@ class ScaledNorm(MultipleInstanceCUDAFactory):
         solver_width : int
             Length of the solver vectors the norm reduces over.
         n : int
-            Number of physical states per stage; equals
-            ``solver_width`` for whole-vector norms.
+            Number of physical states per stage.
         instance_label : str, optional
             Prefix label for parameter names when used as a nested factory.
         **kwargs

--- a/src/cubie/integrators/norms.py
+++ b/src/cubie/integrators/norms.py
@@ -1,6 +1,6 @@
 """CUDA factories for scaled norms."""
 
-from typing import Callable, Optional
+from typing import Callable
 
 from numpy import asarray, ndarray
 from cubie.cuda_simsafe import cuda, int32
@@ -12,7 +12,6 @@ from cubie._utils import (
     getype_validator,
     nonnegative_float_array_validator,
     is_device_validator,
-    opt_getype_validator,
     tol_converter,
 )
 from cubie.CUDAFactory import (
@@ -30,9 +29,8 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
     ----------
     solver_width : int
         Length of the solver vectors the norm reduces over.
-    n : int, optional
-        Number of physical states per stage. Unset, it tracks
-        ``solver_width``.
+    n : int
+        Number of physical states per stage.
     atol : ndarray
         Absolute tolerance array of shape (n,).
     rtol : ndarray
@@ -51,9 +49,9 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
         default=1,
         validator=getype_validator(int, 1),
     )
-    _n: Optional[int] = field(
-        default=None,
-        validator=opt_getype_validator(int, 1),
+    n: int = field(
+        default=1,
+        validator=getype_validator(int, 1),
     )
     atol: ndarray = field(
         default=asarray([1e-6]),
@@ -79,13 +77,6 @@ class ScaledNormConfig(MultipleInstanceCUDAFactoryConfig):
                 "n must equal solver_width for a whole-vector norm; "
                 "use a tiled norm config for stage-blocked tolerances"
             )
-
-    @property
-    def n(self) -> int:
-        """Return the number of physical states per stage."""
-        if self._n is None:
-            return self.solver_width
-        return self._n
 
     @property
     def inv_n(self) -> float:
@@ -172,10 +163,13 @@ class ScaledNorm(MultipleInstanceCUDAFactory):
         **kwargs
             Optional parameters passed to ScaledNormConfig including
             ``n``, atol and rtol. None values are ignored. ``atol``
-            and ``rtol`` hold one entry per physical state.
+            and ``rtol`` hold one entry per physical state; ``n``
+            defaults to ``solver_width``.
         """
         super().__init__(instance_label=instance_label)
 
+        if kwargs.get("n") is None:
+            kwargs["n"] = solver_width
         config = build_config(
             self.config_type,
             required={

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -2038,6 +2038,19 @@ RADAU_ADAPTIVE_CASE = {
     "rtol": 1e-6,
 }
 
+# Three non-uniform entries, one per state of the default nonlinear
+# system. Unset inner tolerances derive from the controller's.
+FIRK_PER_STATE_TOLERANCES = {
+    "algorithm": "radau",
+    "step_controller": "gustafsson",
+    "atol": [1e-7, 1e-6, 1e-5],
+    "rtol": [1e-5, 1e-4, 1e-3],
+    "krylov_atol": None,
+    "krylov_rtol": None,
+    "newton_atol": None,
+    "newton_rtol": None,
+}
+
 DENSE_PREDICTION_ITERATION_CASES = [
     pytest.param(
         {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -697,6 +697,9 @@ def solver_settings(solver_settings_override, system, precision):
                 # Handle None values for optional float parameters
                 if value is None:
                     defaults[key] = None
+                elif np.ndim(value) > 0:
+                    # Per-state vectors keep their length; cast dtype.
+                    defaults[key] = np.asarray(value, dtype=precision)
                 else:
                     defaults[key] = precision(value)
             else:

--- a/tests/integrators/test_SingleIntegratorRunCore.py
+++ b/tests/integrators/test_SingleIntegratorRunCore.py
@@ -23,6 +23,7 @@ from tests._utils import (
 )
 from tests._utils import (
     CN_ADAPTIVE_KRYLOV_GIVEN,
+    FIRK_PER_STATE_TOLERANCES,
     RODAS3P_ADAPTIVE_KRYLOV_DEFAULT,
     RODAS3P_ADAPTIVE_KRYLOV_GIVEN,
 )
@@ -923,6 +924,37 @@ def test_update_controller_swap_builds(single_integrator_run_mutable):
 # ── Inner-solver tolerance defaults ─────────────────────────────────── #
 
 
+@pytest.mark.parametrize(
+    "solver_settings_override", [FIRK_PER_STATE_TOLERANCES], indirect=True
+)
+def test_per_state_tolerances_reach_coupled_firk_norms(
+    single_integrator_run, system
+):
+    """A per-state tolerance vector reaches the coupled FIRK norms."""
+    run = single_integrator_run
+    algo = run._algo_step
+    controller = run._step_controller
+    n = system.sizes.states
+
+    assert algo.is_implicit
+    assert controller.atol.shape == (n,)
+    assert np.asarray(algo.krylov_atol).shape == (n,)
+    assert np.asarray(algo.newton_atol).shape == (n,)
+    assert np.allclose(algo.krylov_atol, controller.atol)
+    assert np.allclose(algo.newton_atol, controller.atol / 10.0)
+
+    # The coupled solve is wider than the physical state, and the
+    # norms keep their tolerances at the physical length.
+    newton_norm = algo.solver.norm
+    krylov_norm = algo.solver.linear_solver.norm
+    assert krylov_norm.solver_width > n
+    for norm in (newton_norm, krylov_norm):
+        assert norm.compile_settings.n == n
+        assert norm.compile_settings.tol_length == n
+        assert norm.atol.shape == (n,)
+        assert norm.rtol.shape == (n,)
+
+    assert run.device_function is not None
 
 
 

--- a/tests/integrators/test_norms.py
+++ b/tests/integrators/test_norms.py
@@ -10,8 +10,11 @@ from numpy.testing import assert_allclose
 from cubie.integrators.norms import (
     DIRKCorrectionNorm,
     FIRKCorrectionNorm,
+    FIRKCorrectionNormConfig,
     ScaledNorm,
     ScaledNormConfig,
+    TiledScaledNorm,
+    TiledScaledNormConfig,
 )
 
 
@@ -163,6 +166,138 @@ def test_resize_nonuniform_wrong_length_raises():
     replacement, _, changed = cfg.update({"solver_width": 5, "atol": new_atol})
     assert replacement.atol.shape == (5,)
     assert_allclose(replacement.atol, new_atol)
+
+
+# ── stage-tiled tolerance sizing ─────────────────────────── #
+
+
+def test_whole_vector_config_rejects_smaller_n():
+    """A whole-vector norm cannot hold fewer tolerances than values."""
+    with pytest.raises(ValueError, match="whole-vector"):
+        ScaledNormConfig(precision=np.float64, solver_width=6, n=3)
+
+
+@pytest.mark.parametrize(
+    "config_class, extra",
+    [
+        (TiledScaledNormConfig, {}),
+        (
+            FIRKCorrectionNormConfig,
+            {"stage_coefficients": tuple(np.arange(4, dtype=float))},
+        ),
+    ],
+)
+def test_tiled_config_tolerances_are_per_state(config_class, extra):
+    """Stage-tiled configs size tolerances by n, not solver_width."""
+    atol = np.array([1e-7, 1e-6], dtype=np.float64)
+    cfg = config_class(
+        precision=np.float64,
+        solver_width=4,
+        n=2,
+        atol=atol,
+        rtol=1e-4,
+        **extra,
+    )
+    assert cfg.tol_length == 2
+    assert cfg.atol.shape == (2,)
+    assert cfg.rtol.shape == (2,)
+    assert_allclose(cfg.atol, atol)
+
+
+def test_tiled_config_rejects_solver_width_length_tolerance():
+    """A stage-stacked tolerance vector is the wrong length."""
+    atol = np.array([1e-7, 1e-6, 1e-5, 1e-4], dtype=np.float64)
+    with pytest.raises(ValueError, match="shape"):
+        TiledScaledNormConfig(
+            precision=np.float64, solver_width=4, n=2, atol=atol
+        )
+
+
+def test_tiled_norm_tiles_tolerances_across_stages():
+    """Each stage block scales by its physical state's tolerance."""
+    n = 2
+    stages = 3
+    width = n * stages
+    atol = np.array([1e-3, 1e-5], dtype=np.float64)
+    rtol = np.array([1e-2, 1e-4], dtype=np.float64)
+    factory = TiledScaledNorm(
+        precision=np.float64, solver_width=width, n=n, atol=atol, rtol=rtol
+    )
+    fn = factory.device_function
+
+    @cuda.jit
+    def kernel(values, reference, result):
+        result[0] = fn(values, reference)
+
+    values_host = np.arange(1.0, width + 1.0, dtype=np.float64)
+    reference_host = np.array([0.5, -2.0], dtype=np.float64)
+    values = cuda.to_device(values_host)
+    reference = cuda.to_device(reference_host)
+    result = cuda.to_device(np.zeros(1, dtype=np.float64))
+
+    kernel[1, 1](values, reference, result)
+
+    expected = 0.0
+    for index in range(width):
+        state = index % n
+        tol = atol[state] + rtol[state] * abs(reference_host[state])
+        expected += (values_host[index] / tol) ** 2
+    expected /= width
+    assert_allclose(result.copy_to_host()[0], expected, rtol=1e-10)
+
+
+def test_firk_correction_norm_tiles_tolerances_across_stages():
+    """The coupled Newton norm scales stage blocks per state."""
+    n = 2
+    stages = 2
+    width = n * stages
+    a = np.array([[0.5, 0.0], [0.5, 0.5]], dtype=np.float64)
+    atol = np.array([1.0, 0.25], dtype=np.float64)
+    rtol = np.array([0.1, 0.4], dtype=np.float64)
+    factory = FIRKCorrectionNorm(
+        precision=np.float64,
+        solver_width=width,
+        n=n,
+        stage_coefficients=tuple(a.ravel().tolist()),
+        atol=atol,
+        rtol=rtol,
+    )
+    fn = factory.device_function
+
+    @cuda.jit
+    def kernel(delta, increment, stage_base, step_start, a_ij, result):
+        result[0] = fn(delta, increment, stage_base, step_start, a_ij)
+
+    delta_host = np.array([0.21, 0.3, 0.46, 0.15], dtype=np.float64)
+    increment_host = np.array([2.0, -1.0, 4.0, 3.0], dtype=np.float64)
+    base_host = np.array([10.0, -4.0], dtype=np.float64)
+    start_host = np.array([8.0, -5.0], dtype=np.float64)
+    result = cuda.to_device(np.zeros(1, dtype=np.float64))
+
+    kernel[1, 1](
+        cuda.to_device(delta_host),
+        cuda.to_device(increment_host),
+        cuda.to_device(base_host),
+        cuda.to_device(start_host),
+        np.float64(0.0),
+        result,
+    )
+
+    expected = 0.0
+    for index in range(width):
+        stage = index // n
+        state = index - stage * n
+        stage_value = base_host[state]
+        for contribution in range(stages):
+            stage_value += (
+                a[stage, contribution]
+                * increment_host[contribution * n + state]
+            )
+        reference = max(abs(stage_value), abs(start_host[state]))
+        tol = atol[state] + rtol[state] * reference
+        expected += (delta_host[index] / tol) ** 2
+    expected /= width
+    assert_allclose(result.copy_to_host()[0], expected, rtol=1e-10)
 
 
 # ── ScaledNormCache ──────────────────────────────────────── #

--- a/tests/integrators/test_norms.py
+++ b/tests/integrators/test_norms.py
@@ -41,7 +41,9 @@ def test_config_custom_tolerances():
     """Custom atol/rtol arrays are stored correctly."""
     atol = np.array([1e-4, 1e-5, 1e-6], dtype=np.float64)
     rtol = np.array([1e-3, 1e-4, 1e-5], dtype=np.float64)
-    cfg = ScaledNormConfig(precision=np.float64, solver_width=3, atol=atol, rtol=rtol)
+    cfg = ScaledNormConfig(
+        precision=np.float64, solver_width=3, n=3, atol=atol, rtol=rtol
+    )
     assert_allclose(cfg.atol, atol)
     assert_allclose(cfg.rtol, rtol)
     assert cfg.atol.shape == (3,)
@@ -51,7 +53,7 @@ def test_config_tolerance_arrays_sealed_after_hashing():
     """Stored tolerances cannot change under a memoized hash."""
     caller_atol = np.array([1e-4, 1e-5, 1e-6], dtype=np.float32)
     cfg = ScaledNormConfig(
-        precision=np.float32, solver_width=3, atol=caller_atol,
+        precision=np.float32, solver_width=3, n=3, atol=caller_atol,
         rtol=1e-4,
     )
     hash_before = cfg.values_hash
@@ -69,7 +71,9 @@ def test_config_tolerance_arrays_sealed_after_hashing():
 
 def test_config_scalar_tolerance_broadcast():
     """Scalar tolerance is broadcast to array of length n."""
-    cfg = ScaledNormConfig(precision=np.float64, solver_width=4, atol=1e-5, rtol=1e-4)
+    cfg = ScaledNormConfig(
+        precision=np.float64, solver_width=4, n=4, atol=1e-5, rtol=1e-4
+    )
     assert cfg.atol.shape == (4,)
     assert cfg.rtol.shape == (4,)
     assert_allclose(cfg.atol, np.full(4, 1e-5))
@@ -79,33 +83,39 @@ def test_config_scalar_tolerance_broadcast():
 def test_config_negative_atol_rejected():
     """atol rejects arrays containing negative values."""
     with pytest.raises(ValueError):
-        ScaledNormConfig(precision=np.float64, solver_width=2, atol=-1e-6)
+        ScaledNormConfig(
+            precision=np.float64, solver_width=2, n=2, atol=-1e-6
+        )
 
 
 def test_config_negative_rtol_rejected():
     """rtol rejects arrays containing negative elements."""
     rtol = np.array([1e-4, -1e-4], dtype=np.float64)
     with pytest.raises(ValueError):
-        ScaledNormConfig(precision=np.float64, solver_width=2, rtol=rtol)
+        ScaledNormConfig(
+            precision=np.float64, solver_width=2, n=2, rtol=rtol
+        )
 
 
 def test_config_zero_tolerances_accepted():
     """Zero tolerances are valid; tol_floor guards the division."""
-    cfg = ScaledNormConfig(precision=np.float64, solver_width=2, atol=0.0, rtol=0.0)
+    cfg = ScaledNormConfig(
+        precision=np.float64, solver_width=2, n=2, atol=0.0, rtol=0.0
+    )
     assert_allclose(cfg.atol, np.zeros(2))
     assert_allclose(cfg.rtol, np.zeros(2))
 
 
 def test_config_inv_n():
     """inv_n returns precision(1.0/n)."""
-    cfg = ScaledNormConfig(precision=np.float32, solver_width=5)
+    cfg = ScaledNormConfig(precision=np.float32, solver_width=5, n=5)
     expected = np.float32(1.0 / 5)
     assert cfg.inv_n == pytest.approx(float(expected), rel=1e-6)
 
 
 def test_config_tol_floor():
     """tol_floor returns precision(1e-16)."""
-    cfg = ScaledNormConfig(precision=np.float64, solver_width=2)
+    cfg = ScaledNormConfig(precision=np.float64, solver_width=2, n=2)
     assert cfg.tol_floor == pytest.approx(1e-16)
 
 
@@ -130,9 +140,11 @@ def test_config_rtol_prefixed_metadata():
 
 def test_resize_uniform_tolerances_on_n_change():
     """Uniform tolerance arrays expand when n changes."""
-    cfg = ScaledNormConfig(precision=np.float64, solver_width=2, atol=1e-5, rtol=1e-4)
+    cfg = ScaledNormConfig(
+        precision=np.float64, solver_width=2, n=2, atol=1e-5, rtol=1e-4
+    )
     assert cfg.atol.shape == (2,)
-    replacement, _, changed = cfg.update({"solver_width": 5})
+    replacement, _, changed = cfg.update({"solver_width": 5, "n": 5})
     assert "solver_width" in changed
     assert replacement.atol.shape == (5,)
     assert replacement.rtol.shape == (5,)
@@ -145,7 +157,9 @@ def test_resize_uniform_tolerances_on_n_change():
 def test_resize_skips_matching_length():
     """Tolerances already matching n are not modified."""
     atol = np.array([1e-4, 1e-5, 1e-6], dtype=np.float64)
-    cfg = ScaledNormConfig(precision=np.float64, solver_width=3, atol=atol, rtol=1e-3)
+    cfg = ScaledNormConfig(
+        precision=np.float64, solver_width=3, n=3, atol=atol, rtol=1e-3
+    )
     replacement, _, changed = cfg.update({"solver_width": 3})  # same size
     assert changed == set()
     assert_allclose(replacement.atol, atol)
@@ -158,12 +172,16 @@ def test_resize_nonuniform_wrong_length_raises():
     change both.
     """
     atol = np.array([1e-4, 1e-5], dtype=np.float64)
-    cfg = ScaledNormConfig(precision=np.float64, solver_width=2, atol=atol, rtol=1e-3)
+    cfg = ScaledNormConfig(
+        precision=np.float64, solver_width=2, n=2, atol=atol, rtol=1e-3
+    )
     with pytest.raises(ValueError, match="shape"):
-        cfg.update({"solver_width": 5})
+        cfg.update({"solver_width": 5, "n": 5})
     # A combined update supplies consistent values in one snapshot.
     new_atol = np.array([1e-4, 1e-5, 1e-6, 1e-7, 1e-8], dtype=np.float64)
-    replacement, _, changed = cfg.update({"solver_width": 5, "atol": new_atol})
+    replacement, _, changed = cfg.update(
+        {"solver_width": 5, "n": 5, "atol": new_atol}
+    )
     assert replacement.atol.shape == (5,)
     assert_allclose(replacement.atol, new_atol)
 

--- a/tests/integrators/test_norms.py
+++ b/tests/integrators/test_norms.py
@@ -22,7 +22,7 @@ from cubie.integrators.norms import (
 
 
 def test_config_defaults():
-    """Default solver_width=1, atol=[1e-6], rtol=[1e-6]."""
+    """Default solver_width=1, n=1, atol=[1e-6], rtol=[1e-6]."""
     cfg = ScaledNormConfig(precision=np.float64)
     assert cfg.solver_width == 1
     assert cfg.atol.shape == (1,)
@@ -34,7 +34,7 @@ def test_config_defaults():
 def test_config_n_validated_minimum():
     """n must be >= 1."""
     with pytest.raises((ValueError, TypeError)):
-        ScaledNormConfig(precision=np.float64, solver_width=0)
+        ScaledNormConfig(precision=np.float64, solver_width=0, n=0)
 
 
 def test_config_custom_tolerances():
@@ -323,7 +323,7 @@ def test_firk_correction_norm_tiles_tolerances_across_stages():
 
 def test_cache_from_build():
     """Build returns ScaledNormCache with scaled_norm field."""
-    factory = ScaledNorm(precision=np.float64, solver_width=3)
+    factory = ScaledNorm(precision=np.float64, solver_width=3, n=3)
     _ = factory.device_function
     cache = factory._cache
     # Cache holds the same function as device_function property
@@ -335,7 +335,7 @@ def test_cache_from_build():
 
 def test_init_sets_compile_settings():
     """__init__ creates config and sets up compile_settings."""
-    factory = ScaledNorm(precision=np.float64, solver_width=4, atol=1e-5, rtol=1e-4)
+    factory = ScaledNorm(precision=np.float64, solver_width=4, n=4, atol=1e-5, rtol=1e-4)
     cs = factory.compile_settings
     assert cs.solver_width == 4
     assert cs.precision == np.float64
@@ -349,7 +349,7 @@ def test_init_with_instance_label():
     rtol = np.array([1e-5, 1e-4, 1e-3], dtype=np.float64)
     factory = ScaledNorm(
         precision=np.float64,
-        solver_width=3,
+        solver_width=3, n=3,
         instance_label="krylov",
         krylov_atol=atol,
         krylov_rtol=rtol,
@@ -362,7 +362,7 @@ def test_init_empty_instance_label():
     """Empty instance_label uses unprefixed kwargs."""
     atol = np.array([1e-8, 1e-7], dtype=np.float64)
     factory = ScaledNorm(
-        precision=np.float64, solver_width=2, instance_label="", atol=atol
+        precision=np.float64, solver_width=2, n=2, instance_label="", atol=atol
     )
     assert_allclose(factory.atol, atol)
 
@@ -372,7 +372,7 @@ def test_init_empty_instance_label():
 
 def test_build_converged_norm():
     """Norm <= 1.0 when errors are within tolerance."""
-    factory = ScaledNorm(precision=np.float64, solver_width=3, atol=1e-3, rtol=1e-3)
+    factory = ScaledNorm(precision=np.float64, solver_width=3, n=3, atol=1e-3, rtol=1e-3)
     fn = factory.device_function
 
     @cuda.jit
@@ -393,7 +393,7 @@ def test_build_converged_norm():
 
 def test_build_exceeds_tolerance():
     """Norm > 1.0 when errors exceed tolerance."""
-    factory = ScaledNorm(precision=np.float64, solver_width=3, atol=1e-6, rtol=1e-6)
+    factory = ScaledNorm(precision=np.float64, solver_width=3, n=3, atol=1e-6, rtol=1e-6)
     fn = factory.device_function
 
     @cuda.jit
@@ -415,7 +415,7 @@ def test_build_exceeds_tolerance():
 def test_build_tol_floor_prevents_division_by_zero():
     """When atol and rtol*ref are near zero, floor of 1e-16 applies."""
     factory = ScaledNorm(
-        precision=np.float64, solver_width=1, atol=0.0, rtol=0.0
+        precision=np.float64, solver_width=1, n=1, atol=0.0, rtol=0.0
     )
     fn = factory.device_function
 
@@ -440,7 +440,7 @@ def test_build_mean_squared_norm():
     """Norm is mean of squared ratios (divided by n)."""
     atol = np.array([1e-3, 1e-4], dtype=np.float64)
     rtol = np.array([0.0, 0.0], dtype=np.float64)
-    factory = ScaledNorm(precision=np.float64, solver_width=2, atol=atol, rtol=rtol)
+    factory = ScaledNorm(precision=np.float64, solver_width=2, n=2, atol=atol, rtol=rtol)
     fn = factory.device_function
 
     @cuda.jit
@@ -464,7 +464,7 @@ def test_build_mean_squared_norm():
 _CORRECTION_NORM_CASES = {
     "dirk": dict(
         factory=DIRKCorrectionNorm,
-        factory_kwargs=dict(solver_width=2),
+        factory_kwargs=dict(solver_width=2, n=2),
         a_ij=0.5,
         delta=(0.21, 0.3),
         increment=(2.0, -1.0),
@@ -556,7 +556,7 @@ def test_correction_norm_scales_by_physical_stage_state(
 
 def test_update_invalidates_cache():
     """update() invalidates the cache when settings change."""
-    factory = ScaledNorm(precision=np.float64, solver_width=3, atol=1e-6, rtol=1e-6)
+    factory = ScaledNorm(precision=np.float64, solver_width=3, n=3, atol=1e-6, rtol=1e-6)
     _ = factory.device_function
     assert factory.cache_valid
     new_atol = np.array([1e-3, 1e-3, 1e-3], dtype=np.float64)
@@ -567,7 +567,7 @@ def test_update_invalidates_cache():
 
 def test_update_empty_returns_empty_set():
     """Empty update returns empty set without cache invalidation."""
-    factory = ScaledNorm(precision=np.float64, solver_width=2)
+    factory = ScaledNorm(precision=np.float64, solver_width=2, n=2)
     _ = factory.device_function
     result = factory.update()
     assert result == set()
@@ -576,7 +576,7 @@ def test_update_empty_returns_empty_set():
 
 def test_update_merges_dict_and_kwargs():
     """update() merges updates_dict and kwargs."""
-    factory = ScaledNorm(precision=np.float64, solver_width=2, atol=1e-6, rtol=1e-6)
+    factory = ScaledNorm(precision=np.float64, solver_width=2, n=2, atol=1e-6, rtol=1e-6)
     new_atol = np.full(2, 1e-3, dtype=np.float64)
     new_rtol = np.full(2, 1e-4, dtype=np.float64)
     recognized = factory.update({"atol": new_atol}, rtol=new_rtol)
@@ -598,7 +598,7 @@ def test_update_merges_dict_and_kwargs():
 )
 def test_forwarding_scalar_properties(prop, child_attr):
     """Scalar forwarding properties delegate to compile_settings."""
-    factory = ScaledNorm(precision=np.float64, solver_width=4, atol=1e-5, rtol=1e-4)
+    factory = ScaledNorm(precision=np.float64, solver_width=4, n=4, atol=1e-5, rtol=1e-4)
     assert getattr(factory, prop) == getattr(
         factory.compile_settings, child_attr
     )
@@ -613,7 +613,7 @@ def test_forwarding_scalar_properties(prop, child_attr):
 )
 def test_forwarding_array_properties(prop, child_attr):
     """Array forwarding properties delegate to compile_settings."""
-    factory = ScaledNorm(precision=np.float64, solver_width=3, atol=1e-5, rtol=1e-4)
+    factory = ScaledNorm(precision=np.float64, solver_width=3, n=3, atol=1e-5, rtol=1e-4)
     result = getattr(factory, prop)
     expected = getattr(factory.compile_settings, child_attr)
     assert_allclose(result, expected)
@@ -621,6 +621,6 @@ def test_forwarding_array_properties(prop, child_attr):
 
 def test_device_function_forwards_cache():
     """device_function returns get_cached_output('scaled_norm')."""
-    factory = ScaledNorm(precision=np.float64, solver_width=2)
+    factory = ScaledNorm(precision=np.float64, solver_width=2, n=2)
     fn = factory.device_function
     assert fn is factory.get_cached_output("scaled_norm")


### PR DESCRIPTION
Fixes #727.

A per-state `atol`/`rtol` vector could not be passed to any FIRK
algorithm. `ScaledNormConfig.tol_length` returned `solver_width`, and
the stage-tiled configs inherited it, so the coupled FIRK norms
demanded `stage_count * n` entries while the step controller demanded
`n` — no vector length satisfied both. The tiled device functions only
ever read the first `n` entries, so `n` is the length they intend.

- `ScaledNormConfig` gains a concrete int `n`, declared before the
  tolerance fields so the `takes_self` converter reads it;
  `tol_length` returns `n`. Norm constructors default it to
  `solver_width`, and system-size updates already deliver `n`
  alongside the refreshed `solver_width` through
  `ODEImplicitStep.update`.
- `TiledScaledNormConfig` and `FIRKCorrectionNormConfig` inherit that
  `n` and move their divisibility rule into a `_check_widths`
  override. The base rule requires `n == solver_width`, so a
  whole-vector norm cannot be given tolerances shorter than the
  vector it indexes, and a `solver_width`-only update on a mismatched
  config fails loudly.
- `TiledScaledNorm` and `FIRKCorrectionNorm` read their tolerance
  entries at `i mod n`, alongside the reference.
- `tests/conftest.py` casts array-valued tolerance overrides instead
  of calling `precision(value)` on them, which raised for vectors.

Uniform vectors and scalars broadcast as before, so existing
configurations are numerically unchanged.

Tests: five in `tests/integrators/test_norms.py` covering config
sizing, wrong-length rejection, and both device functions against
explicit references; one end-to-end in
`tests/integrators/test_SingleIntegratorRunCore.py` on the new shared
set `FIRK_PER_STATE_TOLERANCES`. Full CUDASIM suite 3089 passed; full
real-GPU suite 3139 passed.

## Performance gate

Retry run (`--pairs 8`), published as-is.

```
A = origin/main (844b98fb)   B = fix/727-per-state-atol-firk (working tree)   backends: numba-cuda, mlir   (8 block pairs x 15 solves/block/side)

numba-cuda fixed          kernel  A    62.319  B    62.331   -0.05%  ok  DISTRUST
numba-cuda fixed          wall    A    75.507  B    72.308   -4.27%  ok
numba-cuda adaptive       kernel  A    17.871  B    17.918   +0.28%  ok  DISTRUST
numba-cuda adaptive       wall    A    21.863  B    21.013   -3.99%  ok
numba-cuda host_overhead  wall    A     0.821  B     0.628   -0.198ms  ok
numba-cuda chunked        kernel  A    62.731  B    62.528   -0.27%  ok  DISTRUST
numba-cuda chunked        wall    A    77.213  B    77.166   -0.19%  ok
numba-cuda wave           kernel  A    25.582  B    25.540   +0.02%  ok
numba-cuda wave           wall    A    27.439  B    27.385   -0.18%  ok

mlir       fixed          kernel  A    62.159  B    62.201   +0.08%  ok
mlir       fixed          wall    A    75.540  B    75.578   +0.12%  ok
mlir       adaptive       kernel  A    17.257  B    17.253   +0.04%  ok
mlir       adaptive       wall    A    21.265  B    21.270   +0.07%  ok
mlir       host_overhead  wall    A     0.811  B     0.800   -0.004ms  ok
mlir       chunked        kernel  A    62.567  B    62.541   -0.15%  ok  DISTRUST
mlir       chunked        wall    A    77.169  B    77.360   +0.30%  ok
mlir       wave           kernel  A    25.733  B    25.659   -0.06%  ok
mlir       wave           wall    A    28.078  B    28.096   +0.24%  ok

GATE: INCONCLUSIVE (kernel threshold 0.50%, wall threshold 10.00%, host-overhead threshold 0.25 ms)
DISTRUST = the pairs split on the regression call, so that verdict is unreliable; rerun, with more --pairs or a quieter GPU, before acting on it.
```

Register counts, spills, and occupancy are identical on both
backends for every config.

Co-authored by Chris' bot
