### PR TITLE
fix(fleet): dashboard caches settled runs durably and reads each leg's own region

### DIFF
--- a/infra/fleet/README.md
+++ b/infra/fleet/README.md
@@ -114,10 +114,8 @@ wait / boot / CI steps / shutdown with the run total broken down beside
 it; time in each CI step (with a run-total bar beside it); cost at the
 achieved spot price; minutes and cost per instance type and spot product
 with the average spot rate annotated; and spot-capacity wait per leg.
-Windows and Linux are separate spot markets for the same instance type
-(g5.xlarge in us-east-2c on 2026-08-05: $0.2846/h Windows, $0.3862/h
-Linux), so each leg carries the product it was priced under and the
-per-type view keeps them in separate bars. The account section
+Windows and Linux are separate spot markets for one instance type and
+get their own bars. The account section
 takes inclusive from/to date pickers and a granularity and charts
 whole-account usage hours per instance type and gross usage $ by service.
 Hourly ranges are limited to 366 inclusive days and daily ranges to 3,660
@@ -154,35 +152,27 @@ read-only grants the bootstrap policy's `ReadOnly` / `HistoryReadOnly` /
 `CostExplorerReadOnly` statements add.
 
 Both AWS instance reads are made in the region a leg's own instance ran
-in, taken from its AZ. A CI run outlives a fleet region move and its
-history exists only where it ran, so a leg with no log — and therefore
-no AZ — is looked up in each region in `SEARCH_REGIONS` (the current
-region first) until one answers. `HistoryReadOnly` is the matching
-grant: `ec2:DescribeSpotPriceHistory` and `cloudtrail:LookupEvents`
-across `HISTORY_REGIONS` in the bootstrap script, while every other
-deployer permission stays locked to the active region. **Adding a region
-to the fleet means adding it to both lists and rerunning the bootstrap
-script**; without the grant, pre-move runs render with unknown price and
-cost rather than failing.
+in, taken from its AZ. A leg with no log, and therefore no AZ, is looked
+up in each region in `SEARCH_REGIONS` (current region first) until one
+answers. The matching grant is `HistoryReadOnly`:
+`ec2:DescribeSpotPriceHistory` and `cloudtrail:LookupEvents` across
+`HISTORY_REGIONS` in the bootstrap script, while every other deployer
+permission stays locked to the active region. **A new fleet region must
+be added to both lists, and the bootstrap script rerun.** Without the
+grant, that region's runs render with unknown price and cost.
 
 Settled run detail is cached durably in a third transactional SQLite
-store, `.dashboard-cache/details.sqlite3` (gitignored), so a run already
-looked at redraws with no GitHub or AWS request at all — 12.1 s to 0.03 s
-for a 16-leg run, across process restarts. A run payload is stored only
+store, `.dashboard-cache/details.sqlite3` (gitignored): a run already
+looked at redraws with no GitHub or AWS request, across process
+restarts (12.1 s to 0.03 s for a 16-leg run). A run payload is stored
 once every GPU leg has completed, its log has arrived or is permanently
-absent, and every leg has both a spot price and a termination time: an
-incomplete view is served but never persisted, so a gap that closes
-later (a CloudTrail event still landing, a region the credentials cannot
-yet read) is not frozen into every future view. Underneath the run
-payload the two per-leg AWS reads are cached in their own right — a past
-instant's spot price and a terminated instance's launch/termination
-record are both final once observed — which is what makes a run that is
-still settling cheap to reload. Only known answers are stored; a denied
-or not-yet-recorded read is retried. Nothing is evicted by age: a run's
-rows outlive its seven-day slot in the dropdown at a few tens of
-kilobytes each, which is the point of the store. Every table is derived
-data, so a schema or payload-shape change discards the file rather than
-migrating it, and deleting it costs only the refetch.
+absent, and every leg has both a spot price and a termination time; an
+incomplete view is served but not stored. The two per-leg AWS reads are
+cached in their own right, which is what makes a run that is still
+settling cheap to reload. Only known answers are stored; a denied or
+not-yet-recorded read is retried. Nothing is evicted by age. A schema or
+payload-shape change discards the file rather than migrating it, and
+deleting it costs only the refetch.
 
 **Cost of use:** per-run views are free (GitHub API, `ec2:Describe*` and
 `cloudtrail:LookupEvents` carry no charge). Only the account panels touch

--- a/infra/fleet/README.md
+++ b/infra/fleet/README.md
@@ -112,8 +112,12 @@ python infra/fleet/cost_dashboard.py    # opens http://localhost:8787
 Pick a run from the dropdown to see, per leg: a timeline of spot-capacity
 wait / boot / CI steps / shutdown with the run total broken down beside
 it; time in each CI step (with a run-total bar beside it); cost at the
-achieved spot price; minutes and cost per instance type with the average
-spot rate annotated; and spot-capacity wait per leg. The account section
+achieved spot price; minutes and cost per instance type and spot product
+with the average spot rate annotated; and spot-capacity wait per leg.
+Windows and Linux are separate spot markets for the same instance type
+(g5.xlarge in us-east-2c on 2026-08-05: $0.2846/h Windows, $0.3862/h
+Linux), so each leg carries the product it was priced under and the
+per-type view keeps them in separate bars. The account section
 takes inclusive from/to date pickers and a granularity and charts
 whole-account usage hours per instance type and gross usage $ by service.
 Hourly ranges are limited to 366 inclusive days and daily ranges to 3,660
