### PR TITLE
chore(diagnostics): neumann convergence findings report through the logger

### DIFF
--- a/docs/source/tutorials/stiff_systems.rst
+++ b/docs/source/tutorials/stiff_systems.rst
@@ -58,20 +58,6 @@ to meet:
 CuBIE derives the Jacobian your implicit solver needs symbolically
 from the equations, so there is nothing extra to supply.
 
-The default Neumann preconditioner has a step limit beyond which its
-series diverges.  CuBIE reports that limit on the ``cubie`` logger at
-debug level:
-
-.. code-block:: python
-
-   import logging
-
-   logging.basicConfig()
-   logging.getLogger("cubie").setLevel(logging.DEBUG)
-
-Passing ``preconditioner_type="jacobi"`` selects a preconditioner
-suited to systems like this one.
-
 Radau is the big gun of the family, and its robustness costs
 iterations.  For mildly stiff problems, cheaper options include the
 linearly implicit Rosenbrock-W methods (``method="rosenbrock"``,

--- a/docs/source/tutorials/stiff_systems.rst
+++ b/docs/source/tutorials/stiff_systems.rst
@@ -58,11 +58,19 @@ to meet:
 CuBIE derives the Jacobian your implicit solver needs symbolically
 from the equations, so there is nothing extra to supply.
 
-This solve succeeds, but it also prints a warning that the default
-Neumann preconditioner may diverge for this system.  The solve above
-finished cleanly regardless (the status check confirms it), and
-passing ``preconditioner_type="jacobi"`` selects a preconditioner
-suited to systems like this one and silences the warning.
+The default Neumann preconditioner has a step limit beyond which its
+series diverges.  CuBIE reports that limit on the ``cubie`` logger at
+debug level:
+
+.. code-block:: python
+
+   import logging
+
+   logging.basicConfig()
+   logging.getLogger("cubie").setLevel(logging.DEBUG)
+
+Passing ``preconditioner_type="jacobi"`` selects a preconditioner
+suited to systems like this one.
 
 Radau is the big gun of the family, and its robustness costs
 iterations.  For mildly stiff problems, cheaper options include the

--- a/docs/source/user_guide/troubleshooting.rst
+++ b/docs/source/user_guide/troubleshooting.rst
@@ -25,15 +25,7 @@ convergence:
    solver more room.
 2. **Increase the preconditioner order.** Higher Neumann-series orders
    improve Krylov convergence at some compute cost.
-3. **Switch preconditioner.** The default Neumann series has a step
-   limit; ``preconditioner_type="jacobi"`` has none. CuBIE logs the
-   limit at debug level::
-
-       import logging
-
-       logging.basicConfig()
-       logging.getLogger("cubie").setLevel(logging.DEBUG)
-
+3. **Neumann can diverge.** Try ``preconditioner_type="jacobi"``.
 4. **Reduce the initial step size.** A large first step can push the
    Newton iteration far from convergence.
 5. **Try a different algorithm.** Rosenbrock-W methods avoid Newton

--- a/docs/source/user_guide/troubleshooting.rst
+++ b/docs/source/user_guide/troubleshooting.rst
@@ -25,12 +25,21 @@ convergence:
    solver more room.
 2. **Increase the preconditioner order.** Higher Neumann-series orders
    improve Krylov convergence at some compute cost.
-3. **Reduce the initial step size.** A large first step can push the
+3. **Switch preconditioner.** The default Neumann series has a step
+   limit; ``preconditioner_type="jacobi"`` has none. CuBIE logs the
+   limit at debug level::
+
+       import logging
+
+       logging.basicConfig()
+       logging.getLogger("cubie").setLevel(logging.DEBUG)
+
+4. **Reduce the initial step size.** A large first step can push the
    Newton iteration far from convergence.
-4. **Try a different algorithm.** Rosenbrock-W methods avoid Newton
+5. **Try a different algorithm.** Rosenbrock-W methods avoid Newton
    iteration entirely; FIRK methods are more robust than DIRK for very
    stiff problems.
-5. **Check the equations.** Singular or near-singular Jacobians can
+6. **Check the equations.** Singular or near-singular Jacobians can
    prevent convergence.
 
 Out of VRAM

--- a/src/cubie/odesystems/symbolic/codegen/neumann_convergence.py
+++ b/src/cubie/odesystems/symbolic/codegen/neumann_convergence.py
@@ -34,7 +34,8 @@ Published Objects
     Evaluate convergence diagnostics for the Neumann preconditioner and
     log them when divergence is likely.
 
-Findings go to this module's logger at debug level. Enable them with
+Findings go to this module's logger at debug level. cubie installs no
+handler, so enable them with ``logging.basicConfig()`` followed by
 ``logging.getLogger("cubie").setLevel(logging.DEBUG)``.
 """
 

--- a/src/cubie/odesystems/symbolic/codegen/neumann_convergence.py
+++ b/src/cubie/odesystems/symbolic/codegen/neumann_convergence.py
@@ -32,11 +32,13 @@ Published Objects
     of the Jacobian and the ``beta``/``gamma``/tableau parameters.
 :func:`check_neumann_convergence`
     Evaluate convergence diagnostics for the Neumann preconditioner and
-    emit a warning when divergence is likely.
+    log them when divergence is likely.
+
+Findings go to this module's logger at debug level. Enable them with
+``logging.getLogger("cubie").setLevel(logging.DEBUG)``.
 """
 
 import logging
-import warnings
 from typing import Callable, Dict, Optional, Sequence, Union
 
 import numpy as np
@@ -409,6 +411,9 @@ def check_neumann_convergence(
     The tableau ``c`` nodes influence the Jacobian only through the
     ``O(h)`` per-stage time/state offset, which this h-independent
     diagnostic neglects.
+
+    A radius suggesting divergence logs at debug level; a Jacobian
+    that cannot be evaluated logs at warning level.
     """
     jacobian = evaluator.jacobian(index_map, t0=t0)
     if not np.isfinite(jacobian).all():
@@ -449,8 +454,7 @@ def check_neumann_convergence(
             "was unavailable to this static check, so this is not a "
             "divergence verdict."
         )
-        warnings.warn(message, stacklevel=3)
-        logger.warning(message)
+        logger.debug(message)
     elif result["series_converges"] is False:
         rho_series = result["rho_series"]
         critical_step = result["critical_step_factor"]
@@ -462,7 +466,6 @@ def check_neumann_convergence(
             f"{rho_series:.3g} >= 1. Convergence requires "
             f"abs({step_factor}) < {critical_step:.3g}."
         )
-        warnings.warn(message, stacklevel=3)
-        logger.warning(message)
+        logger.debug(message)
 
     return result

--- a/tests/odesystems/symbolic/test_neumann_convergence.py
+++ b/tests/odesystems/symbolic/test_neumann_convergence.py
@@ -6,10 +6,10 @@ Covers the pure-numeric :func:`neumann_spectral_radius`,
 policies selecting independent evaluators on a shared system.
 """
 
+import logging
 import os
 from pathlib import Path
 import shutil
-import warnings
 
 import numpy as np
 import pytest
@@ -39,6 +39,11 @@ _RESULT_KEYS = {
     "series_converges",
 }
 
+# Logger the diagnostic reports through, at debug level.
+_DIAGNOSTIC_LOGGER = (
+    "cubie.odesystems.symbolic.codegen.neumann_convergence"
+)
+
 
 @pytest.mark.parametrize(
     "solver_settings_override", [DIAGONALLY_DOMINANT], indirect=True
@@ -59,35 +64,42 @@ def test_small_step_converges_for_diagonally_dominant_system(system):
 @pytest.mark.parametrize(
     "solver_settings_override", [OFF_DIAGONAL_HEAVY], indirect=True
 )
-def test_large_step_diverges_for_off_diagonal_heavy_system(system):
-    """A supplied step beyond the critical magnitude warns."""
-    with pytest.warns(UserWarning):
-        result = check_neumann_convergence(
-            system.indices,
-            system._get_neumann_evaluator(CachePolicy()),
-            step_size=1.0,
-            stage_coefficients=1.0,
-        )
+def test_large_step_diverges_for_off_diagonal_heavy_system(
+    system, caplog, recwarn
+):
+    """A supplied step beyond the critical magnitude logs divergence."""
+    caplog.set_level(logging.DEBUG, logger=_DIAGNOSTIC_LOGGER)
+    result = check_neumann_convergence(
+        system.indices,
+        system._get_neumann_evaluator(CachePolicy()),
+        step_size=1.0,
+        stage_coefficients=1.0,
+    )
     assert result["series_converges"] is False
     assert result["rho_series"] >= 1.0
     assert result["critical_step_factor"] <= 1.0
+    assert "does not converge" in caplog.text
+    assert [record.levelno for record in caplog.records] == [logging.DEBUG]
+    assert len(recwarn) == 0
 
 
 @pytest.mark.parametrize(
     "solver_settings_override", [GATING_SINGULARITY], indirect=True
 )
-def test_gating_singularity_converges_without_false_divergence(system):
+def test_gating_singularity_converges_without_false_divergence(
+    system, caplog
+):
     """Guarded gating terms do not trigger a false divergence report."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("always")
-        result = check_neumann_convergence(
-            system.indices,
-            system._get_neumann_evaluator(CachePolicy()),
-            step_size=1e-4,
-            stage_coefficients=1.0,
-        )
+    caplog.set_level(logging.DEBUG, logger=_DIAGNOSTIC_LOGGER)
+    result = check_neumann_convergence(
+        system.indices,
+        system._get_neumann_evaluator(CachePolicy()),
+        step_size=1e-4,
+        stage_coefficients=1.0,
+    )
     assert result["series_converges"] is True
     assert result["rho_series"] < 1.0
+    assert caplog.records == []
 
 
 @pytest.mark.parametrize(
@@ -107,14 +119,18 @@ def test_non_finite_jacobian_reports_not_verified(system):
 @pytest.mark.parametrize(
     "solver_settings_override", [OFF_DIAGONAL_HEAVY], indirect=True
 )
-def test_get_solver_helper_runs_diagnostic_for_neumann_type(system):
+def test_get_solver_helper_runs_diagnostic_for_neumann_type(
+    system, caplog, recwarn
+):
     """Static helper check reports a step limit, not divergence."""
-    with pytest.warns(UserWarning, match="not a divergence verdict"):
-        system.get_solver_helper(
-            SolverHelperRequest(
-                kind="neumann_preconditioner", beta=1.0, gamma=1.0
-            )
+    caplog.set_level(logging.DEBUG, logger=_DIAGNOSTIC_LOGGER)
+    system.get_solver_helper(
+        SolverHelperRequest(
+            kind="neumann_preconditioner", beta=1.0, gamma=1.0
         )
+    )
+    assert "not a divergence verdict" in caplog.text
+    assert len(recwarn) == 0
 
 
 def _seed_kernel_cache(system_name, *target_dirs):
@@ -173,10 +189,8 @@ def test_kernel_cache_policies_stay_isolated(system, tmp_path):
         request = SolverHelperRequest(
             kind="neumann_preconditioner", beta=1.0, gamma=1.0
         )
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            kernel_a._solver_helper_fn(request)
-            kernel_b._solver_helper_fn(request)
+        kernel_a._solver_helper_fn(request)
+        kernel_b._solver_helper_fn(request)
 
         policy_a = kernel_a.cache_handler.policy
         policy_b = kernel_b.cache_handler.policy
@@ -194,9 +208,7 @@ def test_kernel_cache_policies_stay_isolated(system, tmp_path):
         kept_b = evaluator_b.get_cached_output("evaluation_kernel")
         assert kept_b is built_b
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            kernel_a._solver_helper_fn(request)
+        kernel_a._solver_helper_fn(request)
         moved = kernel_a.cache_handler.policy
         assert (
             system._neumann_diagnostics[moved].cache_policy.cache_dir


### PR DESCRIPTION
The Neumann spectral-radius diagnostic reports through
`cubie.odesystems.symbolic.codegen.neumann_convergence`'s logger at
debug level and raises no Python warning. Enable it with
`logging.getLogger("cubie").setLevel(logging.DEBUG)`.

The check runs from the helper-registry validation hook on every
`neumann_*` request, including cache hits, and without the runtime
step factor: `step_size` is never supplied, so `series_converges` is
always `None` and only the "depends on the runtime step factor" branch
can fire. That branch fires whenever rho((gamma/beta)(A (x) J)) >= 1 in
raw units, which holds for any system with a timescale faster than one
time unit. The finding is a step limit, not a divergence verdict, so it
belongs in a log rather than in the user's stderr on every solve.

The non-finite-Jacobian message stays at warning level: it means the
diagnostic reached no verdict at all.

Tests assert the log records through `caplog` and assert `recwarn` is
empty. The `catch_warnings` suppressions in the cache-policy isolation
test are gone with the warning they suppressed. The stiff-systems
tutorial and the Newton-convergence troubleshooting entry show how to
enable the log.

## Tests

Full suites against this tree, both green:

- real GPU (`-m "not specific_algos and not sim_only"`): 3139 passed in 121.18s
- CUDASIM (`-m "not nocudasim and not cupy and not specific_algos"`): 3089 passed in 25.64s
- `flake8 . --select=E9,F63,F7,F82` and `ruff check` on the changed files: clean

## Performance gate

First run flagged `mlir chunked kernel +0.84% REGRESSION` with three
DISTRUST rows. Retried once with `--pairs 8` per the documented
protocol; the retry's table follows as-is. Both REGRESSION rows in the
retry carry DISTRUST, and 8 of 18 rows are DISTRUST. Compile metrics
are identical A -> B on every config and both backends (registers,
spill bytes, shared/const, occupancy, chunk counts).

```
A = origin/main (415fa893)   B = chore/neumann-warning-to-log (working tree)   backends: numba-cuda, mlir   (8 block pairs x 15 solves/block/side)
numba-cuda fixed          kernel  A    63.314  B    63.249   +0.02%  ok  DISTRUST
numba-cuda fixed          wall    A    77.557  B    73.691   -4.86%  ok
numba-cuda adaptive       kernel  A    18.217  B    18.093   -0.50%  ok
numba-cuda adaptive       wall    A    23.126  B    21.525   -6.30%  ok
numba-cuda host_overhead  wall    A     1.287  B     0.761   -0.494ms  improvement
numba-cuda chunked        kernel  A    63.598  B    63.606   -0.05%  ok  DISTRUST
numba-cuda chunked        wall    A    79.759  B    79.165   -0.55%  ok
numba-cuda wave           kernel  A    25.923  B    26.131   +0.09%  ok  DISTRUST
numba-cuda wave           wall    A    28.142  B    28.301   -0.02%  ok
mlir       fixed          kernel  A    63.547  B    63.493   -0.50%  ok  DISTRUST
mlir       fixed          wall    A    79.826  B    79.430   -0.61%  ok
mlir       adaptive       kernel  A    17.552  B    17.604   +0.17%  ok  DISTRUST
mlir       adaptive       wall    A    22.883  B    23.408   +1.06%  ok
mlir       host_overhead  wall    A     1.712  B     2.060   +0.309ms  REGRESSION  DISTRUST
mlir       chunked        kernel  A    63.885  B    64.267   +0.69%  REGRESSION  DISTRUST
mlir       chunked        wall    A    82.351  B    85.371   +2.89%  ok
mlir       wave           kernel  A    26.203  B    26.146   -0.89%  improvement  DISTRUST
mlir       wave           wall    A    29.961  B    29.873   -0.03%  ok
GATE: REGRESSION (kernel threshold 0.50%, wall threshold 10.00%, host-overhead threshold 0.25 ms)
DISTRUST = the pairs split on the regression call, so that verdict is unreliable; rerun, with more --pairs or a quieter GPU, before acting on it.
```
