### PR TITLE
chore(fleet): bootstrap script publishes IAM only, with no credential minting

### DIFF
--- a/infra/fleet/README.md
+++ b/infra/fleet/README.md
@@ -45,22 +45,23 @@ instances. All capacity is cold spot launches.
 3. **AWS deployer credentials.** Paste
    [`bootstrap/cloudshell-iam.sh`](bootstrap/cloudshell-iam.sh) into an
    AWS CloudShell session. It creates a name-scoped, region-locked
-   deployer role and prints 1-hour temporary credentials. Put them in
-   `~/.aws/credentials`:
+   deployer role, `cubie-fleet-deployer`. Point a profile at it, with
+   `source_profile` naming an IAM user that is allowed to assume that
+   role and whose access key is in `~/.aws/credentials`:
 
    ```ini
-   [cubie-fleet]
-   aws_access_key_id     = ...
-   aws_secret_access_key = ...
-   aws_session_token     = ...
+   # ~/.aws/config
+   [profile cubie-fleet]
+   role_arn       = arn:aws:iam::<account-id>:role/cubie-fleet-deployer
+   source_profile = cubie-fleet-bootstrap
+   region         = us-east-2
    ```
 
-   When they expire, rerun the script's final `aws sts assume-role`
-   command in CloudShell and paste the fresh block — nothing else
-   changes. When the *policy documents* in the script change, paste
-   the whole script again: it is idempotent and republishes the two
-   deployer policies (`cubie-fleet-deployer`,
-   `cubie-fleet-deployer-scoped`) as new default versions.
+   The CLI assumes the role per call and refreshes the 1-hour session
+   itself. When the *policy documents* in the script change, paste the
+   whole script again: it is idempotent, republishes the two deployer
+   policies (`cubie-fleet-deployer`, `cubie-fleet-deployer-scoped`) as
+   new default versions, and a live session picks them up at once.
 4. **Variables.** Copy `terraform.tfvars.example` to
    `terraform.tfvars` (gitignored) and fill in the App ID, key path,
    RunsOn license key (one license covers Flex and Fleet), and alert

--- a/infra/fleet/README.md
+++ b/infra/fleet/README.md
@@ -57,11 +57,11 @@ instances. All capacity is cold spot launches.
    region         = us-east-2
    ```
 
-   The CLI assumes the role per call and refreshes the 1-hour session
-   itself. When the *policy documents* in the script change, paste the
-   whole script again: it is idempotent, republishes the two deployer
-   policies (`cubie-fleet-deployer`, `cubie-fleet-deployer-scoped`) as
-   new default versions, and a live session picks them up at once.
+   The CLI assumes the role per call and refreshes the 1-hour session.
+   To change permissions, edit the script and paste it again: it
+   republishes both deployer policies (`cubie-fleet-deployer`,
+   `cubie-fleet-deployer-scoped`) as new default versions, and live
+   sessions pick them up.
 4. **Variables.** Copy `terraform.tfvars.example` to
    `terraform.tfvars` (gitignored) and fill in the App ID, key path,
    RunsOn license key (one license covers Flex and Fleet), and alert

--- a/infra/fleet/bootstrap/cloudshell-iam.sh
+++ b/infra/fleet/bootstrap/cloudshell-iam.sh
@@ -12,10 +12,9 @@
 #      this account only, with both policies attached.
 #
 # Local access is the `cubie-fleet` profile in ~/.aws/config: `role_arn`
-# for this role plus `source_profile` naming an IAM user's key, so the
-# CLI assumes the role per call and refreshes the 1-hour session itself.
-# Rerun this file to change permissions; a live session picks them up at
-# once. It is idempotent, and mints no credentials.
+# for this role, `source_profile` naming an IAM user's key. The CLI
+# assumes the role per call and refreshes the 1-hour session.
+# Rerun this file to republish permissions; live sessions pick them up.
 set -euo pipefail
 
 REGION="us-east-2"

--- a/infra/fleet/bootstrap/cloudshell-iam.sh
+++ b/infra/fleet/bootstrap/cloudshell-iam.sh
@@ -9,17 +9,13 @@
 #      policy documents below for the per-service rationale; the
 #      split exists only for IAM's 6144-character policy size limit);
 #   2. a role `cubie-fleet-deployer` assumable by IAM identities in
-#      this account only, with both policies attached;
-# and then mints 1-hour temporary credentials for that role.
+#      this account only, with both policies attached.
 #
-# The local AWS CLI only ever holds those 1-hour credentials, so a
-# leaked or mishandled key expires on its own and never carries more
-# than the scoped deployer permissions (see the IamScoped residual
-# risk note below for what "scoped" does and does not bound).
-#
-# REGENERATING CREDENTIALS: rerun just the final `aws sts assume-role`
-# command (or the whole script -- it is idempotent) and copy the fresh
-# Credentials block into ~/.aws/credentials under [cubie-fleet].
+# Local access is the `cubie-fleet` profile in ~/.aws/config: `role_arn`
+# for this role plus `source_profile` naming an IAM user's key, so the
+# CLI assumes the role per call and refreshes the 1-hour session itself.
+# Rerun this file to change permissions; a live session picks them up at
+# once. It is idempotent, and mints no credentials.
 set -euo pipefail
 
 REGION="us-east-2"
@@ -536,12 +532,4 @@ publish_policy cubie-fleet-deployer-scoped \
   /tmp/cubie-fleet-deployer-scoped-policy.json
 
 echo
-echo "=== Temporary credentials (valid 1 hour) ==="
-aws sts assume-role \
-  --role-arn "arn:aws:iam::${ACCOUNT_ID}:role/cubie-fleet-deployer" \
-  --role-session-name cubie-fleet-cli \
-  --duration-seconds 3600 \
-  --query Credentials
-echo
-echo "Copy the JSON above into the [cubie-fleet] profile locally."
-echo "To regenerate later, rerun just the 'aws sts assume-role' command."
+echo "cubie-fleet-deployer role and policies are up to date."


### PR DESCRIPTION
Local AWS access is the `cubie-fleet` profile in `~/.aws/config`: a `role_arn` for `cubie-fleet-deployer` with `source_profile` naming an IAM user's key, so the CLI assumes the role per call and refreshes the hour-long session itself. The script's trailing `aws sts assume-role` and its paste-into-`~/.aws/credentials` instructions describe a flow nobody uses, and they fail outright in a CloudShell session signed in as the account root. Both are gone; the script now publishes the role and the two policies and stops. The README documents the profile that is actually in use.

Verified: `bash -n` clean, and the rendered policy documents are still valid JSON (3,379 / 4,321 / 136 chars).