@@ -146,8 +150,39 @@ timeline, instance type/AZ, launch time), and AWS via the `cubie-fleet`
 profile — `ec2:DescribeSpotPriceHistory` (achieved spot rate),
 `cloudtrail:LookupEvents` (instance launch and terminate), and Cost Explorer
 (`ce:GetCostAndUsage`) for the account panels. The last two are the
-read-only grants the bootstrap policy's `ReadOnly` / `CostExplorerReadOnly`
-statements add.
+read-only grants the bootstrap policy's `ReadOnly` / `HistoryReadOnly` /
+`CostExplorerReadOnly` statements add.
+
+Both AWS instance reads are made in the region a leg's own instance ran
+in, taken from its AZ. A CI run outlives a fleet region move and its
+history exists only where it ran, so a leg with no log — and therefore
+no AZ — is looked up in each region in `SEARCH_REGIONS` (the current
+region first) until one answers. `HistoryReadOnly` is the matching
+grant: `ec2:DescribeSpotPriceHistory` and `cloudtrail:LookupEvents`
+across `HISTORY_REGIONS` in the bootstrap script, while every other
+deployer permission stays locked to the active region. **Adding a region
+to the fleet means adding it to both lists and rerunning the bootstrap
+script**; without the grant, pre-move runs render with unknown price and
+cost rather than failing.
+
+Settled run detail is cached durably in a third transactional SQLite
+store, `.dashboard-cache/details.sqlite3` (gitignored), so a run already
+looked at redraws with no GitHub or AWS request at all — 12.1 s to 0.03 s
+for a 16-leg run, across process restarts. A run payload is stored only
+once every GPU leg has completed, its log has arrived or is permanently
+absent, and every leg has both a spot price and a termination time: an
+incomplete view is served but never persisted, so a gap that closes
+later (a CloudTrail event still landing, a region the credentials cannot
+yet read) is not frozen into every future view. Underneath the run
+payload the two per-leg AWS reads are cached in their own right — a past
+instant's spot price and a terminated instance's launch/termination
+record are both final once observed — which is what makes a run that is
+still settling cheap to reload. Only known answers are stored; a denied
+or not-yet-recorded read is retried. Nothing is evicted by age: a run's
+rows outlive its seven-day slot in the dropdown at a few tens of
+kilobytes each, which is the point of the store. Every table is derived
+data, so a schema or payload-shape change discards the file rather than
+migrating it, and deleting it costs only the refetch.
 
 **Cost of use:** per-run views are free (GitHub API, `ec2:Describe*` and
 `cloudtrail:LookupEvents` carry no charge). Only the account panels touch

--- a/infra/fleet/bootstrap/cloudshell-iam.sh
+++ b/infra/fleet/bootstrap/cloudshell-iam.sh
@@ -23,6 +23,14 @@
 set -euo pipefail
 
 REGION="us-east-2"
+# Regions the fleet has run GPU CI in, current one first. The cost
+# dashboard reads instance launch/termination history and achieved spot
+# prices from whichever region a run's instances actually ran in, and a
+# run outlives a region move, so those two reads span this list while
+# every other permission stays locked to the active region.
+HISTORY_REGIONS=("${REGION}" "ap-southeast-2")
+HISTORY_REGIONS_JSON=$(printf '"%s",' "${HISTORY_REGIONS[@]}")
+HISTORY_REGIONS_JSON="[${HISTORY_REGIONS_JSON%,}]"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
 # Permissions, by statement:
@@ -34,6 +42,13 @@ ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 #   cost/timeline report). Reads carry no secret material:
 #   secretsmanager:GetSecretValue is NOT here -- it lives in
 #   SecretsScoped, bound to this stack's secret prefix.
+# - HistoryReadOnly: the two reads the cost dashboard makes against a
+#   run's own region, allowed across every region in HISTORY_REGIONS.
+#   A CI run outlives a fleet region move, and CloudTrail history and
+#   spot prices only exist in the region the instances ran in, so a
+#   region-locked read would leave every pre-move run unpriced. Both
+#   actions are read-only, account-wide by nature (spot price history
+#   is public market data), and carry no secret material.
 # - CostExplorerReadOnly: read-only Cost Explorer for the CI
 #   cost/usage report. Cost Explorer is a global service reached
 #   through us-east-1, so it CANNOT sit in the region-locked ReadOnly
