### PR TITLE
docs: performance gate applies to PRs that touch src/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,8 @@ updating a PR; targeted subsets miss cross-cutting tests.
 - **Agents:** every fix or feature is developed on its own branch off `main`. When the work is
   done and verified, commit, push the branch, and open a PR.
 - Capture `ab_gate.py` stdout untruncated.
-- **Performance gate (every PR):** run `python benchmarks/ab_gate.py` and paste its table into
-  the PR message. One command compares A (`origin/main`, an ephemeral `git worktree`) against B
+- **Performance gate (every PR that touches `src/`):** run `python benchmarks/ab_gate.py` and
+  paste its table into the PR message. One command compares A (`origin/main`, an ephemeral `git worktree`) against B
   (the working tree) on every installed CUDA backend — both `numba-cuda` and `numba-cuda-mlir`
   should be in the venv. Per backend it starts one persistent worker per side (each compiles and
   builds its grid once) and ping-pongs short solve blocks between them in ABBA order with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,9 @@ updating a PR; targeted subsets miss cross-cutting tests.
 - **Performance gate (every PR that touches `src/`):** run `python benchmarks/ab_gate.py` and
   paste its table into the PR message. One command compares A (`origin/main`, an ephemeral
   `git worktree`) against B (the working tree) on every installed CUDA backend — both
-  `numba-cuda` and `numba-cuda-mlir` should be in the venv. Per backend it starts one persistent worker per side (each compiles and
-  builds its grid once) and ping-pongs short solve blocks between them in ABBA order with
+  `numba-cuda` and `numba-cuda-mlir` should be in the venv. Per backend it starts one persistent
+  worker per side (each compiles and builds its grid once) and ping-pongs short solve blocks
+  between them in ABBA order with
   randomised idle gaps — continuous load pins the GPU at its power limit and the kernel-time
   floor dithers, so the rest between blocks keeps it in a repeatable boost state, and the
   per-block jitter stops a concurrent periodic GPU load phase-locking with the rhythm and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,9 @@ updating a PR; targeted subsets miss cross-cutting tests.
   done and verified, commit, push the branch, and open a PR.
 - Capture `ab_gate.py` stdout untruncated.
 - **Performance gate (every PR that touches `src/`):** run `python benchmarks/ab_gate.py` and
-  paste its table into the PR message. One command compares A (`origin/main`, an ephemeral `git worktree`) against B
-  (the working tree) on every installed CUDA backend — both `numba-cuda` and `numba-cuda-mlir`
-  should be in the venv. Per backend it starts one persistent worker per side (each compiles and
+  paste its table into the PR message. One command compares A (`origin/main`, an ephemeral
+  `git worktree`) against B (the working tree) on every installed CUDA backend — both
+  `numba-cuda` and `numba-cuda-mlir` should be in the venv. Per backend it starts one persistent worker per side (each compiles and
   builds its grid once) and ping-pongs short solve blocks between them in ABBA order with
   randomised idle gaps — continuous load pins the GPU at its power limit and the kernel-time
   floor dithers, so the rest between blocks keeps it in a repeatable boost state, and the


### PR DESCRIPTION
The A/B performance gate compares solver kernel and wall times between `origin/main` and the working tree, so it only has a subject on changes to `src/`. Infrastructure-, CI-, and docs-only PRs now say so explicitly.