### PR TITLE
fix(batchsolving): driver evaluation seeded from the owned interpolator at kernel construction

### DIFF
--- a/src/cubie/batchsolving/BatchSolverKernel.py
+++ b/src/cubie/batchsolving/BatchSolverKernel.py
@@ -326,10 +326,8 @@ class BatchSolverKernel(CUDAFactory):
         )
         self._solver_helper_fn = system.solver_helper_getter(cache_policy)
 
-        # The step and loop bake driver evaluation in as a closure
-        # constant; seed it from the owned interpolator unless the
-        # caller supplied an evaluator explicitly, mirroring the
-        # injection ``update`` performs on interpolator changes.
+        # Seed driver evaluation from the owned interpolator unless
+        # the caller supplied an evaluator.
         if evaluate_driver_at_t is None and system.sizes.drivers > 0:
             evaluate_driver_at_t = (
                 self.driver_interpolator.evaluation_function

--- a/src/cubie/batchsolving/BatchSolverKernel.py
+++ b/src/cubie/batchsolving/BatchSolverKernel.py
@@ -326,6 +326,17 @@ class BatchSolverKernel(CUDAFactory):
         )
         self._solver_helper_fn = system.solver_helper_getter(cache_policy)
 
+        # The step and loop bake driver evaluation in as a closure
+        # constant; seed it from the owned interpolator unless the
+        # caller supplied an evaluator explicitly, mirroring the
+        # injection ``update`` performs on interpolator changes.
+        if evaluate_driver_at_t is None and system.sizes.drivers > 0:
+            evaluate_driver_at_t = (
+                self.driver_interpolator.evaluation_function
+            )
+            if driver_del_t is None:
+                driver_del_t = self.driver_interpolator.driver_del_t
+
         # Build the single integrator to derive compile-critical metadata
         self.single_integrator = SingleIntegratorRun(
             system,

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -8,7 +8,10 @@ from tests._utils import (
     FLOAT64_PRECISION,
     _build_solver_instance,
 )
-from tests.system_fixtures import build_three_state_nonlinear_system
+from tests.system_fixtures import (
+    build_diagonally_dominant_system,
+    build_three_state_nonlinear_system,
+)
 
 from cubie import create_ODE_system
 from cubie.batchsolving.solver import Solver, solve_ivp
@@ -748,6 +751,48 @@ def test_lineinfo_constructor_propagates_to_children(precision):
     assert integrator._step_controller.compile_settings.lineinfo is True
     assert integrator._output_functions.compile_settings.lineinfo is True
     assert integrator._system.compile_settings.lineinfo is True
+
+
+def test_driver_evaluator_wired_at_construction(precision):
+    """A fresh solver on a driver-bearing system bakes driver
+    evaluation into the loop and step from the owned interpolator.
+
+    Before any update, ``evaluate_driver_at_t`` must already be the
+    interpolator's evaluation function: the first-built kernel
+    otherwise compiles without driver evaluation and integrates
+    uninitialised driver values (issue #734). Uses a private system:
+    the assertion is about construction-time state, which the shared
+    solver fixtures have already advanced past by configuring
+    drivers.
+    """
+    system = build_three_state_nonlinear_system(precision)
+    solver = Solver(system, algorithm="radau")
+
+    integrator = solver.kernel.single_integrator
+    evaluator = solver.kernel.driver_interpolator.evaluation_function
+    assert (
+        integrator._loop.compile_settings.evaluate_driver_at_t
+        is evaluator
+    )
+    assert (
+        integrator._algo_step.compile_settings.evaluate_driver_at_t
+        is evaluator
+    )
+
+
+def test_driverless_system_has_no_driver_evaluator(precision):
+    """A driverless system leaves ``evaluate_driver_at_t`` unset."""
+    system = build_diagonally_dominant_system(precision)
+    solver = Solver(system, algorithm="radau")
+
+    integrator = solver.kernel.single_integrator
+    assert (
+        integrator._loop.compile_settings.evaluate_driver_at_t is None
+    )
+    assert (
+        integrator._algo_step.compile_settings.evaluate_driver_at_t
+        is None
+    )
 
 
 def test_update_saved_variables(solver_mutable, system):

--- a/tests/batchsolving/test_solver.py
+++ b/tests/batchsolving/test_solver.py
@@ -754,17 +754,7 @@ def test_lineinfo_constructor_propagates_to_children(precision):
 
 
 def test_driver_evaluator_wired_at_construction(precision):
-    """A fresh solver on a driver-bearing system bakes driver
-    evaluation into the loop and step from the owned interpolator.
-
-    Before any update, ``evaluate_driver_at_t`` must already be the
-    interpolator's evaluation function: the first-built kernel
-    otherwise compiles without driver evaluation and integrates
-    uninitialised driver values (issue #734). Uses a private system:
-    the assertion is about construction-time state, which the shared
-    solver fixtures have already advanced past by configuring
-    drivers.
-    """
+    """A fresh solver wires the interpolator's evaluator in."""
     system = build_three_state_nonlinear_system(precision)
     solver = Solver(system, algorithm="radau")
 


### PR DESCRIPTION
Fixes #734.

`BatchSolverKernel.__init__` seeds `evaluate_driver_at_t` (and `driver_del_t`) from the kernel-owned `ArrayInterpolator` whenever the system has drivers and the caller supplied no evaluator, matching the injection the update path performs when an interpolator setting changes.

Previously the evaluator was `None` through the whole integrator tree at construction: the first-built step and loop compiled with driver evaluation disabled, so a first-build FIRK step passed an unfilled per-stage driver stack into the coupled Newton residual and integrated uninitialised local memory — all-NaN states at float32 on the reproducer. Any settings round-trip repaired it because `BatchSolverKernel.update` injects the interpolator's evaluation function when the interpolator recognises any key in the update (jit flags such as `nsz` qualify). The field is `eq=False`, so the broken and repaired kernels' configurations compared identical.

Regression tests: a fresh solver on a driver-bearing system holds the interpolator's evaluation function in the loop and step compile settings (fails on `main`); a driverless system still leaves it unset.

Verification: issue reproducer prints `True`/`True` on RTX 4070 SUPER; full CUDASIM suite 3091 passed; full real-GPU suite 3141 passed.

Performance gate:

```
A = origin/main (415fa893)   B = fix/734-driver-fn-first-build (working tree)   backends: numba-cuda, mlir   (4 block pairs x 15 solves/block/side)

numba-cuda fixed          kernel  A   167.693  B   165.589   -1.23%  improvement
numba-cuda fixed          wall    A   177.836  B   175.672   -1.18%  ok
numba-cuda adaptive       kernel  A    44.277  B    43.806   -1.17%  improvement
numba-cuda adaptive       wall    A    47.564  B    46.982   -1.27%  ok
numba-cuda host_overhead  wall    A     1.194  B     1.118   +0.016ms  ok
numba-cuda chunked        kernel  A   168.684  B   166.729   -0.96%  improvement
numba-cuda chunked        wall    A   183.688  B   181.550   -0.88%  ok
numba-cuda wave           kernel  A    67.716  B    66.359   -1.60%  improvement
numba-cuda wave           wall    A    69.788  B    68.358   -1.59%  ok

mlir       fixed          kernel  A   167.396  B   165.494   -0.55%  improvement
mlir       fixed          wall    A   182.824  B   181.052   -0.71%  ok
mlir       adaptive       kernel  A    42.819  B    42.696   +0.05%  ok
mlir       adaptive       wall    A    48.066  B    47.740   -0.93%  ok
mlir       host_overhead  wall    A     1.623  B     1.692   +0.061ms  ok
mlir       chunked        kernel  A   166.967  B   166.489   -0.49%  ok
mlir       chunked        wall    A   182.509  B   183.084   -0.10%  ok
mlir       wave           kernel  A    66.327  B    66.651   +0.07%  ok
mlir       wave           wall    A    68.926  B    69.832   +1.19%  ok

GATE: PASS (kernel threshold 0.50%, wall threshold 10.00%, host-overhead threshold 0.25 ms)