@@ -138,6 +153,18 @@ cat > /tmp/cubie-fleet-deployer-policy.json <<EOF
       "Resource": "*",
       "Condition": {
         "StringEquals": { "aws:RequestedRegion": "${REGION}" }
+      }
+    },
+    {
+      "Sid": "HistoryReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeSpotPriceHistory",
+        "cloudtrail:LookupEvents"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": { "aws:RequestedRegion": ${HISTORY_REGIONS_JSON} }
       }
     },
     {

--- a/infra/fleet/bootstrap/cloudshell-iam.sh
+++ b/infra/fleet/bootstrap/cloudshell-iam.sh
@@ -23,11 +23,7 @@
 set -euo pipefail
 
 REGION="us-east-2"
-# Regions the fleet has run GPU CI in, current one first. The cost
-# dashboard reads instance launch/termination history and achieved spot
-# prices from whichever region a run's instances actually ran in, and a
-# run outlives a region move, so those two reads span this list while
-# every other permission stays locked to the active region.
+# Regions the cost dashboard reads instance and spot history from.
 HISTORY_REGIONS=("${REGION}" "ap-southeast-2")
 HISTORY_REGIONS_JSON=$(printf '"%s",' "${HISTORY_REGIONS[@]}")
 HISTORY_REGIONS_JSON="[${HISTORY_REGIONS_JSON%,}]"
@@ -42,13 +38,9 @@ ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 #   cost/timeline report). Reads carry no secret material:
 #   secretsmanager:GetSecretValue is NOT here -- it lives in
 #   SecretsScoped, bound to this stack's secret prefix.
-# - HistoryReadOnly: the two reads the cost dashboard makes against a
-#   run's own region, allowed across every region in HISTORY_REGIONS.
-#   A CI run outlives a fleet region move, and CloudTrail history and
-#   spot prices only exist in the region the instances ran in, so a
-#   region-locked read would leave every pre-move run unpriced. Both
-#   actions are read-only, account-wide by nature (spot price history
-#   is public market data), and carry no secret material.
+# - HistoryReadOnly: CloudTrail and spot-price reads across every
+#   region in HISTORY_REGIONS, for runs from before a region move.
+#   Read-only, and carries no secret material.
 # - CostExplorerReadOnly: read-only Cost Explorer for the CI
 #   cost/usage report. Cost Explorer is a global service reached
 #   through us-east-1, so it CANNOT sit in the region-locked ReadOnly

--- a/infra/fleet/cost_dashboard.html
+++ b/infra/fleet/cost_dashboard.html
@@ -101,7 +101,7 @@
         </div>
       </div>
 
-      <h2>Per instance type</h2>
+      <h2>Per instance type and spot product</h2>
       <div id="typeLegend" class="shared-legend"></div>
       <div class="card"><div id="cType" class="chart"></div></div>
     </div>

--- a/infra/fleet/cost_dashboard.js
+++ b/infra/fleet/cost_dashboard.js
@@ -295,8 +295,7 @@ function renderStepsAggregate(payload) {
   }, true);
 }
 
-// Windows and Linux are separate spot markets for the same instance
-// type, so a bar that merged them would show a rate neither leg paid.
+// Windows and Linux are separate spot markets for one instance type.
 function typeKey(leg) {
   return leg.product ? `${leg.type} · ${leg.product}` : leg.type;
 }

--- a/infra/fleet/cost_dashboard.js
+++ b/infra/fleet/cost_dashboard.js
@@ -295,11 +295,17 @@ function renderStepsAggregate(payload) {
   }, true);
 }
 
+// Windows and Linux are separate spot markets for the same instance
+// type, so a bar that merged them would show a rate neither leg paid.
+function typeKey(leg) {
+  return leg.product ? `${leg.type} · ${leg.product}` : leg.type;
+}
+
 function renderType(payload) {
   const legs = payload.legs.filter(leg => leg.type);
-  const types = [...new Set(legs.map(leg => leg.type))].sort();
+  const types = [...new Set(legs.map(typeKey))].sort();
   const aggregates = types.map(type => {
-    const matching = legs.filter(leg => leg.type === type);
+    const matching = legs.filter(leg => typeKey(leg) === type);
     const complete = matching.every(
       leg => leg.cost != null && leg.billed_hours != null
     );
@@ -323,7 +329,7 @@ function renderType(payload) {
     color: PALETTE[index % PALETTE.length],
     emphasis: {focus: 'series'},
     data: types.map(type => {
-      if (leg.type !== type) {
+      if (typeKey(leg) !== type) {
         return null;
       }
       return leg.billed_hours == null ? null : leg.billed_hours * 60;
@@ -353,7 +359,7 @@ function renderType(payload) {
         );
         const lines = [];
         legs.forEach((leg, index) => {
-          if (leg.type !== type) {
+          if (typeKey(leg) !== type) {
             return;
           }
           const value = leg.billed_hours == null

--- a/infra/fleet/cost_dashboard.py
+++ b/infra/fleet/cost_dashboard.py
@@ -10,9 +10,11 @@ Serves an interactive page backed by a local JSON API:
 
 Per-run data is free to fetch (GitHub API + ec2:DescribeSpotPriceHistory
 + cloudtrail:LookupEvents carry no charge). Only the account panels touch
-Cost Explorer, billed at $0.01 per GetCostAndUsage request. Hourly usage
-and run qualification are retained in separate transactional SQLite
-stores. The workflow list is refreshed at most once per minute, and
+Cost Explorer, billed at $0.01 per GetCostAndUsage request. Hourly usage,
+run qualification, and settled run detail are retained in separate
+transactional SQLite stores that outlive the process, so a run whose
+telemetry can no longer change is redrawn without a single GitHub or AWS
+request. The workflow list is refreshed at most once per minute, and
 completed qualification decisions are reused until they age out.
 Hourly usage is retained with per-hour confirmation.
 Non-zero gross service cost confirms an hour immediately; zero or missing
@@ -28,6 +30,12 @@ unknown throughout the API and UI rather than being coerced to zero. A
 leg whose runner died mid-step never gets an archived job log; it prices
 from its CloudTrail launch record instead, and reports its queue wait as
 unknown.
+
+Every leg is read in the region its own instance ran in, so runs that
+predate a fleet region move still price and time correctly. Spot price
+depends on the operating system as well as the instance type, so each
+leg carries the spot product it was priced under and the per-type view
+separates Windows from Linux.
 
 Run:  python infra/fleet/cost_dashboard.py   (opens http://localhost:8787)
 Needs: gh authenticated to the repo, the cubie-fleet AWS profile.
@@ -55,11 +63,18 @@ REPO = "cubiepy/cubie"
 WORKFLOW = "ci_cuda_tests.yml"
 PROFILE = "cubie-fleet"
 REGION = "us-east-2"
+# Regions the fleet has previously run in. A run older than a region
+# move still has to price and time from wherever its instances actually
+# ran, and a leg with no job log carries no AZ to derive that from, so
+# its CloudTrail history is looked for in each of these in turn.
+HISTORICAL_REGIONS = ("ap-southeast-2",)
+SEARCH_REGIONS = (REGION, *HISTORICAL_REGIONS)
 EC2_COMPUTE = "Amazon Elastic Compute Cloud - Compute"
 HERE = Path(__file__).resolve().parent
 CACHE_DIR = HERE / ".dashboard-cache"
 USAGE_DB = CACHE_DIR / "usage.sqlite3"
 RUN_DB = CACHE_DIR / "runs.sqlite3"
+DETAIL_DB = CACHE_DIR / "details.sqlite3"
 RUN_LOOKBACK = timedelta(days=7)
 RUN_LIST_TTL = timedelta(seconds=60)
 RUN_SCAN_LEASE = timedelta(minutes=10)
@@ -77,6 +92,9 @@ MAX_HOURLY_RANGE_DAYS = 366
 USAGE_SCHEMA_VERSION = 3
 USAGE_QUERY_VERSION = "ce-usage-v1"
 RUN_CACHE_SCHEMA_VERSION = 1
+# The detail cache stores assembled API payloads, so this covers the
+# payload shape as well as the tables holding it.
+DETAIL_CACHE_SCHEMA_VERSION = 1
 API_TOKEN = secrets.token_urlsafe(32)
 TOKEN_HEADER = "X-Cubie-Dashboard-Token"
 
@@ -85,7 +103,6 @@ TOKEN_HEADER = "X-Cubie-Dashboard-Token"
 # carry. Force UTF-8 for every subprocess.
 _ENV = {**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"}
 
-_RUN_CACHE = {}
 _CE_LOCK = threading.Lock()
 
 
@@ -155,9 +172,9 @@ def _step_name(name):
     return name.strip()
 
 
-# ------------------------------------------------------------------ github
-class RunStore:
-    """Transactional cache for the qualified seven-day run snapshot."""
+# ------------------------------------------------------------------ stores
+class SQLiteStore:
+    """Base for the dashboard's transactional local SQLite caches."""
 
     def __init__(self, path):
         self.path = Path(path)
@@ -170,6 +187,8 @@ class RunStore:
         try:
             connection.execute("PRAGMA journal_mode = WAL")
         except sqlite3.OperationalError as exc:
+            # WAL persists once a peer initializer enables it. Continue
+            # to the busy-timeout-protected transaction during that race.
             if "locked" not in str(exc).lower():
                 connection.close()
                 raise
@@ -183,6 +202,24 @@ class RunStore:
                 yield connection
         finally:
             connection.close()
+
+    def _initialize(self):
+        raise NotImplementedError
+
+    @staticmethod
+    def _set_metadata(connection, key, value):
+        connection.execute(
+            """
+            INSERT INTO metadata(key, value) VALUES (?, ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """,
+            (key, value),
+        )
+
+
+# ------------------------------------------------------------------ github
+class RunStore(SQLiteStore):
+    """Transactional cache for the qualified seven-day run snapshot."""
 
     def _initialize(self):
         with self._connection() as connection:
@@ -226,16 +263,6 @@ class RunStore:
             connection.execute(
                 f"PRAGMA user_version = {RUN_CACHE_SCHEMA_VERSION}"
             )
-
-    @staticmethod
-    def _set_metadata(connection, key, value):
-        connection.execute(
-            """
-            INSERT INTO metadata(key, value) VALUES (?, ?)
-            ON CONFLICT(key) DO UPDATE SET value = excluded.value
-            """,
-            (key, value),
-        )
 
     def acquire_scan_lease(self, now):
         """Acquire the persisted list-refresh lease and attempt slot."""
@@ -771,14 +798,205 @@ def parse_log(text):
     return info
 
 
+# -------------------------------------------------------- durable detail
+class DetailStore(SQLiteStore):
+    """Durable cache for settled run detail and immutable AWS reads.
+
+    A run whose GPU legs have all finished and whose telemetry can no
+    longer change is stored whole, so reopening it costs no GitHub or
+    AWS request in this process or any later one. Underneath that, the
+    two per-leg AWS reads are cached in their own right, which is what
+    makes a run that is still settling cheap to reload: the spot price
+    at a past instant and a terminated instance's launch/termination
+    record are both final once observed.
+
+    Only known answers are stored. A price or history AWS declined to
+    serve, or has not recorded yet, is retried on the next request
+    rather than remembered as unknown. Every table here is derived
+    data, so a schema or payload-shape change discards the file instead
+    of migrating it.
+
+    Nothing is evicted by age. A run's rows outlive its seven-day slot
+    in the dropdown, and eventually outlive CloudTrail's own 90-day
+    history, at a few tens of kilobytes per run; that longevity is the
+    point of the store, and the row is simply unreachable until the
+    qualified window admits the run again.
+    """
+
+    def _initialize(self):
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            schema_version = connection.execute(
+                "PRAGMA user_version"
+            ).fetchone()[0]
+            if schema_version != DETAIL_CACHE_SCHEMA_VERSION:
+                for table in ("run_details", "instances", "spot_prices"):
+                    connection.execute(f"DROP TABLE IF EXISTS {table}")
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS run_details (
+                    run_id INTEGER PRIMARY KEY CHECK (run_id > 0),
+                    payload TEXT NOT NULL,
+                    stored_at TEXT NOT NULL
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS instances (
+                    instance_id TEXT PRIMARY KEY,
+                    region TEXT NOT NULL,
+                    launch TEXT,
+                    termination TEXT NOT NULL,
+                    stored_at TEXT NOT NULL
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS spot_prices (
+                    instance_type TEXT NOT NULL,
+                    az TEXT NOT NULL,
+                    product TEXT NOT NULL,
+                    at TEXT NOT NULL,
+                    price REAL NOT NULL,
+                    stored_at TEXT NOT NULL,
+                    PRIMARY KEY (instance_type, az, product, at)
+                )
+                """
+            )
+            connection.execute(
+                f"PRAGMA user_version = {DETAIL_CACHE_SCHEMA_VERSION}"
+            )
+
+    def run_detail(self, run_id):
+        """Return a stored settled run payload, or None."""
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT payload FROM run_details WHERE run_id = ?",
+                (int(run_id),),
+            ).fetchone()
+        return json.loads(row[0]) if row else None
+
+    def store_run_detail(self, run_id, payload):
+        with self._connection() as connection:
+            connection.execute(
+                """
+                INSERT INTO run_details(run_id, payload, stored_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(run_id) DO UPDATE SET
+                    payload = excluded.payload,
+                    stored_at = excluded.stored_at
+                """,
+                (
+                    int(run_id),
+                    json.dumps(payload),
+                    now_utc().isoformat(),
+                ),
+            )
+
+    def instance_history(self, instance_id):
+        """Return a stored (launch, termination) pair, or None."""
+        with self._connection() as connection:
+            row = connection.execute(
+                """
+                SELECT launch, termination FROM instances
+                WHERE instance_id = ?
+                """,
+                (instance_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        launch = json.loads(row[0]) if row[0] else None
+        if launch is not None and launch.get("launched_at"):
+            launch["launched_at"] = ts(launch["launched_at"])
+        return launch, ts(row[1])
+
+    def store_instance_history(self, instance_id, region, launch, term):
+        stored = dict(launch) if launch else None
+        if stored and stored.get("launched_at"):
+            stored["launched_at"] = stored["launched_at"].isoformat()
+        with self._connection() as connection:
+            connection.execute(
+                """
+                INSERT INTO instances(
+                    instance_id, region, launch, termination, stored_at
+                ) VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(instance_id) DO UPDATE SET
+                    region = excluded.region,
+                    launch = excluded.launch,
+                    termination = excluded.termination,
+                    stored_at = excluded.stored_at
+                """,
+                (
+                    instance_id,
+                    region,
+                    json.dumps(stored) if stored else None,
+                    term.isoformat(),
+                    now_utc().isoformat(),
+                ),
+            )
+
+    def spot_price(self, instance_type, az, product, at):
+        """Return a stored achieved spot price, or None."""
+        with self._connection() as connection:
+            row = connection.execute(
+                """
+                SELECT price FROM spot_prices
+                WHERE instance_type = ? AND az = ? AND product = ?
+                  AND at = ?
+                """,
+                (instance_type, az, product, at),
+            ).fetchone()
+        return row[0] if row else None
+
+    def store_spot_price(self, instance_type, az, product, at, price):
+        with self._connection() as connection:
+            connection.execute(
+                """
+                INSERT INTO spot_prices(
+                    instance_type, az, product, at, price, stored_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(instance_type, az, product, at) DO UPDATE SET
+                    price = excluded.price,
+                    stored_at = excluded.stored_at
+                """,
+                (
+                    instance_type,
+                    az,
+                    product,
+                    at,
+                    float(price),
+                    now_utc().isoformat(),
+                ),
+            )
+
+
 # --------------------------------------------------------------------- aws
 def az_region(az):
-    """Return the region an availability zone belongs to."""
-    return az.rstrip("abcdef") if az else REGION
+    """Return the region an availability zone belongs to, if known."""
+    return az.rstrip("abcdef") if az else None
 
 
-def spot_price(itype, az, at, platform):
-    prod = "Windows" if (platform or "").startswith("win") else "Linux/UNIX"
+def spot_product(platform):
+    """Return the spot product a leg's platform is billed under.
+
+    Windows and Linux carry separate spot markets for the same instance
+    type, so the product is part of a price, not a footnote to it. An
+    unknown platform is Linux: CloudTrail records `windows` explicitly
+    and omits the field otherwise.
+    """
+    return "Windows" if (platform or "").startswith("win") else "Linux/UNIX"
+
+
+def spot_price(itype, az, at, platform, details=None):
+    """Return the achieved spot price for one leg, or None."""
+    prod = spot_product(platform)
+    at_key = at.strftime("%Y-%m-%dT%H:%M:%SZ")
+    if details is not None:
+        cached = details.spot_price(itype, az, prod, at_key)
+        if cached is not None:
+            return cached
     ok, res = aws(
         "ec2",
         "describe-spot-price-history",
@@ -793,7 +1011,7 @@ def spot_price(itype, az, at, platform):
         "--start-time",
         (at - timedelta(hours=8)).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "--end-time",
-        at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        at_key,
     )
     if not ok or not res or not res.get("SpotPriceHistory"):
         return None
@@ -802,7 +1020,11 @@ def spot_price(itype, az, at, platform):
     for h in hist:
         if ts(h["Timestamp"]) <= at:
             price = float(h["SpotPrice"])
-    return price if price is not None else float(hist[-1]["SpotPrice"])
+    if price is None:
+        price = float(hist[-1]["SpotPrice"])
+    if details is not None:
+        details.store_spot_price(itype, az, prod, at_key, price)
+    return price
 
 
 def _launch_details(event, iid):
@@ -826,8 +1048,8 @@ def _launch_details(event, iid):
     return None
 
 
-def instance_history(iid, around, region):
-    """Return one instance's launch record and termination time."""
+def _region_events(iid, around, region):
+    """Return one region's CloudTrail events for an instance."""
     ok, res = aws(
         "cloudtrail",
         "lookup-events",
@@ -840,19 +1062,43 @@ def instance_history(iid, around, region):
         "--end-time",
         (around + timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%SZ"),
     )
-    if not ok:
-        return None, None
+    return res.get("Events", []) if ok else []
+
+
+def instance_history(iid, around, region=None, details=None):
+    """Return one instance's launch record and termination time.
+
+    CloudTrail is per-region, and an instance id is only meaningful in
+    the region that issued it. With the region unknown -- a leg whose
+    log never arrived carries no AZ to derive it from -- every region
+    the fleet has run in is tried, so runs from before a region move
+    still resolve.
+    """
+    if details is not None:
+        cached = details.instance_history(iid)
+        if cached is not None:
+            return cached
+    regions = [region] if region else list(SEARCH_REGIONS)
     launch = None
     termination = None
-    for ev in res.get("Events", []):
-        name = ev["EventName"]
-        if termination is None and name in (
-            "TerminateInstances",
-            "BidEvictedEvent",
-        ):
-            termination = ts(ev["EventTime"])
-        elif launch is None and name == "RunInstances":
-            launch = _launch_details(ev, iid)
+    found_region = None
+    for candidate in regions:
+        events = _region_events(iid, around, candidate)
+        if not events:
+            continue
+        found_region = candidate
+        for ev in events:
+            name = ev["EventName"]
+            if termination is None and name in (
+                "TerminateInstances",
+                "BidEvictedEvent",
+            ):
+                termination = ts(ev["EventTime"])
+            elif launch is None and name == "RunInstances":
+                launch = _launch_details(ev, iid)
+        break
+    if details is not None and termination is not None:
+        details.store_instance_history(iid, found_region, launch, termination)
     return launch, termination
 
 
@@ -866,12 +1112,12 @@ def _billing_values(run_start, termination, price):
     return billed_hours, cost
 
 
-def _enrich_leg(leg):
+def _enrich_leg(leg, details=None):
     log = parse_log(fetch_log(leg["job_id"]))
     leg.update(log)
     anchor = log["running_start"] or leg["job_start"]
     launch, term = instance_history(
-        leg["instance_id"], anchor, az_region(log["az"])
+        leg["instance_id"], anchor, az_region(log["az"]), details
     )
     launch = launch or {}
     # The log is authoritative where it exists; the launch record only
@@ -887,7 +1133,11 @@ def _enrich_leg(leg):
         run_start = launch.get("launched_at") or leg["job_start"]
     price = (
         spot_price(
-            leg["instance_type"], leg["az"], run_start, leg["platform"]
+            leg["instance_type"],
+            leg["az"],
+            run_start,
+            leg["platform"],
+            details,
         )
         if leg["instance_type"] and leg["az"]
         else None
@@ -931,21 +1181,23 @@ def _enrich_leg(leg):
     return leg
 
 
-def run_payload(run_id, store=None, now=None):
+def run_payload(run_id, store=None, details=None, now=None):
     """Build detail only for a cached qualified seven-day run."""
     run_id = int(run_id)
     store = store or RunStore(RUN_DB)
+    details = details or DetailStore(DETAIL_DB)
     current = now or now_utc()
     run = store.qualified_run(run_id, current - RUN_LOOKBACK, current)
     if run is None:
         raise PermissionError(
             "run is not in the cached qualified seven-day set"
         )
-    if run_id in _RUN_CACHE:
-        return _RUN_CACHE[run_id]
+    stored = details.run_detail(run_id)
+    if stored is not None:
+        return stored
     legs, settled = fetch_legs(run_id)
     with ThreadPoolExecutor(max_workers=8) as ex:
-        list(ex.map(_enrich_leg, legs))
+        list(ex.map(lambda leg: _enrich_leg(leg, details), legs))
     # A log absent within moments of the job finishing is still being
     # archived; only an older absence is the permanent one a dead runner
     # leaves behind, and only that is safe to memoize.
@@ -975,6 +1227,8 @@ def run_payload(run_id, store=None, now=None):
                 "instance_id": leg["instance_id"],
                 "type": leg["instance_type"],
                 "az": leg["az"],
+                "platform": leg["platform"],
+                "product": spot_product(leg["platform"]),
                 "price": d["price"],
                 "cost": d["cost"],
                 "billed_hours": d["billed_hours"],
@@ -993,8 +1247,17 @@ def run_payload(run_id, store=None, now=None):
                 ],
             }
         )
-    if settled and out["legs"]:
-        _RUN_CACHE[run_id] = out
+    # Missing price or termination telemetry is almost always a gap
+    # that closes later -- a CloudTrail event still landing, or a
+    # region the credentials cannot read yet. Serving it is right;
+    # persisting it would freeze the gap into every future view, so a
+    # payload is only stored once every leg is fully accounted for.
+    complete = all(
+        leg["_derived"]["termination_known"] and leg["_derived"]["price_known"]
+        for leg in legs
+    )
+    if settled and complete and out["legs"]:
+        details.store_run_detail(run_id, out)
     return out
 
 
@@ -1132,35 +1395,8 @@ def _rollup(hours, day):
     return {"usage": u, "cost": c}
 
 
-class UsageStore:
+class UsageStore(SQLiteStore):
     """Transactional local store for retained Cost Explorer usage."""
-
-    def __init__(self, path):
-        self.path = Path(path)
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self._initialize()
-
-    def _connect(self):
-        connection = sqlite3.connect(self.path, timeout=30)
-        connection.execute("PRAGMA busy_timeout = 30000")
-        try:
-            connection.execute("PRAGMA journal_mode = WAL")
-        except sqlite3.OperationalError as exc:
-            # WAL persists once a peer initializer enables it. Continue
-            # to the busy-timeout-protected transaction during that race.
-            if "locked" not in str(exc).lower():
-                connection.close()
-                raise
-        return connection
-
-    @contextmanager
-    def _connection(self):
-        connection = self._connect()
-        try:
-            with connection:
-                yield connection
-        finally:
-            connection.close()
 
     def _initialize(self):
         with self._connection() as connection:
@@ -1286,16 +1522,6 @@ class UsageStore:
             self._upsert_daily(connection, day, payload)
         for key, value in legacy["meta.json"].items():
             self._set_metadata(connection, key, str(value))
-
-    @staticmethod
-    def _set_metadata(connection, key, value):
-        connection.execute(
-            """
-            INSERT INTO metadata(key, value) VALUES (?, ?)
-            ON CONFLICT(key) DO UPDATE SET value = excluded.value
-            """,
-            (key, value),
-        )
 
     @staticmethod
     def _upsert_hourly(connection, period_start, payload, confirmed):
@@ -2023,6 +2249,7 @@ def main():
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     RunStore(RUN_DB)
     UsageStore(USAGE_DB)
+    DetailStore(DETAIL_DB)
     url = f"http://localhost:{args.port}"
     srv = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
     print(f"fleet cost dashboard on {url}  (Ctrl-C to stop)")

--- a/infra/fleet/cost_dashboard.py
+++ b/infra/fleet/cost_dashboard.py
@@ -12,9 +12,9 @@ Per-run data is free to fetch (GitHub API + ec2:DescribeSpotPriceHistory
 + cloudtrail:LookupEvents carry no charge). Only the account panels touch
 Cost Explorer, billed at $0.01 per GetCostAndUsage request. Hourly usage,
 run qualification, and settled run detail are retained in separate
-transactional SQLite stores that outlive the process, so a run whose
-telemetry can no longer change is redrawn without a single GitHub or AWS
-request. The workflow list is refreshed at most once per minute, and
+transactional SQLite stores that outlive the process; a fully priced and
+terminated run is served from that store with no GitHub or AWS request.
+The workflow list is refreshed at most once per minute, and
 completed qualification decisions are reused until they age out.
 Hourly usage is retained with per-hour confirmation.
 Non-zero gross service cost confirms an hour immediately; zero or missing
@@ -31,11 +31,9 @@ leg whose runner died mid-step never gets an archived job log; it prices
 from its CloudTrail launch record instead, and reports its queue wait as
 unknown.
 
-Every leg is read in the region its own instance ran in, so runs that
-predate a fleet region move still price and time correctly. Spot price
-depends on the operating system as well as the instance type, so each
-leg carries the spot product it was priced under and the per-type view
-separates Windows from Linux.
+Each leg is read in the region its own instance ran in. Each leg also
+carries the spot market it was priced in, Windows and Linux being
+separate markets for one instance type.
 
 Run:  python infra/fleet/cost_dashboard.py   (opens http://localhost:8787)
 Needs: gh authenticated to the repo, the cubie-fleet AWS profile.
@@ -63,10 +61,7 @@ REPO = "cubiepy/cubie"
 WORKFLOW = "ci_cuda_tests.yml"
 PROFILE = "cubie-fleet"
 REGION = "us-east-2"
-# Regions the fleet has previously run in. A run older than a region
-# move still has to price and time from wherever its instances actually
-# ran, and a leg with no job log carries no AZ to derive that from, so
-# its CloudTrail history is looked for in each of these in turn.
+# Regions the fleet has run in; searched when a leg's own is unknown.
 HISTORICAL_REGIONS = ("ap-southeast-2",)
 SEARCH_REGIONS = (REGION, *HISTORICAL_REGIONS)
 EC2_COMPUTE = "Amazon Elastic Compute Cloud - Compute"
@@ -92,8 +87,7 @@ MAX_HOURLY_RANGE_DAYS = 366
 USAGE_SCHEMA_VERSION = 3
 USAGE_QUERY_VERSION = "ce-usage-v1"
 RUN_CACHE_SCHEMA_VERSION = 1
-# The detail cache stores assembled API payloads, so this covers the
-# payload shape as well as the tables holding it.
+# Covers the stored payload shape as well as the tables.
 DETAIL_CACHE_SCHEMA_VERSION = 1
 API_TOKEN = secrets.token_urlsafe(32)
 TOKEN_HEADER = "X-Cubie-Dashboard-Token"
@@ -802,25 +796,11 @@ def parse_log(text):
 class DetailStore(SQLiteStore):
     """Durable cache for settled run detail and immutable AWS reads.
 
-    A run whose GPU legs have all finished and whose telemetry can no
-    longer change is stored whole, so reopening it costs no GitHub or
-    AWS request in this process or any later one. Underneath that, the
-    two per-leg AWS reads are cached in their own right, which is what
-    makes a run that is still settling cheap to reload: the spot price
-    at a past instant and a terminated instance's launch/termination
-    record are both final once observed.
-
-    Only known answers are stored. A price or history AWS declined to
-    serve, or has not recorded yet, is retried on the next request
-    rather than remembered as unknown. Every table here is derived
-    data, so a schema or payload-shape change discards the file instead
-    of migrating it.
-
-    Nothing is evicted by age. A run's rows outlive its seven-day slot
-    in the dropdown, and eventually outlive CloudTrail's own 90-day
-    history, at a few tens of kilobytes per run; that longevity is the
-    point of the store, and the row is simply unreachable until the
-    qualified window admits the run again.
+    Holds whole run payloads, achieved spot prices, and terminated
+    instances' launch/termination records: all final once observed. An
+    unknown answer is never stored, so it is retried on the next
+    request. Nothing is evicted by age. A schema or payload-shape
+    change discards the file rather than migrating it.
     """
 
     def _initialize(self):
@@ -979,10 +959,9 @@ def az_region(az):
 
 
 def spot_product(platform):
-    """Return the spot product a leg's platform is billed under.
+    """Return the spot market a leg's platform is priced in.
 
-    Windows and Linux carry separate spot markets for the same instance
-    type, so the product is part of a price, not a footnote to it. An
+    Windows and Linux are separate markets for one instance type. An
     unknown platform is Linux: CloudTrail records `windows` explicitly
     and omits the field otherwise.
     """
@@ -1068,11 +1047,8 @@ def _region_events(iid, around, region):
 def instance_history(iid, around, region=None, details=None):
     """Return one instance's launch record and termination time.
 
-    CloudTrail is per-region, and an instance id is only meaningful in
-    the region that issued it. With the region unknown -- a leg whose
-    log never arrived carries no AZ to derive it from -- every region
-    the fleet has run in is tried, so runs from before a region move
-    still resolve.
+    CloudTrail answers only in the instance's own region. With no
+    region given, each of SEARCH_REGIONS is tried until one has events.
     """
     if details is not None:
         cached = details.instance_history(iid)
@@ -1247,11 +1223,8 @@ def run_payload(run_id, store=None, details=None, now=None):
                 ],
             }
         )
-    # Missing price or termination telemetry is almost always a gap
-    # that closes later -- a CloudTrail event still landing, or a
-    # region the credentials cannot read yet. Serving it is right;
-    # persisting it would freeze the gap into every future view, so a
-    # payload is only stored once every leg is fully accounted for.
+    # Only a fully priced and terminated run is safe to store; missing
+    # telemetry can still arrive.
     complete = all(
         leg["_derived"]["termination_known"] and leg["_derived"]["price_known"]
         for leg in legs


### PR DESCRIPTION
Settled run detail, achieved spot prices, and instance launch/termination
records are retained in a third transactional SQLite store,
`.dashboard-cache/details.sqlite3` (already gitignored), so a run already
viewed redraws with no GitHub or AWS request at all, across process
restarts: 12.1 s cold, 0.029 s warm for a 16-leg run, measured on run
31031364379. A run payload is stored only once every GPU leg has
completed, its log has arrived or is permanently absent, and every leg
carries both a spot price and a termination time — an incomplete view is
served but never persisted, so a gap that closes later is not frozen into
every future view. Beneath it, the two per-leg AWS reads are cached in
their own right (a past instant's spot price and a terminated instance's
CloudTrail record are final once observed), which is what makes a run
that is still settling cheap to reload. Only known answers are stored;
denied or not-yet-recorded reads retry. A schema or payload-shape change
discards the file rather than migrating it.

CloudTrail is per-region and an instance id only means anything in the
region that issued it. Each leg's history is now looked up in its own
region, derived from its AZ, and a leg with no log — and therefore no AZ
— is searched across every region in `SEARCH_REGIONS`, current region
first. The deployer policy gains a `HistoryReadOnly` statement allowing
`ec2:DescribeSpotPriceHistory` and `cloudtrail:LookupEvents` across
`HISTORY_REGIONS` (us-east-2, ap-southeast-2); every other deployer
permission stays locked to the active region. Without that grant,
pre-move runs render with unknown price and cost rather than failing.

Windows and Linux are separate spot markets for the same instance type —
g5.xlarge in us-east-2c on 2026-08-05 was $0.2846/h Windows against
$0.3862/h Linux — so each leg reports the spot product it was priced
under and the per-type chart keeps the two in separate bars with separate
rate annotations. Pricing already used the right product per leg; the
chart was merging them into one blended rate.

The three SQLite stores now share a common base class holding the
connection, transaction, and metadata helpers.

## Verification

- `flake8` and `ruff check` clean on `cost_dashboard.py`; `node --check`
  clean on `cost_dashboard.js`.
- End-to-end against the live repo and the `cubie-fleet` profile:
  `/api/runs` (14 runs), `/api/run` (16 legs, both products present),
  `/api/account` all served through the real handler with token auth.
- Cold/warm/cross-process: 12.7 s, 0.029 s, and 0.028 s in a fresh
  interpreter.
- Completeness gate: an ap-southeast-2 run (30838868303) serves its 16
  legs with unknown price and cost and is **not** written to
  `run_details`; the fully-priced us-east-2 run is.
- Region probe with the region unknown finds a us-east-2 instance in
  1.6 s and returns unknowns for a nonexistent id after trying both
  regions.
- Schema-version mismatch drops and recreates the tables.
- Rendered IAM policy is valid JSON at 3,589 compact characters, under
  the 6,144 limit, with the two-region condition as intended.

Requires rerunning `infra/fleet/bootstrap/cloudshell-iam.sh` in
CloudShell for the ap-southeast-2 reads to be permitted.
