### PR TITLE
docs: inventory documentation freshness and rewrites

### DIFF
--- a/docs/review/README.md
+++ b/docs/review/README.md
@@ -1,0 +1,42 @@
+# Documentation review artifacts
+
+## Review state
+
+The review covers every tracked repository entry. Existing documentation,
+source, tests, and configuration remain unchanged. The files in this
+directory contain inventories and proposed text for later approval.
+
+The documentation corpus contains 149 reStructuredText pages. Every page was
+read and checked against current source, tests, exports, configuration, and
+runtime-resolved autodoc targets where dependencies allowed import.
+
+The repository manifest contains 585 tracked entries. The assigned
+documentation, package, test, instruction, and mirror lanes cover 524 entries.
+The repository-support lane is the exact 61-entry complement. One NPZ file is
+binary and is inventoried as data. Generated data, schemas, and fixtures were
+traversed and checked structurally.
+
+## Artifact map
+
+| Review lane | Inventory | Proposed rewrites | Coverage receipt |
+|---|---|---|---|
+| User-facing pages and support prose | [Inventory](user_facing_inventory.md) | [Proposals](user_facing_rewrite_proposals.md) | 42 files and 6,973 lines |
+| Developer, batch, and integrator API pages | [Inventory](batch_integrator_inventory.md) | [Proposals](batch_integrator_rewrite_proposals.md) | 69 pages, 1,917 RST lines, and 3,396 rendered docstring lines |
+| Memory, ODE-system, output, and GUI pages | [Inventory](systems_output_inventory.md) | [Proposals](systems_output_rewrite_proposals.md) | 51 pages, 695 RST lines, 39,147 source lines, 21,456 test lines, and 1,068 lines in ten nested instruction files |
+| Root and batch source and tests | [Inventory](root_batch_source_inventory.md) | [Proposals](root_batch_supplemental_proposals.md) | 70 files and 45,405 lines |
+| Integrator source and tests | [Inventory](integrator_source_inventory.md) | [Proposals](integrator_supplemental_proposals.md) | 115 entries and 34,556 newly read text lines |
+| Repository support files | [Inventory](repository_support_inventory.md) | [Proposals](repository_support_supplemental_proposals.md) | 61 files and 65,778 lines |
+| Combined result | [Completeness and freshness ledger](completeness_freshness_inventory.md) | Use the six proposal files above | 585 tracked entries and 149 documentation pages |
+
+Lane line totals are not additive. Some source and instruction files were read
+by more than one lane as evidence. The manifest reconciliation uses unique
+tracked paths.
+
+## Proposal use
+
+The proposal files contain exact replacements with source evidence. They do
+not authorize changes to the reviewed files. Apply factual corrections before
+language-only rewrites so later wording is based on current behavior.
+
+`CHANGELOG.md` was read and inventoried. Historical punctuation has no rewrite
+proposal because project instructions prohibit editing that file.

--- a/docs/review/batch_integrator_inventory.md
+++ b/docs/review/batch_integrator_inventory.md
@@ -1,0 +1,241 @@
+# Batch solving, integrator, and developer-guide inventory
+
+## Audit totals
+
+| Measure | Result |
+|---|---:|
+| Developer-guide pages | 7 |
+| API root-index pages | 1 |
+| Batch-solving API pages | 17 |
+| Integrator API pages | 44 |
+| Total pages | 69 |
+| Total RST lines read | 1,917 |
+| Autodoc directives checked | 58 |
+| Resolved autodoc targets | 54 |
+| Broken autodoc targets | 4 |
+| Unique source-docstring lines followed through resolved `:members:` targets | 3,396 |
+| Authored RST em-dash or semicolon lines | 30 |
+| Rendered source-docstring em-dash lines | 7 |
+| Rendered source-docstring semicolon lines | 32 |
+| Prospective missing-page autodoc targets checked | 4 |
+| Prospective rendered em-dash lines | 2 |
+| Prospective rendered semicolon lines | 5 |
+| Prospective rendered avoidable-colon lines | 4 |
+| Prospective rendered framing tells | 1 |
+| False-drama staccato findings | 0 |
+
+`Read` means every physical RST line was inspected. `Resolved` means the
+documented Python object exists at the cited source location. Resolution does
+not establish that rendered docstrings are fresh or stylistically compliant.
+
+## Page-by-page inventory
+
+### Developer guide
+
+| Page | Lines | Read | Autodoc target | Freshness and completeness | Issues |
+|---|---:|---|---|---|---|
+| `developer_guide/index.rst` | 18 | Complete | Not applicable | Complete page tree; opening is framed around reader identity | DG-00 |
+| `developer_guide/adding_algorithms.rst` | 73 | Complete | Not applicable | Stale tableau fields, false FIRK transformation requirement, incomplete family steps, removed helper API | DG-01, DG-02, DG-03, STYLE-RST-01, STYLE-FRAME-01 |
+| `developer_guide/adding_metrics.rst` | 118 | Complete | Not applicable | Example imports, metadata, signatures, CUDA import, decorators, reset, and registration are stale | DG-04, DG-05, DG-06, STYLE-FRAME-01 |
+| `developer_guide/architecture.rst` | 73 | Complete | Not applicable | Ownership, factory lifecycle, config update, and prefixed-instance descriptions are stale | DG-07, DG-08, DG-09, DG-10, STYLE-RST-02, STYLE-FRAME-01 |
+| `developer_guide/buffer_registry.rst` | 95 | Complete | Not applicable | Registry scope, local-memory claim, registration timing, allocator signatures, budget policy, and units are stale | DG-11, DG-12, DG-13, STYLE-RST-01 |
+| `developer_guide/codegen.rst` | 89 | Complete | Not applicable | Parser scope is incomplete; helper API, stage utilities, cache location, and JIT timing are stale | DG-14, DG-15, DG-16, STYLE-RST-01, STYLE-RST-02 |
+| `developer_guide/testing.rst` | 72 | Complete | Not applicable | Commands are not PowerShell or current marker selections; marker, fixture, and test-rule prose is stale | DG-17, DG-18, DG-19, STYLE-RST-01 |
+
+### API root and batch solving
+
+| Page | Lines | Read | Autodoc target and status | Freshness and completeness | Issues |
+|---|---:|---|---|---|---|
+| `API_reference/index.rst` | 18 | Complete | Not applicable | Module tree is current; opening is framed | API-01, STYLE-FRAME-01 |
+| `batchsolving/index.rst` | 62 | Complete | Not applicable | Omits three public exports and mislabels `solve_ivp` as single-run | API-01, API-03, STYLE-FRAME-01 |
+| `batchsolving/arrays.rst` | 57 | Complete | Not applicable | Array lifetime and transfer description is stale; `ActiveOutputs` is placed under the arrays subtree | API-02, API-03, STYLE-RST-02, STYLE-FRAME-01 |
+| `batchsolving/active_outputs.rst` | 8 | Complete | `cubie.batchsolving.ActiveOutputs` resolved at `src/cubie/batchsolving/BatchSolverConfig.py:35` | API target fresh; rendered prose needs direct wording | STYLE-DOC-03 |
+| `batchsolving/array_container.rst` | 8 | Complete | `cubie.batchsolving.ArrayContainer` resolved at `src/cubie/batchsolving/arrays/BaseArrayManager.py:227` | Fresh | CLEAN |
+| `batchsolving/base_array_manager.rst` | 8 | Complete | `cubie.batchsolving.BaseArrayManager` resolved at `src/cubie/batchsolving/arrays/BaseArrayManager.py:313` | API target fresh; rendered member prose has framing and punctuation findings | STYLE-DOC-02, STYLE-DOC-03 |
+| `batchsolving/batch_solver_config.rst` | 9 | Complete | `cubie.batchsolving.BatchSolverConfig` resolved at `src/cubie/batchsolving/BatchSolverConfig.py:132` | API target fresh; rendered class prose has punctuation findings | STYLE-DOC-02 |
+| `batchsolving/batch_solver_kernel.rst` | 8 | Complete | `cubie.batchsolving.BatchSolverKernel` resolved at `src/cubie/batchsolving/BatchSolverKernel.py:211` | API target fresh; rendered prose has em dashes, semicolons, colons, and framing | STYLE-DOC-01, STYLE-DOC-02, STYLE-DOC-03 |
+| `batchsolving/input_array_container.rst` | 8 | Complete | `cubie.batchsolving.InputArrayContainer` resolved at `src/cubie/batchsolving/arrays/BatchInputArrays.py:60` | API target fresh; one rendered colon rewrite | STYLE-DOC-03 |
+| `batchsolving/input_arrays.rst` | 8 | Complete | `cubie.batchsolving.InputArrays` resolved at `src/cubie/batchsolving/arrays/BatchInputArrays.py:128` | API target fresh; rendered punctuation findings | STYLE-DOC-02, STYLE-DOC-03 |
+| `batchsolving/managed_array.rst` | 8 | Complete | `cubie.batchsolving.ManagedArray` resolved at `src/cubie/batchsolving/arrays/BaseArrayManager.py:72` | Fresh | CLEAN |
+| `batchsolving/output_array_container.rst` | 8 | Complete | `cubie.batchsolving.OutputArrayContainer` resolved at `src/cubie/batchsolving/arrays/BatchOutputArrays.py:61` | API target fresh; one rendered colon rewrite | STYLE-DOC-03 |
+| `batchsolving/output_arrays.rst` | 8 | Complete | `cubie.batchsolving.OutputArrays` resolved at `src/cubie/batchsolving/arrays/BatchOutputArrays.py:152` | API target fresh; rendered factory wording is framed | STYLE-DOC-03 |
+| `batchsolving/solve_ivp.rst` | 6 | Complete | `cubie.batchsolving.solve_ivp` resolved at `src/cubie/batchsolving/solver.py:215` | Target fresh; rendered docstring has semicolon findings | STYLE-DOC-02 |
+| `batchsolving/solve_result.rst` | 8 | Complete | `cubie.batchsolving.SolveResult` resolved at `src/cubie/batchsolving/solveresult.py:195` | Target fresh; rendered ownership prose has em-dash, semicolon, and framing findings | STYLE-DOC-01, STYLE-DOC-02, STYLE-DOC-03 |
+| `batchsolving/solve_spec.rst` | 9 | Complete | `cubie.batchsolving.SolveSpec` resolved at `src/cubie/batchsolving/solveresult.py:116` | Fresh | CLEAN |
+| `batchsolving/solver.rst` | 8 | Complete | `cubie.batchsolving.Solver` resolved at `src/cubie/batchsolving/solver.py:350` | Target fresh; extensive rendered punctuation findings | STYLE-DOC-01, STYLE-DOC-02, STYLE-DOC-03 |
+| `batchsolving/system_interface.rst` | 8 | Complete | `cubie.batchsolving.SystemInterface` resolved at `src/cubie/batchsolving/SystemInterface.py:48` | Target fresh; rendered update description is framed | STYLE-DOC-03 |
+
+### Integrator package and algorithms
+
+| Page | Lines | Read | Autodoc target and status | Freshness and completeness | Issues |
+|---|---:|---|---|---|---|
+| `integrators/index.rst` | 53 | Complete | Not applicable | Misidentifies primary interface, references unexported settings type, and names removed result-code class | INT-01, INT-02, INT-15, STYLE-FRAME-01 |
+| `integrators/integrator_return_codes.rst` | 8 | Complete | `cubie.integrators.IntegratorReturnCodes` does not resolve | Broken target; current object is `CUBIE_RESULT_CODES` | INT-02 |
+| `integrators/single_integrator_run.rst` | 8 | Complete | `cubie.integrators.SingleIntegratorRun` resolved at `src/cubie/integrators/SingleIntegratorRun.py:38` | Target fresh; internal settings and core composition lack a reference page | INT-15 |
+| `integrators/algorithms.rst` | 192 | Complete | Not applicable | Family classification, adaptive selection, deadbands, tolerances, cache description, and resolver types are stale | INT-05, INT-06, INT-07, INT-08, INT-09, STYLE-RST-01, STYLE-RST-02, STYLE-FRAME-01 |
+| `algorithms/backwards_euler_pc_step.rst` | 17 | Complete | `cubie.integrators.algorithms.BackwardsEulerPCStep` resolved at `src/cubie/integrators/algorithms/backwards_euler_predict_correct.py:27` | Facts current; two em-dash rewrites | STYLE-RST-01 |
+| `algorithms/backwards_euler_step.rst` | 17 | Complete | `cubie.integrators.algorithms.BackwardsEulerStep` resolved at `src/cubie/integrators/algorithms/backwards_euler.py:61` | Facts current; one semicolon rewrite | STYLE-RST-01 |
+| `algorithms/base_algorithm_step.rst` | 8 | Complete | `cubie.integrators.algorithms.base_algorithm_step.BaseAlgorithmStep` resolved at `src/cubie/integrators/algorithms/base_algorithm_step.py:705` | Target fresh; rendered base description is framed | STYLE-DOC-03 |
+| `algorithms/base_step_config.rst` | 8 | Complete | `cubie.integrators.algorithms.base_algorithm_step.BaseStepConfig` resolved at `src/cubie/integrators/algorithms/base_algorithm_step.py:596` | Fresh | CLEAN |
+| `algorithms/crank_nicolson_step.rst` | 19 | Complete | `cubie.integrators.algorithms.CrankNicolsonStep` resolved at `src/cubie/integrators/algorithms/crank_nicolson.py:71` | Facts current; one semicolon rewrite | STYLE-RST-01 |
+| `algorithms/explicit_euler_step.rst` | 17 | Complete | `cubie.integrators.algorithms.ExplicitEulerStep` resolved at `src/cubie/integrators/algorithms/explicit_euler.py:47` | Fresh | CLEAN |
+| `algorithms/explicit_step_config.rst` | 8 | Complete | `cubie.integrators.algorithms.ExplicitStepConfig` resolved at `src/cubie/integrators/algorithms/ode_explicitstep.py:36` | Fresh | CLEAN |
+| `algorithms/generic_dirk_step.rst` | 33 | Complete | `cubie.integrators.algorithms.DIRKStep` resolved at `src/cubie/integrators/algorithms/generic_dirk.py:181`; `generic_dirk.DIRKStepConfig` resolved at line 113 | Universal adaptive claim is false; RST and rendered punctuation findings | INT-11, STYLE-RST-01, STYLE-DOC-02, STYLE-DOC-03 |
+| `algorithms/generic_dirk_tableaus.rst` | 66 | Complete | `DIRK_TABLEAU_REGISTRY` resolved at `src/cubie/integrators/algorithms/generic_dirk_tableaus.py:429`; `DIRKTableau` resolved at line 56 | Alias table omits `ode23t`, `kvaerno3`, and `kvaerno5` | INT-10, STYLE-RST-01, STYLE-DOC-02 |
+| `algorithms/generic_erk_step.rst` | 31 | Complete | `cubie.integrators.algorithms.ERKStep` resolved at `src/cubie/integrators/algorithms/generic_erk.py:146`; `generic_erk.ERKStepConfig` resolved at line 115 | Facts current; RST punctuation findings | STYLE-RST-01, STYLE-DOC-03 |
+| `algorithms/generic_erk_tableaus.rst` | 77 | Complete | `ERK_TABLEAU_REGISTRY` resolved at `src/cubie/integrators/algorithms/generic_erk_tableaus.py:751`; `ERKTableau` resolved at line 43 | Alias table omits 11 current keys; introduction has framing language | INT-10, STYLE-FRAME-01 |
+| `algorithms/generic_firk_step.rst` | 32 | Complete | `cubie.integrators.algorithms.FIRKStep` resolved at `src/cubie/integrators/algorithms/generic_firk.py:180`; `generic_firk.FIRKStepConfig` resolved at line 117 | Universal adaptive claim is false; punctuation findings | INT-11, STYLE-RST-01, STYLE-DOC-02, STYLE-DOC-03 |
+| `algorithms/generic_firk_tableaus.rst` | 48 | Complete | `FIRK_TABLEAU_REGISTRY` resolved at `src/cubie/integrators/algorithms/generic_firk_tableaus.py:219`; `FIRKTableau` resolved at line 53 | Omits the order-eight four-stage Gauss-Legendre tableau | INT-10 |
+| `algorithms/generic_rosenbrock_step.rst` | 33 | Complete | `cubie.integrators.algorithms.GenericRosenbrockWStep` resolved at `src/cubie/integrators/algorithms/generic_rosenbrock_w.py:155`; `RosenbrockWStepConfig` resolved at line 119 | False factorization claim; punctuation findings | INT-12, STYLE-RST-01, STYLE-DOC-03 |
+| `algorithms/generic_rosenbrock_tableaus.rst` | 54 | Complete | `ROSENBROCK_TABLEAUS` resolved at `src/cubie/integrators/algorithms/generic_rosenbrockw_tableaus.py:416`; `RosenbrockTableau` resolved at line 43 | Registry rows match all active keys; introduction has framing language | STYLE-FRAME-01 |
+| `algorithms/get_algorithm_step.rst` | 6 | Complete | `cubie.integrators.algorithms.get_algorithm_step` resolved at `src/cubie/integrators/algorithms/__init__.py:150` | Target fresh; narrative page describes enum input incorrectly | INT-09 |
+| `algorithms/implicit_step_config.rst` | 8 | Complete | `cubie.integrators.algorithms.ImplicitStepConfig` resolved at `src/cubie/integrators/algorithms/ode_implicitstep.py:91` | Target fresh; one rendered colon rewrite | STYLE-DOC-03 |
+| `algorithms/step_cache.rst` | 8 | Complete | `cubie.integrators.algorithms.base_algorithm_step.StepCache` resolved at `src/cubie/integrators/algorithms/base_algorithm_step.py:685` | Target fresh; parent-page description is stale | INT-09 |
+
+### Integrator loops, matrix-free solvers, and step control
+
+| Page | Lines | Read | Autodoc target and status | Freshness and completeness | Issues |
+|---|---:|---|---|---|---|
+| `integrators/loops.rst` | 40 | Complete | Not applicable | ODELoopConfig is assigned layout responsibility that belongs to BufferRegistry | INT-14 |
+| `loops/ivp_loop.rst` | 8 | Complete | `cubie.integrators.loops.IVPLoop` resolved at `src/cubie/integrators/loops/ode_loop.py:132` | Fresh | CLEAN |
+| `loops/ode_loop_config.rst` | 9 | Complete | `cubie.integrators.loops.ode_loop_config.ODELoopConfig` resolved at `src/cubie/integrators/loops/ode_loop_config.py:44` | Target fresh; one rendered semicolon finding | INT-14, STYLE-DOC-02 |
+| `integrators/matrix_free_solvers.rst` | 56 | Complete | Not applicable | Removed names, missing BiCGSTAB, false damping, wrong ownership, wrong CUDA import path | INT-02, INT-03, INT-04, INT-15 |
+| `matrix_free_solvers/linear_solver_factory.rst` | 16 | Complete | `LinearSolver` broken; `LinearSolverConfig` broken; `LinearSolverCache` resolved at `src/cubie/integrators/matrix_free_solvers/linear_solver_base.py:152` | Two broken targets and missing current linear solvers | INT-03, INT-15, STYLE-DOC-03 |
+| `matrix_free_solvers/newton_krylov_solver_factory.rst` | 16 | Complete | `NewtonKrylov` resolved at `src/cubie/integrators/matrix_free_solvers/newton_krylov.py:161`; `NewtonKrylovConfig` at line 69; `NewtonKrylovCache` at line 149 | Targets fresh; rendered punctuation findings | STYLE-DOC-02, STYLE-DOC-03 |
+| `matrix_free_solvers/solver_ret_codes.rst` | 8 | Complete | `cubie.integrators.matrix_free_solvers.SolverRetCodes` does not resolve | Broken target; current object is `CUBIE_RESULT_CODES` | INT-02 |
+| `integrators/step_control.rst` | 107 | Complete | Not applicable | Suggested beta table does not match current config fields or defaults | INT-13 |
+| `step_control/adaptive_i_controller.rst` | 8 | Complete | `cubie.integrators.step_control.AdaptiveIController` resolved at `src/cubie/integrators/step_control/adaptive_I_controller.py:36` | Fresh | CLEAN |
+| `step_control/adaptive_pi_controller.rst` | 8 | Complete | `cubie.integrators.step_control.AdaptivePIController` resolved at `src/cubie/integrators/step_control/adaptive_PI_controller.py:79` | Fresh | CLEAN |
+| `step_control/adaptive_pid_controller.rst` | 8 | Complete | `cubie.integrators.step_control.AdaptivePIDController` resolved at `src/cubie/integrators/step_control/adaptive_PID_controller.py:70` | Fresh | CLEAN |
+| `step_control/adaptive_step_control_config.rst` | 8 | Complete | `cubie.integrators.step_control.AdaptiveStepControlConfig` resolved at `src/cubie/integrators/step_control/adaptive_step_controller.py:85` | Target fresh; parent page defaults are stale | INT-13 |
+| `step_control/base_adaptive_step_controller.rst` | 8 | Complete | `cubie.integrators.step_control.BaseAdaptiveStepController` resolved at `src/cubie/integrators/step_control/adaptive_step_controller.py:199` | Fresh | CLEAN |
+| `step_control/base_step_controller_config.rst` | 9 | Complete | `cubie.integrators.step_control.BaseStepControllerConfig` resolved at `src/cubie/integrators/step_control/base_step_controller.py:166` | Target fresh; one rendered semicolon finding | STYLE-DOC-02 |
+| `step_control/base_step_controller.rst` | 8 | Complete | `cubie.integrators.step_control.BaseStepController` resolved at `src/cubie/integrators/step_control/base_step_controller.py:244` | Fresh | CLEAN |
+| `step_control/fixed_step_control_config.rst` | 8 | Complete | `cubie.integrators.step_control.FixedStepControlConfig` resolved at `src/cubie/integrators/step_control/fixed_step_controller.py:42` | Fresh | CLEAN |
+| `step_control/fixed_step_controller.rst` | 8 | Complete | `cubie.integrators.step_control.FixedStepController` resolved at `src/cubie/integrators/step_control/fixed_step_controller.py:97` | Fresh | CLEAN |
+| `step_control/get_controller.rst` | 6 | Complete | `cubie.integrators.step_control.get_controller` resolved at `src/cubie/integrators/step_control/__init__.py:66` | Fresh | CLEAN |
+| `step_control/gustafsson_controller.rst` | 8 | Complete | `cubie.integrators.step_control.GustafssonController` resolved at `src/cubie/integrators/step_control/gustafsson_controller.py:84` | Fresh | CLEAN |
+| `step_control/gustafsson_step_control_config.rst` | 8 | Complete | `cubie.integrators.step_control.GustafssonStepControlConfig` resolved at `src/cubie/integrators/step_control/gustafsson_controller.py:54` | Target fresh; parent page defaults are stale | INT-13 |
+| `step_control/pi_step_control_config.rst` | 8 | Complete | `cubie.integrators.step_control.PIStepControlConfig` resolved at `src/cubie/integrators/step_control/adaptive_PI_controller.py:49` | Target fresh; parent page defaults are stale | INT-13 |
+| `step_control/pid_step_control_config.rst` | 8 | Complete | `cubie.integrators.step_control.PIDStepControlConfig` resolved at `src/cubie/integrators/step_control/adaptive_PID_controller.py:52` | Target fresh; parent page defaults are stale | INT-13 |
+
+## Broken autodoc target inventory
+
+| Page and line | Broken target | Current source-backed target |
+|---|---|---|
+| `integrators/integrator_return_codes.rst:6` | `cubie.integrators.IntegratorReturnCodes` | `cubie.integrators.CUBIE_RESULT_CODES`, exported at `src/cubie/integrators/__init__.py:36,68-93` |
+| `matrix_free_solvers/linear_solver_factory.rst:6` | `LinearSolver` | `MRLinearSolver` and `BiCGSTABSolver`, exported at `src/cubie/integrators/matrix_free_solvers/__init__.py:29-42` |
+| `matrix_free_solvers/linear_solver_factory.rst:10` | `LinearSolverConfig` | `MRLinearSolverConfig` and `BiCGSTABSolverConfig`, same export block |
+| `matrix_free_solvers/solver_ret_codes.rst:6` | `SolverRetCodes` | `CUBIE_RESULT_CODES`, exported at `src/cubie/integrators/matrix_free_solvers/__init__.py:29-42` |
+
+## Source-driven completeness inventory
+
+### Public batch-solving exports
+
+The authoritative export list is
+`src/cubie/batchsolving/__init__.py:54-74`.
+
+| Public symbol | Coverage | Finding |
+|---|---|---|
+| `ActiveOutputs` | Dedicated page | Target resolves; page is placed under arrays although the class is declared with `BatchSolverConfig` |
+| `ArrayContainer` | Dedicated page | Current |
+| `ArrayTypes` | Mention only in arrays dependencies | No definition page or linked API target |
+| `BatchInputHandler` | None | Public grid-building and direct batch-input normalization API is absent; prospective docstring findings are in STYLE-PROSPECTIVE-01 |
+| `BatchSolverConfig` | Dedicated page | Current target; rendered style findings |
+| `BatchSolverKernel` | Dedicated page | Current target; rendered style findings |
+| `BaseArrayManager` | Dedicated page | Current target; rendered style findings |
+| `DeviceSolveResult` | None | Public device-buffer lifetime and synchronization contract is absent; prospective docstring findings are in STYLE-PROSPECTIVE-01 |
+| `InputArrayContainer` | Dedicated page | Current |
+| `InputArrays` | Dedicated page | Current target; narrative page omits device-input passthrough and staged transfers |
+| `ManagedArray` | Dedicated page | Current |
+| `OutputArrayContainer` | Dedicated page | Current |
+| `OutputArrays` | Dedicated page | Current target; narrative page misstates per-launch mirroring and omits loans |
+| `Solver` | Dedicated page | Current target; rendered style findings |
+| `SolveResult` | Dedicated page | Current target; rendered style findings |
+| `SolveSpec` | Dedicated page | Current |
+| `SystemInterface` | Dedicated page | Current target; rendered style finding |
+| `solve_ivp` | Dedicated page | Current target; batch index mislabels it as single-run |
+| `summary_metrics` | Covered in the outputhandling documentation lane | No duplicate page required here |
+
+Missing batch capabilities that need either a page or a direct cross-reference:
+
+- Caller-supplied device input detection and the no-copy path.
+- `on_device=True`, `DeviceSolveResult`, explicit synchronization, and device
+  buffer lifetime.
+- Pinned staging pools and asynchronous transfer/writeback watchers.
+- Output-buffer loans from `OutputArrays` to `SolveResult`.
+- Spill thresholds, disk-backed arrays, and explicit `close()` lifetime.
+- `BatchInputHandler` grid modes and direct device-array bypass.
+
+These behaviors are exposed by the public classes and methods in
+`src/cubie/batchsolving/solver.py:636-711`,
+`src/cubie/batchsolving/arrays/BatchInputArrays.py:450-522`, and
+`src/cubie/batchsolving/arrays/BatchOutputArrays.py:311-364`.
+
+### Public integrator exports
+
+The authoritative export list is `src/cubie/integrators/__init__.py:68-93`.
+
+| Public symbol | Coverage | Finding |
+|---|---|---|
+| `SingleIntegratorRun` | Dedicated page | Current target; internal role should be stated |
+| `CUBIE_RESULT_CODES` | Two pages use removed names | Replace both broken targets |
+| `get_algorithm_step` | Dedicated page | Target current; parent prose incorrectly says enum or name |
+| `ExplicitStepConfig` | Dedicated page | Current |
+| `ImplicitStepConfig` | Dedicated page | Current target; rendered colon finding |
+| `ExplicitEulerStep` | Dedicated page | Current |
+| `BackwardsEulerStep` | Dedicated page | Current target; RST semicolon finding |
+| `BackwardsEulerPCStep` | Dedicated page | Current target; RST em-dash findings |
+| `CrankNicolsonStep` | Dedicated page | Current target; RST semicolon finding |
+| `IVPLoop` | Dedicated page | Current |
+| `MRLinearSolver` | Removed-name page | Replace broken `LinearSolver` target |
+| `MRLinearSolverConfig` | Removed-name page | Replace broken `LinearSolverConfig` target |
+| `LinearSolverCache` | Dedicated target on removed-name page | Target current |
+| `BiCGSTABSolver` | None | Add target and describe breakdown/status behavior; prospective docstring findings are in STYLE-PROSPECTIVE-01 |
+| `BiCGSTABSolverConfig` | None | Add target; prospective docstring findings are in STYLE-PROSPECTIVE-01 |
+| `NewtonKrylov` | Dedicated page | Current target; overview falsely says damped |
+| `NewtonKrylovConfig` | Dedicated page | Current target; rendered punctuation findings |
+| `NewtonKrylovCache` | Dedicated page | Current |
+| `AdaptiveIController` | Dedicated page | Current |
+| `AdaptivePIController` | Dedicated page | Current |
+| `AdaptivePIDController` | Dedicated page | Current |
+| `FixedStepController` | Dedicated page | Current |
+| `GustafssonController` | Dedicated page | Current |
+| `get_controller` | Dedicated page | Current |
+
+The algorithms subpackage publicly exports `algorithm_is_adaptive` at
+`src/cubie/integrators/algorithms/__init__.py:31-53`; it has no API target.
+
+Internal capabilities that materially affect documented settings but have no
+focused coverage:
+
+- `SingleIntegratorRunCore` tolerance derivation and
+  `IntegratorRunSettings` composition.
+- `memory_heuristics` and automatic memory-policy selection.
+- Scaled, tiled, correction, and FIRK norms used by matrix-free solvers.
+- Dense stage prediction and its applicability limits.
+- BiCGSTAB scratch layout, residual reduction, residual floor, and breakdown
+  result codes.
+
+### Registry freshness
+
+| Registry | Documentation status | Source |
+|---|---|---|
+| `ERK_TABLEAU_REGISTRY` | Eleven active aliases omitted | `src/cubie/integrators/algorithms/generic_erk_tableaus.py:751-771` |
+| `DIRK_TABLEAU_REGISTRY` | `ode23t`, `kvaerno3`, and `kvaerno5` omitted | `src/cubie/integrators/algorithms/generic_dirk_tableaus.py:429-438` |
+| `FIRK_TABLEAU_REGISTRY` | `firk_gauss_legendre_4` omitted | `src/cubie/integrators/algorithms/generic_firk_tableaus.py:219-224` |
+| `ROSENBROCK_TABLEAUS` | All active aliases present | `src/cubie/integrators/algorithms/generic_rosenbrockw_tableaus.py:416-424` |
+
+## Language-sweep accounting
+
+- Every authored RST em dash and semicolon is listed with an exact replacement
+  in `STYLE-RST-01` of the proposal artifact.
+- Every rendered autodoc em dash is listed in `STYLE-DOC-01`.
+- Every rendered autodoc semicolon is listed in `STYLE-DOC-02`.
+- Punctuation and framing in four proposed missing API targets are listed in
+  `STYLE-PROSPECTIVE-01`.
+- Non-structural colon rewrites and retained structural colon categories are
+  recorded in `STYLE-RST-02` and `STYLE-DOC-03`.
+- Every detected framing or intensifying tell is listed in
+  `STYLE-FRAME-01` or `STYLE-DOC-03`.
+- No scoped prose contains false-drama staccato matching the supplied examples.

--- a/docs/review/batch_integrator_rewrite_proposals.md
+++ b/docs/review/batch_integrator_rewrite_proposals.md
@@ -1,0 +1,1988 @@
+# Batch solving, integrator, and developer-guide rewrite proposals
+
+## Scope and method
+
+This audit covers every line in these 69 pages, totalling 1,917 lines.
+
+- `docs/source/developer_guide/**/*.rst`
+- `docs/source/API_reference/index.rst`
+- `docs/source/API_reference/batchsolving/**/*.rst`
+- `docs/source/API_reference/integrators/**/*.rst`
+
+The audit follows every `autoclass`, `autofunction`, and `autodata`
+directive into the source docstrings rendered by `:members:`. There are 58
+autodoc directives. Fifty-four targets resolve and four are stale. The
+inventory artifact records the result for each page and the missing public API
+surface. A prospective audit covers docstrings for four proposed missing
+API targets before those targets are added.
+
+This artifact records proposals. No source documentation was changed.
+
+## Developer guide
+
+### DG-00: contributor-guide opening carries framing
+
+Location: `docs/source/developer_guide/index.rst:4-7`
+
+Current text:
+
+```rst
+This section is for contributors and users who want to extend CuBIE with
+new algorithms, metrics, or other components. It assumes familiarity with
+the :doc:`User Guide </user_guide/index>` and a working knowledge of
+Python, NumPy, and CUDA concepts.
+```
+
+Replacement:
+
+```rst
+Implement algorithm, metric, code-generation, and CUDA-buffer extensions
+with these instructions. The examples require Python, NumPy, and CUDA
+knowledge.
+```
+
+Reason: the current opening frames the section and describes reader identity.
+The replacement states the prerequisites and available instructions.
+
+### DG-01: the tableau example uses stale construction details
+
+Location: `docs/source/developer_guide/adding_algorithms.rst:4-26`
+
+Current text:
+
+```rst
+CuBIE's algorithm system is designed to make adding new integration
+methods straightforward, from simple tableau entries to entirely new
+algorithm families.
+
+The simplest case.  Add a new entry to ``ERK_TABLEAU_REGISTRY`` in
+``src/cubie/integrators/algorithms/generic_erk_tableaus.py``:
+
+.. code-block:: python
+
+   ERK_TABLEAU_REGISTRY["my_method_43"] = ERKTableau(
+       a=np.array([...]),       # Butcher A matrix (lower-triangular)
+       b=np.array([...]),       # weights
+       b_hat=np.array([...]),   # embedded weights (or None if non-adaptive)
+       c=np.array([...]),       # nodes
+       order=4,
+       name="my_method_43",
+   )
+
+The method is immediately available as
+``Solver(system, algorithm="my_method_43")``.
+```
+
+Replacement:
+
+```rst
+Add integration tableaus to the registry for their algorithm family.
+Add an ERK tableau to ``ERK_TABLEAU_REGISTRY`` in
+``src/cubie/integrators/algorithms/generic_erk_tableaus.py``.
+
+.. code-block:: python
+
+   MY_METHOD_43_TABLEAU = ERKTableau(
+       a=((...), (...)),
+       b=(...),
+       b_hat=(...),
+       c=(...),
+       order=4,
+   )
+
+   ERK_TABLEAU_REGISTRY["my_method_43"] = MY_METHOD_43_TABLEAU
+
+Select the method with ``Solver(system, algorithm="my_method_43")``.
+```
+
+Reason: current tableaus are frozen attrs objects with tuple coefficients and
+no `name` field. The registry supplies the public name. See
+`src/cubie/integrators/algorithms/base_algorithm_step.py:217-257` and
+`src/cubie/integrators/algorithms/generic_erk_tableaus.py:751-771`.
+
+### DG-02: tableau-family and new-family instructions are stale and incomplete
+
+Location: `docs/source/developer_guide/adding_algorithms.rst:28-60`
+
+Current text:
+
+```rst
+The process is analogous.  Each family has its own tableau registry and
+dataclass:
+
+- ``DIRK_TABLEAU_REGISTRY`` in ``generic_dirk_tableaus.py``
+- ``FIRK_TABLEAU_REGISTRY`` in ``generic_firk_tableaus.py``
+- ``ROSENBROCK_TABLEAUS`` in ``generic_rosenbrockw_tableaus.py``
+
+FIRK tableaus must also supply a transformation matrix ``T`` and its
+inverse for the stage-coupled solver.
+
+For an entirely new algorithm type:
+
+1. **Subclass** ``ODEExplicitStep`` or ``ODEImplicitStep`` (in
+   ``src/cubie/integrators/algorithms/``).
+
+2. **Implement** ``build_step()``, which returns a CUDA device function
+   that performs one integration step.
+
+3. **Register buffers** via the buffer registry for any working arrays
+   the step function needs (see :doc:`buffer_registry`).
+
+4. **Register** the new class in ``_ALGORITHM_REGISTRY`` in
+   ``src/cubie/integrators/algorithms/__init__.py``.
+
+5. **Declare defaults** by setting ``StepControlDefaults`` on the class
+   to specify preferred controller settings (tolerances, step-size
+   bounds, controller type).
+```
+
+Replacement:
+
+```rst
+Add DIRK, FIRK, and Rosenbrock tableaus to ``DIRK_TABLEAU_REGISTRY``,
+``FIRK_TABLEAU_REGISTRY``, and ``ROSENBROCK_TABLEAUS``. The tableau
+classes are frozen attrs classes. Supply the coefficient fields declared
+by the selected class. ``FIRKTableau`` uses the base ``a``, ``b``,
+``b_hat``, ``c``, and ``order`` fields and does not accept transformation
+matrices.
+
+Add a new algorithm family with these changes.
+
+1. Subclass ``ODEExplicitStep`` or ``ODEImplicitStep``.
+2. Implement the abstract build and resource properties required by the
+   base class, including ``build_step()``.
+3. Register working buffers before a build requests their allocators.
+4. Add accepted settings to ``ALL_ALGORITHM_STEP_PARAMETERS``.
+5. Add the class to ``_ALGORITHM_REGISTRY``.
+6. Construct the algorithm family's ``StepControlDefaults`` and pass it to
+   the base constructor.
+7. Add a CPU reference implementation and compare GPU results with it in
+   the algorithm tests.
+```
+
+Reason: `FIRKTableau` declares no transformation fields
+(`src/cubie/integrators/algorithms/generic_firk_tableaus.py:52-59`). The
+factory filters settings through `ALL_ALGORITHM_STEP_PARAMETERS`
+(`src/cubie/integrators/algorithms/base_algorithm_step.py:62-123`). Existing
+families pass defaults during construction rather than assigning a class
+attribute, for example
+`src/cubie/integrators/algorithms/generic_dirk.py:81-99`.
+
+### DG-03: the implicit-helper example calls a removed API
+
+Location: `docs/source/developer_guide/adding_algorithms.rst:65-73`
+
+Current text:
+
+```rst
+Implicit algorithms typically need Jacobian--vector products and solver
+infrastructure.  Use ``build_implicit_helpers()`` to request these from
+the ODE system's code generator:
+
+.. code-block:: python
+
+   helpers = self.system.get_solver_helper("linear_operator_cached")
+```
+
+Replacement:
+
+```rst
+Implicit algorithms obtain generated helpers through the configured
+request callback.
+
+.. code-block:: python
+
+   from cubie.odesystems.solver_helpers import (
+       SolverHelperKind,
+       SolverHelperRequest,
+   )
+
+   operator = self.compile_settings.get_solver_helper_fn(
+       SolverHelperRequest(
+           kind=SolverHelperKind.LINEAR_OPERATOR_CACHED,
+       )
+   ).device_function
+
+Use ``build_implicit_helpers()`` when the standard implicit-step helper
+chain matches the algorithm.
+```
+
+Reason: helper lookup takes an immutable `SolverHelperRequest`; implicit
+steps retrieve `.device_function` from the result. See
+`src/cubie/odesystems/solver_helpers.py:288-338` and
+`src/cubie/integrators/algorithms/ode_implicitstep.py:587-625`.
+
+### DG-04: the custom metric imports and metadata are wrong
+
+Location: `docs/source/developer_guide/adding_metrics.rst:4-44`
+
+Current text:
+
+```rst
+CuBIE's summary metrics system is extensible via the
+``@register_metric`` decorator.  This page walks through implementing a
+custom metric.
+
+   from cubie.outputhandling.summarymetrics.metrics import (
+       SummaryMetric,
+       MetricFuncCache,
+       register_metric,
+       summary_metrics,
+   )
+
+   @register_metric(summary_metrics)
+   class MyCustomMetric(SummaryMetric):
+       def __init__(self, precision):
+           super().__init__(
+               buffer_size=2,
+               output_size=1,
+               name="my_custom",
+               precision=precision,
+               unit_modification="[custom]",
+               sample_summaries_every=None,
+           )
+
+       def build(self) -> MetricFuncCache:
+           # Return a MetricFuncCache with update and save callables
+           ...
+```
+
+Replacement:
+
+```rst
+Register a ``SummaryMetric`` subclass with ``@register_metric``.
+
+   from cubie.outputhandling.summarymetrics import summary_metrics
+   from cubie.outputhandling.summarymetrics.metrics import (
+       MetricFuncCache,
+       SummaryMetric,
+       register_metric,
+   )
+
+   @register_metric(summary_metrics)
+   class MyCustomMetric(SummaryMetric):
+       def __init__(self, precision):
+           super().__init__(
+               buffer_size=2,
+               output_size=1,
+               name="my_custom",
+               precision=precision,
+               unit_modification="[unit] custom",
+           )
+
+       def build(self) -> MetricFuncCache:
+           ...
+```
+
+Reason: `summary_metrics` is created in the package initializer, not
+`metrics.py` (`src/cubie/outputhandling/summarymetrics/__init__.py:27-38`).
+`unit_modification` is a format string containing `[unit]`, and the sampling
+interval defaults to `0.01`
+(`src/cubie/outputhandling/summarymetrics/metrics.py:162-189`).
+
+### DG-05: metric parameter descriptions and callback signatures are stale
+
+Location: `docs/source/developer_guide/adding_metrics.rst:49-84`
+
+Current text:
+
+```rst
+``buffer_size``
+   Number of scratch elements per variable needed during accumulation.
+   Can be an ``int`` or a callable that receives the number of
+   summarised variables.
+
+``unit_modification``
+   Label suffix appended to variable names in the summary legend
+   (e.g. ``"[mean]"``, ``"[max]"``).
+
+``sample_summaries_every``
+   If not ``None``, the metric requests sub-step sampling at this
+   interval.
+
+``update(buffer, value, t, dt)``
+   Called at every summary sample point during integration.  Accumulates
+   data into ``buffer``.
+
+``save(buffer, output, n_samples)``
+   Called at the end of the solve.  Finalises the accumulated data and
+   writes to ``output``.
+```
+
+Replacement:
+
+```rst
+``buffer_size``
+   Number of scratch elements per variable. A callable receives the
+   metric parameter parsed from the output specification.
+
+``output_size``
+   Number of persisted output elements per variable. A callable receives
+   the metric parameter.
+
+``unit_modification``
+   Legend format string. Use ``[unit]`` where the source unit belongs.
+
+``sample_summaries_every``
+   Time interval between summary samples. Derivative metrics use the
+   interval to scale finite differences.
+
+``update(value, buffer, current_index, customisable_variable)``
+   Accumulates one sampled value.
+
+``save(buffer, output_array, summarise_every, customisable_variable)``
+   Writes one summary and resets any scratch state required for the next
+   summary interval.
+```
+
+Reason: the base class documents the sampling interval for every metric at
+`src/cubie/outputhandling/summarymetrics/metrics.py:148-149`. Derivative
+metrics use it for finite-difference scaling as documented at
+`src/cubie/outputhandling/summarymetrics/metrics.py:80-82`. The callback
+contracts are at `src/cubie/outputhandling/summarymetrics/metrics.py:125-159`
+and `src/cubie/outputhandling/summarymetrics/metrics.py:224-240`.
+
+### DG-06: the Count metric does not compile against the current callback API
+
+Location: `docs/source/developer_guide/adding_metrics.rst:86-118`
+
+Current text:
+
+```rst
+Example: Implementing a "Count" Metric
+----------------------------------------
+
+A metric that counts how many samples were accumulated:
+
+.. code-block:: python
+
+   from numba import cuda
+
+   @register_metric(summary_metrics)
+   class CountMetric(SummaryMetric):
+       def __init__(self, precision):
+           super().__init__(
+               buffer_size=1,
+               output_size=1,
+               name="count",
+               precision=precision,
+               unit_modification="[count]",
+           )
+
+       def build(self) -> MetricFuncCache:
+           @cuda.jit(device=True)
+           def update(buffer, value, t, dt):
+               buffer[0] += 1.0
+
+           @cuda.jit(device=True)
+           def save(buffer, output, n_samples):
+               output[0] = buffer[0]
+
+           return MetricFuncCache(update=update, save=save)
+
+After adding the file, the metric is available as
+``output_types=["count"]``.
+```
+
+Replacement:
+
+```rst
+Count metric
+------------
+
+.. code-block:: python
+
+   from cubie.cuda_simsafe import cuda
+
+   @register_metric(summary_metrics)
+   class CountMetric(SummaryMetric):
+       def __init__(self, precision):
+           super().__init__(
+               buffer_size=1,
+               output_size=1,
+               name="count",
+               precision=precision,
+               unit_modification="[unit] count",
+           )
+
+       def build(self) -> MetricFuncCache:
+           precision = self.compile_settings.precision
+
+           @cuda.jit(
+               device=True,
+               inline=True,
+               **self.jit_kwargs,
+           )
+           def update(
+               value,
+               buffer,
+               current_index,
+               customisable_variable,
+           ):
+               buffer[0] += precision(1.0)
+
+           @cuda.jit(
+               device=True,
+               inline=True,
+               **self.jit_kwargs,
+           )
+           def save(
+               buffer,
+               output_array,
+               summarise_every,
+               customisable_variable,
+           ):
+               output_array[0] = buffer[0]
+               buffer[0] = precision(0.0)
+
+           return MetricFuncCache(update=update, save=save)
+
+Import the new module once in
+``cubie.outputhandling.summarymetrics.__init__`` after ``summary_metrics``
+is constructed. The import registers ``output_types=["count"]``.
+```
+
+Reason: CUDA imports must use `cuda_simsafe`. Built-in metrics use `inline=True`,
+the factory `jit_kwargs`, current argument order, and buffer reset. See
+`src/cubie/outputhandling/summarymetrics/mean.py:62-79` and
+`src/cubie/outputhandling/summarymetrics/mean.py:99-136`. Registration happens
+through initializer imports at
+`src/cubie/outputhandling/summarymetrics/__init__.py:37-55`.
+
+### DG-07: the ownership tree and CUDAFactory claim are inaccurate
+
+Location: `docs/source/developer_guide/architecture.rst:4-22`
+
+Current text:
+
+```rst
+This page describes CuBIE's internal design patterns.  Understanding
+these is essential for contributing new algorithms, metrics, or other
+components.
+
+A typical solve involves the following hierarchy::
+
+   Solver
+   └── BatchSolverKernel
+       └── SingleIntegratorRun
+           ├── IVPLoop
+           ├── OutputFunctions
+           ├── Algorithm step (e.g. ERKStep, FIRKStep)
+           └── Controller (PI, PID, Gustafsson)
+
+Each component is a :class:`~cubie.CUDAFactory.CUDAFactory` subclass that
+generates CUDA device functions.
+```
+
+Replacement:
+
+```rst
+CuBIE composes a solve through this ownership tree::
+
+   Solver
+   └── BatchSolverKernel
+       ├── ArrayInterpolator
+       └── SingleIntegratorRun
+           ├── IVPLoop
+           ├── OutputFunctions
+           ├── Algorithm step
+           │   └── Matrix-free solver for implicit methods
+           └── Step controller
+
+``Solver`` owns the host orchestration API. CUDA-generating descendants
+derive from :class:`~cubie.CUDAFactory.CUDAFactory` and expose cached
+compiled-function properties.
+```
+
+Reason: `Solver` is not a `CUDAFactory`. `BatchSolverKernel` constructs and
+owns the driver interpolator at
+`src/cubie/batchsolving/BatchSolverKernel.py:303-312`.
+`Solver.driver_interpolator` is a passthrough to the kernel-owned object at
+`src/cubie/batchsolving/solver.py:608-611`.
+
+### DG-08: the lifecycle promises a generic device-function property
+
+Location: `docs/source/developer_guide/architecture.rst:27-47`
+
+Current text:
+
+```rst
+Every CUDA-generating component follows the same pattern:
+
+2. **Build.**  The ``build()`` method generates and returns compiled
+   device functions.  Subclasses override this method.
+
+3. **Cache.**  The result of ``build()`` is cached.  Subsequent accesses
+   via the ``device_function`` property return the cached result without
+   rebuilding.
+
+.. important::
+
+   Never call ``build()`` directly.  Always access compiled functions
+   through properties (e.g. ``device_function``), which handle caching.
+```
+
+Replacement:
+
+```rst
+CUDA-generating components use this lifecycle.
+
+2. **Build.** The ``build()`` method returns the component's dispatcher
+   cache object.
+
+3. **Cache.** A public compiled-function property calls
+   ``get_cached_output(name)`` and returns the named field from the
+   component's dispatcher cache. Property names are component-specific.
+
+Call compiled-function properties. Do not call ``build()`` directly.
+```
+
+Reason: `get_cached_output(name)` builds an invalid cache and returns the named
+cache field at `src/cubie/CUDAFactory.py:578-604`. Algorithm steps expose that
+protocol through properties such as `step_function` at
+`src/cubie/integrators/algorithms/base_algorithm_step.py:877-880`.
+
+### DG-09: config comparison and update arity are stale
+
+Location: `docs/source/developer_guide/architecture.rst:52-55`
+
+Current text:
+
+```rst
+``_CubieConfigBase`` provides ``values_hash`` (a hex digest of the frozen
+config) and ``values_tuple`` for comparison.  ``update()`` returns two
+sets: the names of fields that were *requested* to change and those that
+*actually* changed.  Only actual changes invalidate the cache.
+```
+
+Replacement:
+
+```rst
+``_CubieConfigBase.values_hash`` is the canonical digest of a frozen
+configuration snapshot. ``update()`` returns a replacement snapshot, the
+recognized setting names, and the names whose converted values changed.
+A change to a converted value invalidates the factory cache.
+```
+
+Reason: `values_tuple` does not exist, and `update()` returns a three-item
+tuple. See `src/cubie/CUDAFactory.py:194-276` and
+`src/cubie/CUDAFactory.py:278-300`.
+
+### DG-10: MultipleInstanceCUDAFactory is described as a collection
+
+Location: `docs/source/developer_guide/architecture.rst:60-63`
+
+Current text:
+
+```rst
+Some components appear multiple times in the tree (e.g. one algorithm
+step per stage in a multi-stage method).  ``MultipleInstanceCUDAFactory``
+manages a collection of identically-typed factories distinguished by a
+prefix string, so their buffers and settings don't collide.
+```
+
+Replacement:
+
+```rst
+``MultipleInstanceCUDAFactory`` represents one factory instance whose
+selected configuration keys use an instance prefix. For example,
+``krylov_atol`` maps to the internal ``atol`` field of the Krylov solver.
+The prefix separates settings for coexisting solver instances.
+```
+
+Reason: the class does not own a collection. Prefix mapping occurs in the
+single instance's config update method. See
+`src/cubie/CUDAFactory.py:706-832` and `src/cubie/CUDAFactory.py:835-878`.
+
+### DG-11: buffer-registry scope and memory descriptions overstate behavior
+
+Location: `docs/source/developer_guide/buffer_registry.rst:4-30`
+
+Current text:
+
+```rst
+CuBIE centralises GPU memory management through the
+:mod:`~cubie.buffer_registry` module.  Every CUDA-generating component
+registers its memory requirements, and the registry computes a layout
+that is allocated once at kernel launch time.
+
+``location``
+   ``"shared"`` (on-chip, fast, limited to ~48 KB per block) or
+   ``"local"`` (per-thread, in registers/L1).
+
+``persistent``
+   If ``True``, the buffer survives across steps (e.g. state arrays).
+   Non-persistent buffers can be aliased.
+```
+
+Replacement:
+
+```rst
+The :mod:`~cubie.buffer_registry` module computes per-run scratch layouts
+for CUDA factories. Batch input and output allocation is handled by the
+memory-manager layer.
+
+``location``
+   ``"shared"`` selects dynamic shared memory. ``"local"`` selects a
+   per-thread CUDA local array.
+
+``persistent``
+   A persistent local buffer occupies a stable slice of the top-level
+   per-run persistent array across integration steps. Non-persistent
+   Register non-persistent buffers as aliases when their lifetimes do not
+   overlap.
+```
+
+Reason: the registry stores layout metadata and builds slice allocators; it is
+not the allocator for all GPU arrays. CUDA local arrays are not guaranteed to
+remain in registers or L1. See `src/cubie/buffer_registry.py:649-700` and
+`src/cubie/buffer_registry.py:703-710`.
+
+### DG-12: registration timing and allocator signatures are wrong
+
+Location: `docs/source/developer_guide/buffer_registry.rst:38-69`
+
+Current text:
+
+```rst
+Components register buffers in their ``build()`` method:
+
+``get_allocator(name, parent)``
+   Returns a function that, given a base pointer and thread index,
+   returns a typed array slice for the named buffer.
+
+``get_child_allocators(parent, child)``
+   Delegates a region of the parent's allocation to a child component.
+```
+
+Replacement:
+
+```rst
+Register buffers before requesting layouts or compiled allocators.
+Factories normally register buffers during construction and refresh their
+sizes when compile settings change.
+
+``get_allocator(name, parent)``
+   Returns a device function with the signature
+   ``(shared, persistent) -> array``.
+
+``get_child_allocators(parent, child, name=None)``
+   Registers the child footprint on the parent and returns the child's
+   shared and persistent slice allocators.
+```
+
+Reason: allocator generation reads an existing layout and takes shared and
+persistent base arrays, not a thread index
+(`src/cubie/buffer_registry.py:649-700`). The child allocator accepts an
+optional name and performs registration
+(`src/cubie/buffer_registry.py:1173-1208`).
+
+### DG-13: shared-memory limits and layout-query units are wrong
+
+Location: `docs/source/developer_guide/buffer_registry.rst:71-95`
+
+Current text:
+
+```rst
+Shared memory is limited (~48 KB default, configurable up to 100 KB on
+some architectures).  When the total exceeds the budget, CuBIE reduces
+the block size (fewer threads per block) to fit.
+
+``buffer_registry.shared_buffer_size(parent)``
+   Total shared memory bytes for a component and its children.
+
+``buffer_registry.local_buffer_size(parent)``
+   Total local memory bytes (non-persistent).
+
+``buffer_registry.persistent_local_buffer_size(parent)``
+   Total local memory bytes (persistent).
+
+Use these to verify that your component's memory footprint is reasonable.
+```
+
+Replacement:
+
+```rst
+The performance stage reduces block size toward a dynamic shared-memory
+target under 32 KiB and stops at one warp. The 32 KiB target does not
+apply after the block reaches one warp. The hardware stage then applies
+the device's per-block limit and reduces to fewer than 32 threads when
+required for a valid launch.
+
+``buffer_registry.shared_buffer_size(parent)``
+   Number of shared-memory elements in the parent's layout, including
+   synthetic shared rollups for registered children.
+
+``buffer_registry.local_buffer_size(parent)``
+   Number of non-persistent local elements registered on the parent.
+
+``buffer_registry.persistent_local_buffer_size(parent)``
+   Number of persistent local elements in the parent's layout, including
+   synthetic persistent rollups for registered children.
+
+Multiply each element count by the buffer dtype's item size to calculate
+bytes.
+```
+
+Reason: the current block-size policy is implemented at
+`src/cubie/batchsolving/BatchSolverKernel.py:810-853`. Registry query methods
+return element counts at `src/cubie/buffer_registry.py:584-618`. Child
+registration creates shared and persistent synthetic entries at
+`src/cubie/buffer_registry.py:1118-1167`; it creates no non-persistent local
+rollup.
+
+### DG-14: code-generation opening and parser scope are padded and incomplete
+
+Location: `docs/source/developer_guide/codegen.rst:4-33`
+
+Current text:
+
+```rst
+CuBIE transforms symbolic ODE definitions into compiled CUDA device
+functions.  SymPy is the parse layer for string and SymPy input; every
+expression converts to a lightweight interned expression IR (the
+``engine`` package) at the parse boundary, and every later stage —
+classification, structural simplification, differentiation, CSE,
+hashing, and printing — runs on the IR.  This page describes the
+pipeline.
+
+The parser in ``src/cubie/odesystems/symbolic/parsing/`` tokenises the
+equation strings, identifies states (variables with ``d<name>`` on the
+left-hand side), parameters, constants, and observables, and converts
+every expression to engine IR before returning.
+```
+
+Replacement:
+
+```rst
+CuBIE parses string, SymPy, callable, and CellML systems and emits CUDA
+device-function factories. SymPy input is converted to the interned
+``engine`` expression IR at the parse boundary. Classification,
+structural simplification, differentiation, common-subexpression
+elimination, hashing, and printing operate on that IR.
+
+The parsing package normalises accepted system inputs, classifies explicit
+ODE and DAE equations, applies CellML substitutions, and converts symbolic
+expressions to engine IR.
+```
+
+Reason: the public normalisation path accepts more than equation strings and
+performs structural DAE processing. The pipeline modules are routed from
+`src/cubie/odesystems/symbolic/symbolicODE.py:318-352` and structural DAE
+simplification is described at
+`src/cubie/odesystems/symbolic/symbolicODE.py:391-415`.
+
+### DG-15: helper and stage-utility descriptions use removed behavior
+
+Location: `docs/source/developer_guide/codegen.rst:53-81`
+
+Current text:
+
+```rst
+``src/cubie/odesystems/symbolic/engine/`` holds the expression IR the
+compute phase runs on: nodes are interned (structurally
+identical expressions are the same object), so substitution,
+differentiation, and common-subexpression elimination are single passes
+over a DAG.  The engine's printer renders IR as Numba-CUDA source:
+
+``get_solver_helper()`` dispatches to the appropriate code-generation
+path based on the requested helper name (``"linear_operator"``,
+``"prepare_jac"``, ``"calculate_cached_jvp"``,
+``"time_derivative_rhs"``).
+
+``_stage_utils`` provides helpers for FIRK methods that need to generate
+code for multiple coupled stages simultaneously, including
+block-structured linear algebra and transformation matrices.
+```
+
+Replacement:
+
+```rst
+``src/cubie/odesystems/symbolic/engine/`` holds the interned expression
+IR. Structural equality reuses the same nodes. Substitution,
+differentiation, and common-subexpression elimination traverse the DAG.
+The printer renders IR as Numba CUDA source.
+
+``get_solver_helper(request, cache_policy=None)`` accepts a
+``SolverHelperRequest`` containing a ``SolverHelperKind`` and the
+coefficient metadata required by that kind. The result carries the
+generated device function and helper metadata. ``get_solver_helper_fn`` is
+the algorithm-config callback field. Use ``solver_helper_getter`` to bind
+a cache policy before passing the callback to the algorithm.
+
+``_stage_utils`` normalises FIRK stage coefficients and nodes and creates
+IR symbol assignments for generated coupled-stage helpers.
+```
+
+Reason: the system API retains `get_solver_helper(request, cache_policy=None)`
+at `src/cubie/odesystems/baseODE.py:440-444` and
+`src/cubie/odesystems/symbolic/symbolicODE.py:941-945`. The policy-bound
+getter is built at `src/cubie/odesystems/baseODE.py:415-438`.
+`get_solver_helper_fn` is an algorithm-config callback field at
+`src/cubie/integrators/algorithms/base_algorithm_step.py:614-640`.
+`_stage_utils` provides only stage-data normalisation and metadata construction
+at `src/cubie/odesystems/symbolic/codegen/_stage_utils.py:37-108`.
+
+### DG-16: generated-file location and compilation timing are overstated
+
+Location: `docs/source/developer_guide/codegen.rst:83-89`
+
+Current text:
+
+```rst
+Each system uses one generated Python module at
+``generated/<system_name>/<system_name>.py``. Solver helpers are added
+to that module as they are requested. Numba compiles the factories on
+import.
+```
+
+Replacement:
+
+```rst
+Each symbolic system stores one generated Python module at
+``<cache_root>/<system_name>/<system_name>.py``. The cache root is the
+process override, ``CUBIE_CACHE_DIR``, or ``<cwd>/generated`` in that
+order. Requested helper factories are appended to the module. Importing
+the module loads the Python factory. A compiled-function property invokes
+the factory and caches the resulting CUDA dispatcher.
+```
+
+Reason: cache-root precedence is implemented at `src/cubie/cache_root.py:34-50`.
+`ODEFile` writes and imports generated Python factories but does not JIT them
+on import (`src/cubie/odesystems/symbolic/odefile.py:27-45` and
+`src/cubie/odesystems/symbolic/odefile.py:133-166`).
+
+### DG-17: test commands are not the project commands and are not PowerShell
+
+Location: `docs/source/developer_guide/testing.rst:9-22`
+
+Current text:
+
+```rst
+.. code-block:: bash
+
+   # Full suite (requires CUDA GPU)
+   python -m pytest
+
+   # CPU-only tests (CUDASIM mode)
+   export NUMBA_ENABLE_CUDASIM=1
+   python -m pytest -m "not nocudasim and not cupy"
+```
+
+Replacement:
+
+```rst
+.. code-block:: powershell
+
+   # Simulator first pass
+   $env:NUMBA_ENABLE_CUDASIM = "1"
+   pytest -m "not nocudasim and not cupy and not specific_algos"
+
+   # Real GPU verification
+   Remove-Item Env:NUMBA_ENABLE_CUDASIM -ErrorAction SilentlyContinue
+   pytest -m "not specific_algos and not sim_only"
+
+   # Specific module
+   pytest tests/integrators/
+
+   # Specific test pattern
+   pytest -k test_solver
+```
+
+Reason: the repository shell is PowerShell. The marker set and automatic
+parallel, coverage, and report options are defined at `pyproject.toml:95-118`.
+The simulator and real-GPU selections must exclude their incompatible marker
+sets.
+
+### DG-18: marker and fixture claims are stale
+
+Location: `docs/source/developer_guide/testing.rst:27-60`
+
+Current text:
+
+```rst
+``nocudasim``
+   Test requires a real GPU; skip in CUDASIM mode.
+
+``cupy``
+   Test requires CuPy; skip if not installed.
+
+Key fixtures include pre-built ODE systems (Lotka--Volterra, van der Pol,
+linear test systems) and solver factories parameterised by algorithm.
+```
+
+Replacement:
+
+```rst
+``nocudasim``
+   Requires a real GPU and fails under CUDASIM.
+
+``cupy``
+   Requires CuPy and fails when it is unavailable.
+
+``slow``
+   Marks slow tests. Exclude them with ``-m "not slow"``.
+
+``sim_only``
+   Runs only in CUDASIM.
+
+``specific_algos``
+   Covers non-default algorithm tableau aliases.
+
+``tests/conftest.py`` supplies session-scoped systems, solver settings,
+and tolerance fixtures. Use their default parameter sets unless a test
+requires an explicit exception.
+```
+
+Reason: marker definitions say these tests fail, not automatically skip
+(`pyproject.toml:100-105`). The shared `system` fixture currently provides the
+models listed at `tests/conftest.py:303-361`; it does not list Lotka-Volterra
+or van der Pol systems.
+
+### DG-19: test rules are framed as philosophy and omit binding constraints
+
+Location: `docs/source/developer_guide/testing.rst:62-72`
+
+Current text:
+
+```rst
+Philosophy
+----------
+
+- **Failing tests are good.**  Tests should assert intended behaviour.
+  If a test fails, fix the code, not the test (unless the test itself is
+  wrong).
+- **Prefer real objects over mocks.**  Use actual CuBIE objects and real
+  (small) ODE systems.  Never patch ``is_device`` checks or CUDA
+  availability.
+- **Never mark tests ``xfail``** or use ``importorskip`` to hide
+  failures.
+```
+
+Replacement:
+
+```rst
+Test constraints
+----------------
+
+- Assert the exact intended behavior. Do not loosen assertions or
+  tolerances to accept a failure.
+- Use the shared session-scoped fixtures and their default parameter sets.
+- Add mocks or patches only with an explicit user exception.
+- Do not patch device checks or CUDA availability.
+- Do not use ``xfail`` or ``importorskip`` to suppress failures.
+- Verify device behavior on a real GPU. CUDASIM results are a first pass.
+```
+
+Reason: the current prose qualifies the rule with an undefined exception and
+omits the project's fixture, mock, exact-assertion, and real-GPU requirements.
+The real fixture surface begins at `tests/conftest.py:303`.
+
+## API reference and batch solving
+
+### API-01: root and batch introductions add framing and mislabel solve_ivp
+
+Locations: `docs/source/API_reference/index.rst:4-6` and
+`docs/source/API_reference/batchsolving/index.rst:22-40`
+
+Current text:
+
+```rst
+The :mod:`cubie` API is organized into subpackages. The main entry point is
+:class:`cubie.batchsolving.Solver` for launching batch runs. The following
+pages describe each top-level module inside :mod:`cubie`.
+
+The :class:`Solver` interface is the main entry point. It brings together batch
+grids, array managers, GPU program builds, and system details into a coordinated
+integration pipeline, while :func:`solve_ivp` offers a shortcut for common
+workflows. Supporting modules prepare the GPU programs, describe solver
+outputs, and provide data checks used by attrs-based containers.
+
+* :doc:`solve_ivp <solve_ivp>` – convenience wrapper for single-run solver configuration.
+```
+
+Replacement:
+
+```rst
+:class:`cubie.batchsolving.Solver` configures and launches batched solves.
+The module pages document the public package API.
+
+:class:`Solver` owns system configuration, batch-grid construction, memory
+managers, compiled kernels, and results. :func:`solve_ivp` constructs a
+temporary ``Solver`` and launches the same batched solve path.
+
+* :doc:`solve_ivp <solve_ivp>`. Convenience wrapper for batch solver construction and execution.
+```
+
+Reason: `solve_ivp` forwards to `Solver` and accepts batched grids. See
+`src/cubie/batchsolving/solver.py:215-315`.
+
+### API-02: the arrays page describes per-launch mirroring that does not occur
+
+Location: `docs/source/API_reference/batchsolving/arrays.rst:23-28`
+
+Current text:
+
+```rst
+The ``batchsolving.arrays`` package coordinates host and device array
+management for batch solver runs. ``InputArrays`` and ``OutputArrays`` are the
+key classes: they collect stride metadata, request GPU allocations via
+:mod:`cubie.memory`, and expose helpers for copying data between the CPU and
+CUDA kernels. ``OutputArrays`` mirrors requested state, observable, and summary
+buffers on the host and GPU for every solver launch.
+```
+
+Replacement:
+
+```rst
+The ``batchsolving.arrays`` package owns host slots, device slots, shape
+metadata, chunk transfers, caller-supplied device inputs, and output-buffer
+loans. ``InputArrays`` stages pageable inputs through pinned buffers when
+needed. ``OutputArrays`` allocates active output slots and loans completed
+host buffers to ``SolveResult`` until the result releases them.
+```
+
+Reason: arrays are reused, reallocated only when their signatures change, and
+can remain device-only. Output buffers are loaned to results. See
+`src/cubie/batchsolving/arrays/BatchOutputArrays.py:311-364` and
+`src/cubie/batchsolving/arrays/BatchInputArrays.py:450-507`.
+
+### API-03: batch package public objects are absent from the page tree
+
+Location: `docs/source/API_reference/batchsolving/index.rst:9-49`
+
+Current text:
+
+```rst
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :titlesonly:
+
+   solver
+   solve_ivp
+   solve_result
+   solve_spec
+   batch_solver_config
+   batch_solver_kernel
+   system_interface
+
+* :doc:`Solver <solver>` – high-level manager that drives CUDA kernel launches.
+* :doc:`solve_ivp <solve_ivp>` – convenience wrapper for single-run solver configuration.
+* :doc:`SolveResult <solve_result>` – captures state, summaries, and diagnostic metadata.
+* :doc:`SolveSpec <solve_spec>` – checked configuration describing a solver invocation.
+```
+
+Replacement:
+
+```rst
+   array_types
+   batch_input_handler
+   device_solve_result
+
+* :doc:`ArrayTypes <array_types>`. Accepted host and device array types.
+* :doc:`BatchInputHandler <batch_input_handler>`. Normalizes batch grids and direct array inputs.
+* :doc:`DeviceSolveResult <device_solve_result>`. Holds views of the solver's device output buffers and its stream. Synchronize the stream before reading. Copy data that must survive the next solve.
+
+Move ``ActiveOutputs`` from the arrays subtree to the
+``BatchSolverConfig`` supporting-infrastructure group.
+```
+
+Reason: all three omitted names are public exports at
+`src/cubie/batchsolving/__init__.py:54-74`. `DeviceSolveResult` holds device
+views and the solver stream but defines no conversion method. Its lifetime and
+synchronization contract is at `src/cubie/batchsolving/solveresult.py:925-944`
+and its fields are populated at
+`src/cubie/batchsolving/solveresult.py:1002-1029`. `ActiveOutputs` resolves to
+`src/cubie/batchsolving/BatchSolverConfig.py:35`.
+
+## Integrator reference
+
+### INT-01: package index identifies an internal factory as the primary API
+
+Location: `docs/source/API_reference/integrators/index.rst:17-24`
+
+Current text:
+
+```rst
+The :class:`SingleIntegratorRun` interface is the primary entry point. It creates
+a loop callable by combining controller, algorithm, and loop submodules as
+directed by the supplied :class:`IntegratorRunSettings`.
+```
+
+Replacement:
+
+```rst
+``cubie.integrators`` contains the compiled components assembled by
+:class:`cubie.batchsolving.Solver`. ``SingleIntegratorRun`` combines an
+algorithm, controller, output callbacks, and ``IVPLoop`` into the per-run
+device function. ``IntegratorRunSettings`` is an internal settings type and
+is not exported by ``cubie.integrators``.
+```
+
+Reason: the public package export list contains `SingleIntegratorRun` but not
+`IntegratorRunSettings`; end users launch integration through the batch solver.
+See `src/cubie/integrators/__init__.py:68-93`.
+
+### INT-02: result-code API is named incorrectly
+
+Locations: `docs/source/API_reference/integrators/index.rst:39-40`,
+`docs/source/API_reference/integrators/integrator_return_codes.rst:1-8`, and
+`docs/source/API_reference/integrators/matrix_free_solvers/solver_ret_codes.rst:1-8`
+
+Current text:
+
+```rst
+* :doc:`IntegratorReturnCodes <integrator_return_codes>` – enumerates loop exit statuses.
+
+.. autoclass:: cubie.integrators.IntegratorReturnCodes
+
+.. autoclass:: cubie.integrators.matrix_free_solvers.SolverRetCodes
+```
+
+Replacement:
+
+```rst
+* :doc:`CUBIE_RESULT_CODES <integrator_return_codes>`. Bit flags reported by loops and matrix-free solvers.
+
+.. autoclass:: cubie.integrators.CUBIE_RESULT_CODES
+    :members:
+    :member-order: bysource
+
+.. autoclass:: cubie.integrators.matrix_free_solvers.CUBIE_RESULT_CODES
+    :members:
+    :member-order: bysource
+```
+
+Reason: `IntegratorReturnCodes` and `SolverRetCodes` do not exist.
+`CUBIE_RESULT_CODES` is an `IntFlag` class defined at
+`src/cubie/result_codes.py:19-58` and exported by both packages. See
+`src/cubie/integrators/__init__.py:28-36` and
+`src/cubie/integrators/matrix_free_solvers/__init__.py:29-42`.
+
+### INT-03: the linear-solver autodoc page points at removed classes
+
+Location: `docs/source/API_reference/integrators/matrix_free_solvers/linear_solver_factory.rst:1-16`
+
+Current text:
+
+```rst
+.. autoclass:: LinearSolver
+    :members:
+
+.. autoclass:: LinearSolverConfig
+    :members:
+
+.. autoclass:: LinearSolverCache
+    :members:
+```
+
+Replacement:
+
+```rst
+.. autoclass:: MRLinearSolver
+    :members:
+    :show-inheritance:
+
+.. autoclass:: MRLinearSolverConfig
+    :members:
+    :show-inheritance:
+
+.. autoclass:: BiCGSTABSolver
+    :members:
+    :show-inheritance:
+
+.. autoclass:: BiCGSTABSolverConfig
+    :members:
+    :show-inheritance:
+
+.. autoclass:: LinearSolverCache
+    :members:
+```
+
+Reason: only `LinearSolverCache` still resolves. The current public linear
+solvers and configs are exported at
+`src/cubie/integrators/matrix_free_solvers/__init__.py:29-42`.
+
+### INT-04: matrix-free overview names removed factories and nonexistent damping
+
+Location: `docs/source/API_reference/integrators/matrix_free_solvers.rst:18-56`
+
+Current text:
+
+```rst
+The ``matrix_free_solvers`` package gathers factories that build CUDA device
+functions for matrix-free linear and nonlinear solves. These factories are used
+by the integrator loops to update implicit states without forming Jacobian
+matrices. The solvers rely on :mod:`numba.cuda` for device kernels and perform
+warp-synchronisation via lightweight vote helpers.
+
+* :doc:`linear_solver_factory <matrix_free_solvers/linear_solver_factory>` – emits steepest-descent/minimal-residual CUDA
+  solvers that operate on matrix-free operators.
+* :doc:`newton_krylov_solver_factory <matrix_free_solvers/newton_krylov_solver_factory>` – wraps the linear solver to construct
+  damped Newton–Krylov iterations for implicit steps.
+* :doc:`SolverRetCodes <matrix_free_solvers/solver_ret_codes>` – enumerates solver completion status codes.
+
+``linear_solver``
+^^^^^^^^^^^^^^^^^
+
+Constructs preconditioned steepest-descent and minimal-residual solvers that
+operate on matrix-free operators. The factory emits CUDA device functions that
+maintain only vector workspaces, which keeps GPU memory usage predictable.
+
+``newton_krylov``
+^^^^^^^^^^^^^^^^^
+
+Wraps the linear solver factory to assemble damped Newton–Krylov iterations for
+implicit integration steps. The solver encodes completion status using the
+:class:`SolverRetCodes` enumeration.
+```
+
+Replacement:
+
+```rst
+The package builds matrix-free linear and nonlinear CUDA device functions.
+Implicit algorithm steps own the solver objects and supply generated
+operators, preconditioners, residuals, and scaled norms. The implementations
+import CUDA primitives from :mod:`cubie.cuda_simsafe`.
+
+* :doc:`Linear solvers <matrix_free_solvers/linear_solver_factory>`.
+  ``MRLinearSolver`` and ``BiCGSTABSolver`` apply matrix-free operators.
+* :doc:`NewtonKrylov <matrix_free_solvers/newton_krylov_solver_factory>`.
+  Newton iteration delegates each correction to an owned linear solver.
+* :doc:`CUBIE_RESULT_CODES <matrix_free_solvers/solver_ret_codes>`.
+  Shared status flags returned by device solvers and integration loops.
+```
+
+Reason: the package exports MR and BiCGSTAB solvers, and no damping or line
+search is implemented. See
+`src/cubie/integrators/matrix_free_solvers/__init__.py:29-42` and the Newton
+configuration at `src/cubie/integrators/matrix_free_solvers/newton_krylov.py:69-140`.
+
+### INT-05: algorithm-family overview treats Rosenbrock as nonlinear
+
+Location: `docs/source/API_reference/integrators/algorithms.rst:33-39`
+
+Current text:
+
+```rst
+Factories in :mod:`cubie.integrators.algorithms` assemble explicit and implicit
+step implementations that plug into the CUDA-based integrator loop. Explicit
+steps wrap direct right-hand-side evaluations, while implicit steps couple
+user-supplied device callbacks with matrix-free Newton–Krylov helpers to
+satisfy nonlinear solves. Precision handling is central: every factory
+propagates the configured precision through compiled device helpers and the
+shared linear and nonlinear solver stack.
+```
+
+Replacement:
+
+```rst
+Algorithm factories build device functions consumed by the integration
+loop. Explicit methods evaluate the right-hand side directly. Backward
+Euler, Crank-Nicolson, DIRK, and FIRK solve nonlinear stage equations with
+Newton and an owned matrix-free linear solver. Rosenbrock-W methods perform
+one matrix-free linear solve per stage without Newton iteration. Each
+factory compiles for its configured precision.
+```
+
+Reason: Rosenbrock overrides helper construction with a direct linear solver at
+`src/cubie/integrators/algorithms/generic_rosenbrock_w.py:307-364`.
+
+### INT-06: adaptive-controller selection is wrong for DIRK
+
+Location: `docs/source/API_reference/integrators/algorithms.rst:98-109`
+
+Current text:
+
+```rst
+CuBIE selects the family's tuned controller if the scheme provides
+an estimate — a PI controller for explicit Runge–Kutta, the
+Gustafsson predictive controller for the implicit families — and a
+fixed-step controller if it does not.
+This is why ``dirk`` and ``firk`` run fixed-step out of the box:
+their default tableaus carry no embedded estimate. Aliases that do
+(``radau``, for example) enable the family's adaptive defaults
+automatically.
+```
+
+Replacement:
+
+```rst
+When ``step_controller`` is unset, an estimate-bearing ERK or DIRK
+tableau selects a PI controller. Estimate-bearing FIRK and Rosenbrock
+tableaus select a Gustafsson controller. A tableau without embedded
+weights selects fixed stepping. The default DIRK and FIRK tableaus have no
+embedded weights. The ``radau`` FIRK alias has embedded weights and selects
+the FIRK adaptive defaults.
+```
+
+Reason: DIRK has order-dependent PI defaults at
+`src/cubie/integrators/algorithms/generic_dirk.py:71-93`. FIRK uses
+Gustafsson at `src/cubie/integrators/algorithms/generic_firk.py:71-84`.
+
+### INT-07: the implicit deadband statement incorrectly includes DIRK
+
+Location: `docs/source/API_reference/integrators/algorithms.rst:111-117`
+
+Current text:
+
+```rst
+The implicit family defaults use a 1.0–1.2 deadband (step-size
+increases smaller than 20% are skipped; decreases always apply),
+matching RADAU5's step-freeze band; the explicit ``erk`` defaults
+apply no deadband. Every value can be overridden per solve — see
+:doc:`/user_guide/configuration` for how kwargs reach the controller
+and :doc:`/user_guide/optional_arguments` for the full parameter
+list.
+```
+
+Replacement:
+
+```rst
+Adaptive FIRK, Rosenbrock, and Crank-Nicolson defaults use a 1.0 to 1.2
+deadband and a maximum gain of 8. Adaptive DIRK defaults use a
+``1 / 1.2`` to 1.0 deadband and a maximum gain of 10. ERK defaults have
+no deadband. Controller keyword arguments override these family defaults.
+```
+
+Reason: DIRK values are defined at
+`src/cubie/integrators/algorithms/generic_dirk.py:81-91`; FIRK and Rosenbrock
+values are at `src/cubie/integrators/algorithms/generic_firk.py:71-79` and
+`src/cubie/integrators/algorithms/generic_rosenbrock_w.py:71-79`.
+
+### INT-08: implicit-solver tolerances are derived rather than fixed at 1e-6
+
+Location: `docs/source/API_reference/integrators/algorithms.rst:133-148`
+
+Current text:
+
+```rst
+   * - ``newton_atol`` / ``newton_rtol``
+     - ``1e-6``
+   * - ``newton_max_iters``
+     - ``100``
+   * - ``krylov_atol`` / ``krylov_rtol``
+     - ``1e-6``
+   * - ``krylov_max_iters``
+     - ``100``
+```
+
+Replacement:
+
+```rst
+   * - ``newton_atol`` / ``newton_rtol``
+     - Controller ``atol`` / ``rtol`` divided by 10 when unset
+   * - ``newton_max_iters``
+     - ``100``
+   * - ``krylov_atol`` / ``krylov_rtol``
+     - Controller ``atol`` / ``rtol`` when unset
+   * - ``krylov_residual_reduction``
+     - Tightest positive controller ``rtol`` when adaptive. Divide it by
+       100 for linearly implicit steps. Use machine epsilon for
+       non-adaptive or pure-absolute control.
+   * - ``krylov_residual_floor``
+     - Square root of machine epsilon when unset
+   * - ``krylov_max_iters``
+     - ``100``
+```
+
+Reason: residual-reduction derivation is implemented at
+`src/cubie/integrators/SingleIntegratorRunCore.py:408-421`. The other
+tolerance defaults are at
+`src/cubie/integrators/SingleIntegratorRunCore.py:368-407`. The iteration
+default is `100` at
+`src/cubie/integrators/matrix_free_solvers/base_solver.py:69-75`, and residual
+fallbacks are defined at
+`src/cubie/integrators/matrix_free_solvers/linear_solver_base.py:52-63`.
+
+### INT-09: StepCache and get_algorithm_step descriptions are stale
+
+Locations: `docs/source/API_reference/integrators/algorithms.rst:150-155` and
+`docs/source/API_reference/integrators/algorithms.rst:179-182`
+
+Current text:
+
+```rst
+* :doc:`StepCache <algorithms/step_cache>` – container storing compiled kernels and loop scratch buffers.
+
+* :doc:`get_algorithm_step <algorithms/get_algorithm_step>` – resolves step factories by enum or name.
+```
+
+Replacement:
+
+```rst
+* :doc:`StepCache <algorithms/step_cache>`. Stores the compiled step function and optional nonlinear-solver function.
+
+* :doc:`get_algorithm_step <algorithms/get_algorithm_step>`. Resolves a registered string alias or a supplied ``ButcherTableau`` instance.
+```
+
+Reason: `StepCache` has only `step` and `nonlinear_solver` fields
+(`src/cubie/integrators/algorithms/base_algorithm_step.py:685-702`). The
+factory accepts strings or `ButcherTableau` instances, not enums
+(`src/cubie/integrators/algorithms/__init__.py:190-207`).
+
+### INT-10: registry tables omit current aliases and schemes
+
+Locations:
+
+- `docs/source/API_reference/integrators/algorithms/generic_erk_tableaus.rst:29-49`
+- `docs/source/API_reference/integrators/algorithms/generic_dirk_tableaus.rst:28-42`
+- `docs/source/API_reference/integrators/algorithms/generic_firk_tableaus.rst:27-32`
+
+Current text:
+
+```rst
+   * - ``"heun-21"``
+     - Heun's improved Euler method (order 2).
+     - [Heun1900]_
+   * - ``"ralston-33"``
+     - Ralston's third-order method with minimized error constants.
+     - [Ralston1962]_
+   * - ``"bogacki-shampine-32"``
+     - Bogacki--Shampine embedded 3(2) pair with FSAL property.
+     - [BogackiShampine1993]_
+   * - ``"dormand-prince-54"`` and ``"dopri54"``
+     - Dormand--Prince embedded 5(4) pair with FSAL property.
+     - [DormandPrince1980]_
+   * - ``"classical-rk4"``
+     - Classical fourth-order Runge--Kutta scheme.
+     - [Kutta1901]_
+   * - ``"cash-karp-54"``
+     - Cash--Karp embedded 5(4) pair with adaptive control weights.
+     - [CashKarp1990]_
+   * - ``"fehlberg-45"``
+     - Runge--Kutta--Fehlberg embedded 5(4) pair.
+     - [Fehlberg1969]_
+
+   * - ``"implicit_midpoint"``
+     - Single-stage implicit midpoint rule with symplectic structure.
+     - [SanzSerna1988]_
+   * - ``"trapezoidal_dirk"``
+     - Two-stage trapezoidal (Crank--Nicolson) ESDIRK scheme.
+     - [CrankNicolson1947]_
+   * - ``"sdirk_2_2"``
+     - Alexander's L-stable SDIRK pair with embedded error weights.
+     - [Alexander1977]_
+   * - ``"l_stable_dirk_3"``
+     - Three-stage, third-order L-stable SDIRK scheme with stiff accuracy.
+     - [MOOSELStableDirk3]_
+   * - ``"l_stable_sdirk_4"``
+     - Hairer--Wanner five-stage, fourth-order L-stable SDIRK tableau.
+     - [HairerWanner1996]_
+
+   * - ``"firk_gauss_legendre_2"``
+     - Two-stage fourth-order Gauss--Legendre scheme with symplectic structure.
+     - [HairerLubichWanner2006FIRK]_
+   * - ``"radau_iia_5"`` and ``"radau"``
+     - Three-stage fifth-order Radau IIA method with stiff accuracy.
+     - [HairerWanner1996FIRK]_
+```
+
+Replacement:
+
+```rst
+Add a row for each registry alias. Group aliases that map to the same tableau.
+Document ``dormand-prince-853`` as order 8, ``tsit5`` as the Tsitouras
+5(4) pair, ``vern7`` as the Verner 7(6) pair, ``kvaerno3`` and
+``kvaerno5`` as their registered ESDIRK tableaus, and
+``firk_gauss_legendre_4`` as the four-stage order-eight fixed-step
+Gauss-Legendre method.
+```
+
+Reason: exact registry keys are at
+`src/cubie/integrators/algorithms/generic_erk_tableaus.py:751-771`,
+`src/cubie/integrators/algorithms/generic_dirk_tableaus.py:429-438`, and
+`src/cubie/integrators/algorithms/generic_firk_tableaus.py:219-224`. The
+order-eight FIRK definition is at
+`src/cubie/integrators/algorithms/generic_firk_tableaus.py:157-207`.
+
+### INT-11: DIRK and FIRK descriptions imply every tableau is adaptive
+
+Locations: `docs/source/API_reference/integrators/algorithms/generic_dirk_step.rst:6-11`
+and `docs/source/API_reference/integrators/algorithms/generic_firk_step.rst:6-11`
+
+Current text:
+
+```rst
+:class:`DIRKStep` provides a diagonally implicit Runge--Kutta integrator that
+solves stage systems with the cached Newton--Krylov helpers supplied by
+:mod:`cubie.integrators.matrix_free_solvers`. The factory consumes
+:class:`~cubie.integrators.algorithms.generic_dirk.DIRKTableau` instances,
+exposing L-stable SDIRK and ESDIRK schemes for stiff problems while preserving
+adaptive error control through embedded weights.
+
+:class:`FIRKStep` provides a fully implicit Runge--Kutta integrator that solves
+coupled stage systems with the cached Newton--Krylov helpers supplied by
+:mod:`cubie.integrators.matrix_free_solvers`. The factory consumes
+:class:`~cubie.integrators.algorithms.generic_firk_tableaus.FIRKTableau`
+instances, exposing high-order Gauss--Legendre and Radau IIA schemes for stiff
+problems while preserving adaptive error control through embedded weights.
+```
+
+Replacement:
+
+```rst
+``DIRKStep`` solves each stage with its owned Newton and matrix-free linear
+solver. A tableau with embedded weights produces the error estimate used
+by adaptive control.
+A tableau without embedded weights uses fixed stepping by default.
+
+``FIRKStep`` solves all stages as one coupled Newton system. Radau IIA-5
+has embedded weights. The registered Gauss-Legendre tableaus do not and
+use fixed stepping by default.
+```
+
+Reason: controller selection tests `tableau.has_error_estimate`; the default
+DIRK and FIRK tableaus have no `b_hat`. See
+`src/cubie/integrators/algorithms/generic_dirk.py:81-99` and
+`src/cubie/integrators/algorithms/generic_firk.py:71-84`.
+
+### INT-12: Rosenbrock page claims a Jacobian factorization
+
+Location: `docs/source/API_reference/integrators/algorithms/generic_rosenbrock_step.rst:6-11`
+
+Current text:
+
+```rst
+:class:`GenericRosenbrockWStep` provides a linearly implicit Rosenbrock-W
+integrator that requires only one Jacobian factorisation per step. The factory
+consumes
+:class:`~cubie.integrators.algorithms.generic_rosenbrockw_tableaus.RosenbrockTableau`
+instances and couples user-supplied device callbacks with matrix-free linear
+solves from :mod:`cubie.integrators.matrix_free_solvers`.
+```
+
+Replacement:
+
+```rst
+:class:`GenericRosenbrockWStep` prepares cached Jacobian auxiliaries once
+per step and performs one matrix-free linear solve per stage. It does not
+materialize or factor a Jacobian matrix. The factory consumes
+:class:`~cubie.integrators.algorithms.generic_rosenbrockw_tableaus.RosenbrockTableau`
+instances.
+```
+
+Reason: helper construction requests `PREPARE_JAC` metadata and a cached
+matrix-free operator, then installs the linear-solver device function. See
+`src/cubie/integrators/algorithms/generic_rosenbrock_w.py:307-364`.
+
+### INT-13: suggested controller table does not describe the API or defaults
+
+Location: `docs/source/API_reference/integrators/step_control.rst:69-107`
+
+Current text:
+
+```rst
+Suggested controller parameters
+-------------------------------
+
+The default proportional, integral, and derivative gains mirror the
+recommendations from Söderlind and Wang while matching the guidance in
+`OrdinaryDiffEq.jl <https://github.com/SciML/OrdinaryDiffEq.jl>`_. Common
+choices include:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Controller
+     - ``beta1``
+     - ``beta2``
+     - ``beta3``
+   * - basic
+     - 1.00
+     - 0.00
+     - 0
+   * - PI42
+     - 0.60
+     - -0.20
+     - 0
+   * - PI33
+     - 2/3
+     - -1/3
+     - 0
+   * - PI34
+     - 0.70
+     - -0.40
+     - 0
+   * - H211PI
+     - 1/6
+     - 1/6
+     - 0
+   * - H312PID
+     - 1/18
+     - 1/9
+     - 1/18
+```
+
+Replacement:
+
+```rst
+Configuration defaults
+----------------------
+
+The adaptive base config defaults to ``dt_min=1e-6``, ``dt_max=1.0``,
+``min_gain=0.3``, ``max_gain=2.0``, ``safety=0.9``, and a 1.0 to 1.2
+deadband. ``PIStepControlConfig`` adds ``kp=0.7`` and ``ki=-0.4``.
+``PIDStepControlConfig`` adds ``kd=0.0``. Gustafsson adds
+``newton_target_iters=20``. Algorithm-family configs override these base
+values at construction.
+```
+
+Reason: current config fields use `kp`, `ki`, and `kd`, not beta names. See
+`src/cubie/integrators/step_control/adaptive_step_controller.py:84-118`,
+`src/cubie/integrators/step_control/adaptive_PI_controller.py:48-69`,
+`src/cubie/integrators/step_control/adaptive_PID_controller.py:51-60`, and
+`src/cubie/integrators/step_control/gustafsson_controller.py:53-74`.
+
+### INT-14: ODELoopConfig does not itself describe computed layouts
+
+Location: `docs/source/API_reference/integrators/loops.rst:7-12`
+
+Current text:
+
+```rst
+Supporting
+configuration classes in :mod:`cubie.integrators.loops.ode_loop_config` describe
+shared and persistent local memory layouts expected during kernel launches.
+```
+
+Replacement:
+
+```rst
+``ODELoopConfig`` stores loop dimensions, callbacks, tolerances, and buffer
+location settings. The buffer registry derives shared and persistent
+layouts from the registered loop and child requirements.
+```
+
+Reason: layout computation belongs to `BufferRegistry`; its query and allocator
+methods are at `src/cubie/buffer_registry.py:948-997` and
+`src/cubie/buffer_registry.py:1079-1110`.
+
+### INT-15: exported integrator API and supporting capabilities lack pages
+
+Locations: `docs/source/API_reference/integrators/index.rst:9-40`,
+`docs/source/API_reference/integrators/matrix_free_solvers.rst:9-31`, and
+`docs/source/API_reference/integrators/algorithms.rst:9-31`
+
+Current text:
+
+```rst
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :titlesonly:
+
+   single_integrator_run
+   integrator_return_codes
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :titlesonly:
+
+   matrix_free_solvers/linear_solver_factory
+   matrix_free_solvers/newton_krylov_solver_factory
+   matrix_free_solvers/solver_ret_codes
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :titlesonly:
+
+   algorithms/base_step_config
+   algorithms/base_algorithm_step
+   algorithms/step_cache
+   algorithms/explicit_step_config
+   algorithms/explicit_euler_step
+   algorithms/implicit_step_config
+   algorithms/backwards_euler_step
+   algorithms/backwards_euler_pc_step
+   algorithms/crank_nicolson_step
+   algorithms/generic_erk_step
+   algorithms/generic_erk_tableaus
+   algorithms/generic_dirk_step
+   algorithms/generic_dirk_tableaus
+   algorithms/generic_firk_step
+   algorithms/generic_firk_tableaus
+   algorithms/generic_rosenbrock_step
+   algorithms/generic_rosenbrock_tableaus
+   algorithms/get_algorithm_step
+```
+
+Replacement:
+
+```rst
+Add resolved API entries for ``MRLinearSolver``,
+``MRLinearSolverConfig``, ``BiCGSTABSolver``, ``BiCGSTABSolverConfig``,
+``CUBIE_RESULT_CODES``, and ``algorithm_is_adaptive``. Add internal
+architecture references for ``SingleIntegratorRunCore``,
+``IntegratorRunSettings``, scaled norms, dense stage prediction, and
+automatic memory heuristics where those settings are explained.
+```
+
+Reason: the public exports are listed at `src/cubie/integrators/__init__.py:68-93`
+and `src/cubie/integrators/algorithms/__init__.py:31-53`. Current internal
+composition also depends on `SingleIntegratorRunCore`, `norms`,
+`stage_predictors`, and `memory_heuristics`.
+
+## Punctuation and AI-language sweep for authored RST prose
+
+### STYLE-RST-01: every em dash and semicolon in scoped RST prose
+
+Each row gives the exact current line and exact replacement. RST directive
+syntax, citation-title colons, and code tokens are excluded because they are not
+authored sentence punctuation.
+
+| Location | Current text | Replacement |
+|---|---|---|
+| `algorithms.rst:48` | `(``algorithm="erk"``) uses the defaults below; requesting a specific` | `(``algorithm="erk"``) selects the family defaults. A specific` |
+| `algorithms.rst:84` | `- Fixed step — the default tableau has no error estimate` | `- Fixed step because the default tableau has no error estimate` |
+| `algorithms.rst:89` | `- Fixed step — the default tableau has no error estimate` | `- Fixed step because the default tableau has no error estimate` |
+| `algorithms.rst:101` | `an estimate — a PI controller for explicit Runge–Kutta, the` | `an estimate. ERK and DIRK use a PI controller. FIRK and Rosenbrock use the` |
+| `algorithms.rst:102` | `Gustafsson predictive controller for the implicit families — and a` | `Gustafsson predictive controller. A scheme without an estimate uses a` |
+| `algorithms.rst:112` | `increases smaller than 20% are skipped; decreases always apply),` | `increases smaller than 20% are skipped. Decreases always apply.` |
+| `algorithms.rst:113` | `matching RADAU5's step-freeze band; the explicit ``erk`` defaults` | `The explicit ``erk`` defaults` |
+| `algorithms.rst:114` | `apply no deadband. Every value can be overridden per solve — see` | `apply no deadband. Controller keyword arguments override these values.` |
+| `backwards_euler_pc_step.rst:10` | ``:doc:`BackwardsEulerStep <backwards_euler_step>` — order 1,`` | ``:doc:`BackwardsEulerStep <backwards_euler_step>`. It uses order 1,`` |
+| `backwards_euler_pc_step.rst:12` | ``(:ref:`algorithm-defaults`) — adding only an explicit forward-Euler`` | ``(:ref:`algorithm-defaults`). The method adds an explicit forward-Euler`` |
+| `backwards_euler_step.rst:10-11` | `backward-Euler update under fixed-step control; the method carries`<br>`no embedded error estimate, so adaptive control is unavailable. Each` | `backward-Euler update under fixed-step control.`<br>`The method carries no embedded error estimate, so adaptive control is unavailable. Each` |
+| `crank_nicolson_step.rst:10-11` | `update and runs a backward-Euler companion solve each step; the`<br>`difference between the two supplies an embedded error estimate, so` | `update and runs a backward-Euler companion solve each step.`<br>`The difference between the two supplies an embedded error estimate, so` |
+| `generic_dirk_step.rst:18` | `no embedded error estimate, so the default is fixed-step control;` | `no embedded error estimate, so the default is fixed-step control.` |
+| `generic_dirk_tableaus.rst:15` | `The :class:\`DIRKStep\` factory defaults to \`\`"l_stable_dirk_3"\`\`—a` | `The :class:\`DIRKStep\` factory defaults to \`\`"l_stable_dirk_3"\`\`, a` |
+| `generic_erk_step.rst:16` | `tableau — explicit Dormand–Prince 5(4), seven stages, with an` | `tableau. Dormand-Prince 5(4) is explicit, has seven stages, and provides an` |
+| `generic_erk_step.rst:17` | `embedded fourth-order error estimate — under adaptive PI control` | `embedded fourth-order error estimate. It uses adaptive PI control` |
+| `generic_erk_step.rst:20` | `the same scheme; the other named schemes in the` | `the same scheme. The other named schemes in the` |
+| `generic_firk_step.rst:21` | `control; tableaus that provide one — ``radau`` (Radau IIA-5), for` | `control. ``radau`` provides an estimate. It is the Radau IIA-5 method and` |
+| `generic_firk_step.rst:22` | `example — enable the family's Gustafsson predictive defaults` | `selects the family's Gustafsson predictive defaults` |
+| `generic_rosenbrock_step.rst:19` | `0.2–8.0×). Rosenbrock-W methods are linearly implicit —` | `0.2 to 8.0 times). Rosenbrock-W methods are linearly implicit.` |
+| `generic_rosenbrock_step.rst:21` | `iteration — so of the solver settings in` | `iteration. Of the solver settings in` |
+| `generic_rosenbrock_step.rst:23` | `defaults apply; the ``newton_*`` parameters do not.` | `defaults apply. The ``newton_*`` parameters do not.` |
+| `buffer_registry.rst:34` | `precision; buffers that differ (e.g. ``np.int32`` iteration` | `precision. Buffers that differ, such as ``np.int32`` iteration` |
+| `codegen.rst:5` | `functions.  SymPy is the parse layer for string and SymPy input; every` | `functions. SymPy parses string and SymPy input. Every` |
+| `codegen.rst:7` | ```engine`` package) at the parse boundary, and every later stage —` | ```engine`` package) at the parse boundary. Every later stage, including` |
+| `codegen.rst:9` | `hashing, and printing — runs on the IR.  This page describes the` | `hashing and printing, runs on the IR.` |
+| `codegen.rst:65` | ```print_cuda_multiple`` renders a list of assignments as source lines;` | ```print_cuda_multiple`` renders a list of assignments as source lines.` |
+| `testing.rst:28` | `Test requires a real GPU; skip in CUDASIM mode.` | `Requires a real GPU and fails under CUDASIM.` |
+| `testing.rst:31` | `Test requires CuPy; skip if not installed.` | `Requires CuPy and fails when it is unavailable.` |
+| `testing.rst:34` | `Long-running test; useful with ``-m "not slow"`` for quick` | `Marks a slow test. Exclude it with ``-m "not slow"``.` |
+
+Factual replacements take precedence where line ranges overlap.
+
+### STYLE-RST-02: prose colons
+
+Rewrite these non-structural uses.
+
+| Location | Current text | Disposition |
+|---|---|---|
+| `architecture.rst:53-55` | ``update()`` returns two sets: the names... | Merged into DG-09. |
+| `codegen.rst:54-57` | `compute phase runs on: nodes are interned...` and `source:` | Merged into DG-15. |
+| `batchsolving/arrays.rst:25-28` | `key classes: they collect...` | Merged into API-02. |
+| `integrators/algorithms.rst:37-39` | `Precision handling is central: every factory...` | Merged into INT-05. |
+| `integrators/algorithms.rst:76` | `Gustafsson predictive: gain clamp...` | `Gustafsson predictive with gain clamp 0.2 to 8.0` |
+| `integrators/algorithms.rst:80` | `PI: ``kp=...`` ` | `PI with ``kp=...`` ` |
+| `integrators/algorithms.rst:93` | `Gustafsson predictive: gain clamp...` | `Gustafsson predictive with gain clamp 0.2 to 8.0` |
+| `integrators/algorithms.rst:104` | `This is why ... out of the box:` | Merged into INT-06. |
+| `integrators/algorithms.rst:125` | `linearly implicit: it performs...` | `linearly implicit. It performs...` |
+
+Retain these colon categories because they perform required syntax or introduce
+a directly adjacent code block, list, or definition list.
+
+- RST directives, roles, options, and literal-block markers.
+- Numpydoc-style field lists rendered through autodoc.
+- `adding_algorithms.rst:12,32,44,67` and
+  `adding_metrics.rst:19,73,89`, which introduce code or enumerated content.
+- `architecture.rst:11,27`, `buffer_registry.rst:12,41,58`, and
+  `step_control.rst:75`, which introduce literal, code, or definition lists.
+- Citation titles at `generic_dirk_tableaus.rst:65` and
+  `generic_firk_tableaus.rst:47`.
+
+### STYLE-FRAME-01: detected AI-language tells in RST prose
+
+| Location | Tell | Disposition |
+|---|---|---|
+| `developer_guide/index.rst:4-7` | Reader framing | Merged into DG-00. |
+| `adding_algorithms.rst:4-6` | “designed to make ... straightforward” | Merged into DG-01. |
+| `adding_algorithms.rst:11` | “The simplest case.” | Merged into DG-01. |
+| `adding_metrics.rst:4-6` | “This page walks through” | Merged into DG-04. |
+| `architecture.rst:4-6` | “Understanding these is essential” | Merged into DG-07. |
+| `API_reference/index.rst:4-6` | “main entry point” and “following pages” framing | Merged into API-01. |
+| `batchsolving/index.rst:22-26` | “main entry point” and “Supporting modules” framing | Merged into API-01. |
+| `batchsolving/arrays.rst:25` | “key classes” intensifier | Merged into API-02. |
+| `integrators/index.rst:17-19` | “primary entry point” | Merged into INT-01. |
+| `integrators/algorithms.rst:37` | “Precision handling is central” | Merged into INT-05. |
+| `integrators/algorithms.rst:104` | “This is why” | Merged into INT-06. |
+| `developer_guide/buffer_registry.rst:78-81` | “the main tool” | `Alias buffers whose lifetimes do not overlap to reduce shared-memory use. Register intermediate stage vectors as aliases of the output writeback buffer when their lifetimes do not overlap.` |
+| `algorithms/generic_erk_tableaus.rst:6-10` | “human-friendly”, “well-known”, and “without manually specifying” | ``ERK_TABLEAU_REGISTRY`` maps string aliases to ``ERKTableau`` instances. Pass a registered alias to ``get_algorithm_step`` to select its coefficients. |
+| `algorithms/generic_erk_tableaus.rst:15-18` | “so existing controller presets continue to work” | `The default ``ERKStep`` tableau is Dormand-Prince 5(4). ``dopri54``, ``rk45``, and ``ode45`` select the same tableau as ``dormand-prince-54``.` |
+| `algorithms/generic_rosenbrock_tableaus.rst:6-10` | “human-friendly” and “without manually specifying” | ``ROSENBROCK_TABLEAUS`` maps string aliases to ``RosenbrockTableau`` instances. Pass a registered alias to ``get_algorithm_step`` to select its coefficients. |
+
+No false-drama staccato of the form “That's it” or “That's the tweet” appears in
+the scoped RST prose.
+
+## Autodoc-rendered source docstrings
+
+Source locations in the STYLE-DOC tables are relative to `src/cubie`. Paths
+beginning with `arrays/` are relative to `src/cubie/batchsolving`, paths
+beginning with `algorithms/`, `loops/`, `matrix_free_solvers/`, or
+`step_control/` are relative to `src/cubie/integrators`, and unprefixed batch
+module names are relative to `src/cubie/batchsolving`.
+
+### STYLE-DOC-01: all seven rendered em-dash lines
+
+| Location | Current text | Replacement |
+|---|---|---|
+| `src/cubie/batchsolving/BatchSolverKernel.py:845` | `no alternative — there a sub-warp block is a launchability` | `no alternative. A sub-warp block is then a launchability` |
+| `src/cubie/batchsolving/BatchSolverKernel.py:1633` | ``ArrayInterpolator.coefficients_shape`` — the exact` | ``ArrayInterpolator.coefficients_shape``, which is the exact` |
+| `src/cubie/batchsolving/BatchSolverKernel.py:1635` | `the compiled driver evaluators — so supplied coefficient` | `the compiled driver evaluators. Supplied coefficient` |
+| `src/cubie/batchsolving/solver.py:377` | `— everything smaller is pageable RAM the operating system` | `Everything smaller uses pageable RAM that the operating system` |
+| `src/cubie/batchsolving/solver.py:685` | ``SolveResult`` owning the solve's host output buffers —` | ``SolveResult`` that owns the solve's host output buffers.` |
+| `src/cubie/batchsolving/solveresult.py:198` | `The result takes the solve's host buffers wholesale — no copies.` | `The result takes ownership of the solve's host buffers without copying them.` |
+| `src/cubie/batchsolving/solveresult.py:470` | `buffer — no copy, no RAM beyond what the solve already used.` | `buffer without copying it or allocating another in-memory array.` |
+
+Reason: these source docstrings render into the scoped API pages through
+`:members:`. The replacements remove the disallowed punctuation without
+changing behavior.
+
+### STYLE-DOC-02: all 32 rendered semicolon lines
+
+| Location | Current text | Replacement |
+|---|---|---|
+| `BatchSolverConfig.py:146` | `occupancy to one block per SM); capping trades spill traffic` | `occupancy to one block per SM). Capping trades spill traffic` |
+| `BatchSolverConfig.py:152` | ``ArrayInterpolator.coefficients_shape``; input sizing and` | ``ArrayInterpolator.coefficients_shape``. Input sizing and` |
+| `BatchSolverConfig.py:159` | ``{algorithm}_{system name}``; the LTO state is appended as` | ``{algorithm}_{system name}``. The LTO state is appended as` |
+| `arrays/BaseArrayManager.py:567` | `Owner's spill threshold; None without an owner.` | `Return the owner's spill threshold or ``None`` without an owner.` |
+| `arrays/BaseArrayManager.py:574` | `Owner's spill directory; None without an owner.` | `Return the owner's spill directory or ``None`` without an owner.` |
+| `arrays/BaseArrayManager.py:922` | `to their slots and are reused; otherwise the next solve` | `to their slots and are reused. Otherwise the next solve` |
+| `arrays/BaseArrayManager.py:1003` | `values are ignored. Used for output arrays, which the kernel` | `values are ignored. Output arrays use this path because the kernel` |
+| `BatchSolverKernel.py:575` | `or device arrays are accepted; device arrays are used in` | `or device arrays are accepted. Device arrays are used in` |
+| `BatchSolverKernel.py:594` | `so results stay in the device output buffers; the run must` | `so results stay in the device output buffers. The run must` |
+| `BatchSolverKernel.py:603` | `memory-manager stream (:attr:`stream`); there is no per-run` | `memory-manager stream (:attr:`stream`). There is no per-run` |
+| `BatchSolverKernel.py:839` | `32 kiB footprint (three blocks per SM on CC7* hardware;` | `32 kiB footprint, which fits three blocks per SM on CC7* hardware.` |
+| `arrays/BatchInputArrays.py:335` | `supplied on device; otherwise the host array.` | `supplied on device. Otherwise it returns the host array.` |
+| `arrays/BatchInputArrays.py:346` | `supplied on device; otherwise the host array.` | `supplied on device. Otherwise it returns the host array.` |
+| `solver.py:242` | `parameter names and defaults from a ``parameters`` dict; for` | `parameter names and defaults from a ``parameters`` dict. For` |
+| `solver.py:294` | `representations on demand; disk-backed results release their` | `representations on demand. Disk-backed results release their` |
+| `solver.py:373` | `Memory configuration; each key may also be a keyword argument.` | `Memory configuration. Each setting accepts a corresponding keyword argument.` |
+| `solver.py:375` | `result arrays are disk-backed instead of held in RAM; by` | `result arrays are disk-backed instead of held in RAM. By` |
+| `solver.py:381` | `directory); point it at a fast disk for large spilled runs.` | `directory). Use a fast disk for large spilled runs.` |
+| `solver.py:383` | `another solver faces a genuine VRAM shortage; the evicted` | `another solver faces a VRAM shortage. The evicted` |
+| `solver.py:396` | `calibrated per GPU architecture; cards without a calibrated` | `calibrated per GPU architecture. Cards without a calibrated` |
+| `solver.py:398` | `arguments always take precedence; pass ``False`` to keep` | `arguments always take precedence. Pass ``False`` to keep` |
+| `solver.py:647` | `Numba) are used in place with no host-to-device transfer;` | `Numba) are used in place with no host-to-device transfer.` |
+| `solver.py:677` | `solve ran on; see Notes. Default ``False``.` | `solve ran on. Default ``False``.` |
+| `solver.py:689` | `and ``as_pandas`` build RAM representations on demand;` | `and ``as_pandas`` build RAM representations on demand.` |
+| `solver.py:1114` | `names set in that run's status word; successful runs are` | `names set in that run's status word. Successful runs are` |
+| `solveresult.py:330-331` | `after the result has been garbage collected; while the result`<br>`lives, the next run allocates fresh backing.` | `after the result has been garbage collected.`<br>`Starting another solve before releasing the result allocates fresh backing.` |
+| `algorithms/generic_dirk.py:225` | `Request dense stage prediction; ignored when the tableau` | `Request dense stage prediction. The setting is ignored when the tableau` |
+| `algorithms/generic_dirk_tableaus.py:97` | `solve from that stage's converged increment; every other` | `solve from that stage's converged increment. Every other` |
+| `algorithms/generic_firk.py:224` | `Request dense stage prediction; ignored when the tableau` | `Request dense stage prediction. The setting is ignored when the tableau` |
+| `loops/ode_loop_config.py:251` | `(≤ 0.01) is accepted with a warning; larger deviations raise` | `(≤ 0.01) is accepted with a warning. Larger deviations raise` |
+| `matrix_free_solvers/newton_krylov.py:135` | `are not included here; access them via solver.newton_atol` | `are not included here. Access them through ``solver.newton_atol``` |
+| `step_control/base_step_controller.py:177` | `error norms with it; every controller carries it so implicit` | `error norms with it. Every controller carries it so implicit` |
+
+Reason: all lines render through the 54 resolved autodoc targets. The
+replacement sentences preserve the documented behavior.
+
+### STYLE-DOC-03: rendered prose colons and framing tells
+
+Rewrite these non-structural colons.
+
+| Location | Current text | Replacement |
+|---|---|---|
+| `BatchSolverConfig.py:96` | `Maps OutputCompileFlags to ActiveOutputs:` | `Map output compile flags to active outputs.` |
+| `arrays/BaseArrayManager.py:942` | `A live owner keeps its buffers: the loan record is dropped so` | `A live owner keeps its buffers. The loan record is dropped so` |
+| `BatchSolverKernel.py:841` | `floored at one warp: profiling shows sub-warp blocks starve` | `floored at one warp. Profiling shows sub-warp blocks starve` |
+| `arrays/BatchInputArrays.py:94` | `Memory type for host arrays: "pinned" or "host".` | `Memory type for host arrays. Accepted values are ``"pinned"`` and ``"host"``.` |
+| `arrays/BatchInputArrays.py:466` | `method never blocks on the stream: with the pool deep enough,` | `method never blocks on the stream. With a sufficiently deep pool,` |
+| `arrays/BatchOutputArrays.py:117` | `Memory type for host arrays: "pinned" or "host".` | `Memory type for host arrays. Accepted values are ``"pinned"`` and ``"host"``.` |
+| `solver.py:702` | `Device arrays are used in place: no grid construction and` | `Device arrays are used in place. No grid construction or` |
+| `solver.py:708` | ``on_device=True`` returns without synchronizing: buffer` | ``on_device=True`` returns without synchronizing. Buffer` |
+| `algorithms/ode_implicitstep.py:105` | `The mass matrix is not an algorithm parameter: it belongs to the` | `The mass matrix belongs to the ODE system.` |
+| `matrix_free_solvers/linear_solver_base.py:83` | `against: ``"state"`` ...` | `against. Use ``"state"`` ...` |
+| `matrix_free_solvers/newton_krylov.py:134` | `Configuration dictionary. Note: newton_atol and newton_rtol` | `Configuration dictionary. ``newton_atol`` and ``newton_rtol``` |
+
+Retain the other 132 colon-bearing rendered lines. They are Sphinx roles,
+numpydoc field declarations, or direct introductions to adjacent lists and
+examples. The retained direct list introductions are
+`solver.py:412,696`, `SystemInterface.py:71`,
+`generic_dirk.py:234,236,239`, `generic_erk.py:200,202,204`,
+`generic_firk.py:233,235,237`, and
+`generic_rosenbrock_w.py:207,209,212`.
+
+Rewrite these framing tells from rendered docstrings.
+
+| Location | Current text | Replacement |
+|---|---|---|
+| `arrays/BaseArrayManager.py:414-416` | `This method sets the num_runs attribute to specify the total number of runs in the batch. This value is used during allocation to determine chunking behavior.` | `Set ``num_runs`` on every managed array for allocation and chunking.` |
+| `arrays/BatchOutputArrays.py:315-318` | `Create an OutputArrays instance from a solver. Does not allocate arrays, just sets up size specifications.` | `Create output-array metadata from a solver without allocating arrays.` |
+| `solveresult.py:326-331` | `Create a SolveResult owning the solver's buffers. The solver's host output buffers are handed to the result without copying. The solver reuses them on its next run only after the result has been garbage collected; while the result lives, the next run allocates fresh backing.` | `Transfer ownership of the solver's host output buffers to a new ``SolveResult`` without copying them. The solver reuses the buffers after the result is collected. Starting another solve before releasing the result allocates new backing.` |
+| `SystemInterface.py:139-140` | `The method attempts to update both parameters and states. Updates are applied to whichever :class:\`SystemValues\` object recognizes each key.` | `Apply each recognized key to the matching parameter or state ``SystemValues`` object.` |
+| `algorithms/base_algorithm_step.py:708-711` | `The class exposes properties and an ``update`` helper shared by concrete explicit and implicit algorithms. Concrete subclasses implement ``build`` to compile device helpers and provide metadata about resource usage.` | `Provide cache, update, and resource interfaces shared by concrete algorithm steps. Concrete subclasses implement ``build`` and resource metadata.` |
+| `BatchSolverKernel.py:1072-1073` | `The method applies updates to the single integrator before refreshing compile-critical settings so the kernel rebuild picks up new metadata.` | `Apply updates to the single integrator, then refresh compile-critical kernel settings.` |
+
+No false-drama staccato was found in the rendered source docstrings.
+
+### STYLE-PROSPECTIVE-01: docstrings for proposed missing API pages
+
+The proposed `BatchInputHandler`, `DeviceSolveResult`, `BiCGSTABSolver`, and
+`BiCGSTABSolverConfig` pages would render these additional findings.
+
+| Location | Current text | Replacement |
+|---|---|---|
+| `BatchInputHandler.py:513` | `Disk-backing size in bytes; ``None`` = the RAM default.` | `Disk-backing size in bytes. ``None`` uses the RAM default.` |
+| `BatchInputHandler.py:515` | `Directory for disk-backed arrays; ``None`` = temp dir.` | `Directory for disk-backed arrays. ``None`` uses the temporary directory.` |
+| `BatchInputHandler.py:565` | `Disk-backing size in bytes; ``None`` = the RAM default.` | `Disk-backing size in bytes. ``None`` uses the RAM default.` |
+| `BatchInputHandler.py:567` | `Directory for disk-backed arrays; ``None`` = temp dir.` | `Directory for disk-backed arrays. ``None`` uses the temporary directory.` |
+| `matrix_free_solvers/bicgstab_solver.py:94-98` | `(default) auto-selects: ``"shared"`` when ``n * itemsize`` lies in the measured DRAM-bound window [``SHARED_WITNESS_MIN_BYTES``, ``SHARED_WITNESS_MAX_BYTES``], ``"local"`` otherwise. Pass ``"local"`` or ``"shared"`` to override.` | `The default selects ``"shared"`` when ``n * itemsize`` lies in the measured DRAM-bound window [``SHARED_WITNESS_MIN_BYTES``, ``SHARED_WITNESS_MAX_BYTES``]. It selects ``"local"`` otherwise. Pass either value to override the selection.` |
+| `matrix_free_solvers/bicgstab_solver.py:172` | `Uses 5 work vectors: r0_hat, p, v, tmp, s_hat.` | `Uses five work vectors named ``r0_hat``, ``p``, ``v``, ``tmp``, and ``s_hat``.` |
+
+Replace the full `DeviceSolveResult` class opening at
+`src/cubie/batchsolving/solveresult.py:928-944`.
+
+Current text:
+
+```python
+Returned by :meth:`Solver.solve` when ``on_device=True``. Nothing
+is copied to the host: the fields are the solver's device output
+buffers plus the kernel's memory-manager stream — the stream
+every launch and transfer for that solver runs on. The solve does
+not synchronize before returning — buffer contents are valid once
+:attr:`stream` has been synchronized, and work queued on that
+stream executes in order after the solve.
+
+This class holds handles only; it performs no stream or memory
+operations. Callers queue follow-up device work on
+:attr:`stream`, and read on the host by synchronizing that stream
+first (or run a normal host solve instead).
+
+The handles are views into the solver's working buffers: the next
+``solve()`` on the same solver overwrites their contents, and a
+reallocation or memory-pressure eviction detaches them from the
+solver. Copy anything that must outlive the next solve.
+```
+
+Replacement:
+
+```python
+Returned by :meth:`Solver.solve` when ``on_device=True``. The fields
+hold the solver's device output buffers and the memory-manager stream
+used by solver launches and transfers. The solve returns without
+synchronizing. Buffer contents are valid after :attr:`stream` is
+synchronized. Work queued on that stream executes in order after the
+solve.
+
+The object performs no stream or memory operations. Queue follow-up
+device work on :attr:`stream`. Synchronize that stream before reading
+the buffers on the host. A normal host solve performs host transfers.
+
+The handles are views into the solver's working buffers. The next
+``solve()`` on the same solver overwrites their contents. Reallocation
+or memory-pressure eviction detaches them from the solver. Copy data
+that must survive the next solve.
+```
+
+Reason: these four public objects are proposed in API-03 and INT-03, so their
+rendered docstrings must pass the same style audit before pages are added. The
+current behavior and lifetime contract for `DeviceSolveResult` is defined at
+`src/cubie/batchsolving/solveresult.py:925-944`.

--- a/docs/review/completeness_freshness_inventory.md
+++ b/docs/review/completeness_freshness_inventory.md
@@ -1,0 +1,109 @@
+# Completeness and freshness ledger
+
+## Repository coverage
+
+| Receipt | Result |
+|---|---|
+| Tracked entries | 585 |
+| Regular tracked files | 566 |
+| Tracked symbolic links | 19 |
+| Exact preassigned lane coverage | 524 entries |
+| Exact repository-support complement | 61 entries |
+| reStructuredText pages | 149 |
+| Missing or unreferenced toctree pages | 0 |
+| Binary assets | 1 NPZ file, inventoried without text claims |
+| Nested systems-lane instruction files | 10 files and 1,068 lines |
+
+Every tracked text file was read by at least one lane. Human-authored prose,
+code, tests, and configuration were read line by line. Generated inventories,
+schemas, and fixtures were traversed in full and received format-specific
+validation. Symbolic-link mirrors were reconciled with their targets.
+
+## Documentation page coverage
+
+| Page group | Pages | Result |
+|---|---:|---|
+| User-facing, tutorial, theory, and guide pages | 29 | Read and source-checked |
+| Developer, batch, and integrator API pages | 69 | Read and source-checked |
+| Memory, ODE-system, output, and GUI API pages | 51 | Read and source-checked |
+| Total | 149 | Complete |
+
+All 149 pages are reachable from the Sphinx page tree. Fifty-eight autodoc
+directives in the batch and integrator lane were checked. Fifty-four resolve
+and four name removed objects. Forty-nine directives in the systems and output
+lane were checked. One uses the wrong directive type. Seven optional GUI
+targets exist statically but could not be imported without `qtpy`.
+
+Sphinx is absent from the system Python and project virtual environment. No
+documentation build was run. The exact failed import is recorded in
+[systems_output_inventory.md](systems_output_inventory.md).
+
+## Freshness priorities
+
+### Build and navigation
+
+- `docs/source/conf.py` reports release `0.0.4`. `pyproject.toml` reports
+  `0.4.0`. See UFR-004.
+- The landing page uses a former repository URL and the wrong Reference Manual
+  target. See UFR-005.
+- Four integrator API directives name removed objects. See INT-02, INT-03, and
+  INT-04.
+- `current_cupy_stream` is a class documented as a function. See SOD-005.
+
+### Public behavior
+
+- Cache layers, cache routing, invalidation, and compilation claims are stale.
+  See UFR-006, UFR-007, UFR-012, and UFR-C01.
+- CellML version support and DAE limitations are incorrect. See UFR-008,
+  UFR-C03, SOD-013, SOD-014, and SOD-015.
+- Algorithm inventories, aliases, controller defaults, and method properties
+  are incomplete or incorrect. See UFR-009, UFR-010, INT-05 through INT-11,
+  D2-03, and D2-04.
+- Memory ownership, stream concurrency, spill behavior, and cleanup contracts
+  are incomplete or incorrect. See UFR-014, UFR-C02, API-02, SOD-001 through
+  SOD-008, and RB-02.
+- Output defaults, result status flags, device-view lifetime, and timing
+  aliases are incomplete or incorrect. See UFR-015, UFR-016, UFR-C05, API-03,
+  SOD-018 through SOD-032, and RB-03.
+- Two checked-in documentation examples call stale or malformed interfaces.
+  See UFR-026 and UFR-027.
+
+### Missing coverage
+
+- Public exports lack API pages in the batch, memory, ODE-system, output, and
+  integrator packages. See API-01, API-03, INT-15, SOD-034 through SOD-037,
+  RB-06, and RB-07.
+- Developer guidance omits current factory, buffer, component-registration,
+  result-code, and testing contracts. See DG-01 through DG-19 and D2-01 through
+  D2-11.
+- Seven nested instruction files contain stale Jacobian, system-size, CellML,
+  summary-metric, test-map, or import guidance. See SOD-039 through SOD-045.
+- `tests/_inventory.json` contains removed symbols and incorrect descriptions.
+  Its query tool names a missing regeneration script. See D3-F04 and D3-F05.
+- Two profiling scripts contain a nonexistent personal worktree path. See
+  D3-F03.
+
+## Language review
+
+Each documentation inventory records em dashes, semicolons, framing colons,
+false-drama phrasing, and rendered source docstrings. Syntax required by code,
+URLs, RST, math, tables, and protocol strings is marked for retention. Prose
+uses have replacements in the paired proposal artifact.
+
+The review also covers prospective autodoc text. New API pages would otherwise
+render prohibited punctuation or framing from `BatchInputHandler`,
+`DeviceSolveResult`, BiCGSTAB classes, `TimeLogger`, `ArrayInterpolator`,
+`load_cellml_model`, `MeanStd`, and `StdRms`. See STYLE-PROSPECTIVE-01, RB-06,
+RB-07, SOD-036, and SOD-037.
+
+Two integrator test docstrings contain explicit AI-authorship narratives.
+D2-12 provides factual replacements.
+
+## Review order
+
+1. Correct factual contradictions and broken targets.
+2. Add missing public API and lifecycle coverage.
+3. Apply source-docstring rewrites required by existing and proposed autodoc.
+4. Apply page-level language rewrites.
+5. Regenerate the stale test inventory and repair its query workflow.
+6. Build the complete Sphinx tree in the documented development environment.

--- a/docs/review/integrator_source_inventory.md
+++ b/docs/review/integrator_source_inventory.md
@@ -1,0 +1,214 @@
+# Integrator source and test inventory
+
+## Coverage receipt
+
+The manifest came from this command.
+
+```powershell
+git ls-files -- 'src/cubie/integrators/**' 'tests/integrators/**' `
+  'tests/integrated_numerical_tests/**'
+```
+
+The command returned 115 tracked entries. The manifest reconciles as
+follows.
+
+| Entry class | Files | Physical lines or bytes | Review state |
+|---|---:|---:|---|
+| Source text under `src/cubie/integrators/**` | 45 | 17,687 lines | READ-COMPLETE |
+| Test and reference text in the two test trees | 63 | 16,869 lines | READ-COMPLETE |
+| `CLAUDE.md` symbolic-link mirrors | 5 | One-line link payload each | MIRROR-RECONCILED |
+| Previously audited Julia data README | 1 | 29 lines | EXCLUDED-PRIOR-AUDIT |
+| Binary Julia reference data | 1 | 4,171,336 bytes | BINARY-INVENTORIED |
+| Total | 115 | 34,556 newly read text lines | RECONCILED |
+
+Every line of all 108 newly scoped text files was read. Empty tracked files
+are recorded with zero physical lines and are vacuously complete. The
+prerequisite instruction files `AGENTS.md` at the repository root and
+`src/cubie/AGENTS.md` were also read in full. They contain 126 and 210
+physical lines respectively.
+
+Impact labels refer to entries in
+`integrator_supplemental_proposals.md`. `EXISTING` means the issue is
+already captured by another review artifact. `STYLE-AI-01` is detailed
+below.
+
+## Integrator source manifest
+
+| Tracked file | Lines | Read state | Documentation impact |
+|---|---:|---|---|
+| `src/cubie/integrators/AGENTS.md` | 105 | READ-COMPLETE | D2-05, D2-06, EXISTING INT-15 |
+| `src/cubie/integrators/IntegratorRunSettings.py` | 54 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/SingleIntegratorRun.py` | 471 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/SingleIntegratorRunCore.py` | 931 | READ-COMPLETE | EVIDENCE D2-01, D2-05 |
+| `src/cubie/integrators/__init__.py` | 93 | READ-COMPLETE | EXISTING INT-15 |
+| `src/cubie/integrators/algorithms/AGENTS.md` | 165 | READ-COMPLETE | D2-02, D2-03 |
+| `src/cubie/integrators/algorithms/__init__.py` | 216 | READ-COMPLETE | EXISTING INT-10, INT-15 |
+| `src/cubie/integrators/algorithms/backwards_euler.py` | 339 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/algorithms/backwards_euler_predict_correct.py` | 216 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/algorithms/base_algorithm_step.py` | 912 | READ-COMPLETE | D2-01 |
+| `src/cubie/integrators/algorithms/crank_nicolson.py` | 378 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/algorithms/explicit_euler.py` | 266 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/algorithms/generic_dirk.py` | 872 | READ-COMPLETE | EXISTING rendered punctuation |
+| `src/cubie/integrators/algorithms/generic_dirk_tableaus.py` | 442 | READ-COMPLETE | EXISTING INT-10 and rendered punctuation |
+| `src/cubie/integrators/algorithms/generic_erk.py` | 599 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/algorithms/generic_erk_tableaus.py` | 772 | READ-COMPLETE | EXISTING INT-10 |
+| `src/cubie/integrators/algorithms/generic_firk.py` | 731 | READ-COMPLETE | EXISTING rendered punctuation |
+| `src/cubie/integrators/algorithms/generic_firk_tableaus.py` | 224 | READ-COMPLETE | D2-03, EXISTING INT-10 |
+| `src/cubie/integrators/algorithms/generic_rosenbrock_w.py` | 789 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/algorithms/generic_rosenbrockw_tableaus.py` | 442 | READ-COMPLETE | D2-04 |
+| `src/cubie/integrators/algorithms/ode_explicitstep.py` | 106 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/algorithms/ode_implicitstep.py` | 728 | READ-COMPLETE | EVIDENCE D2-01, D2-02, EXISTING STYLE-DOC-03 |
+| `src/cubie/integrators/loops/AGENTS.md` | 118 | READ-COMPLETE | D2-07, D2-11 |
+| `src/cubie/integrators/loops/__init__.py` | 9 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/loops/ode_loop.py` | 1,121 | READ-COMPLETE | D2-09 |
+| `src/cubie/integrators/loops/ode_loop_config.py` | 325 | READ-COMPLETE | EVIDENCE D2-07, EXISTING rendered punctuation |
+| `src/cubie/integrators/matrix_free_solvers/AGENTS.md` | 142 | READ-COMPLETE | D2-06, D2-08, D2-11 |
+| `src/cubie/integrators/matrix_free_solvers/__init__.py` | 42 | READ-COMPLETE | EVIDENCE D2-02, EXISTING INT-03, INT-15 |
+| `src/cubie/integrators/matrix_free_solvers/base_solver.py` | 201 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/matrix_free_solvers/bicgstab_solver.py` | 730 | READ-COMPLETE | EVIDENCE D2-06, EXISTING INT-15 |
+| `src/cubie/integrators/matrix_free_solvers/linear_solver.py` | 559 | READ-COMPLETE | D2-10 |
+| `src/cubie/integrators/matrix_free_solvers/linear_solver_base.py` | 340 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/matrix_free_solvers/newton_krylov.py` | 636 | READ-COMPLETE | D2-10, EVIDENCE D2-06, EXISTING INT-04 |
+| `src/cubie/integrators/memory_heuristics.py` | 327 | READ-COMPLETE | EXISTING INT-15 |
+| `src/cubie/integrators/norms.py` | 481 | READ-COMPLETE | EVIDENCE D2-08, EXISTING INT-15 |
+| `src/cubie/integrators/stage_predictors.py` | 546 | READ-COMPLETE | EXISTING INT-15 |
+| `src/cubie/integrators/step_control/AGENTS.md` | 87 | READ-COMPLETE | D2-11 |
+| `src/cubie/integrators/step_control/__init__.py` | 121 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/step_control/adaptive_I_controller.py` | 193 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/step_control/adaptive_PID_controller.py` | 275 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/step_control/adaptive_PI_controller.py` | 265 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/step_control/adaptive_step_controller.py` | 392 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/step_control/base_step_controller.py` | 459 | READ-COMPLETE | EXISTING rendered punctuation |
+| `src/cubie/integrators/step_control/fixed_step_controller.py` | 180 | READ-COMPLETE | NONE |
+| `src/cubie/integrators/step_control/gustafsson_controller.py` | 287 | READ-COMPLETE | NONE |
+
+Source subtotal is 45 files and 17,687 physical lines.
+
+## Integrated numerical test manifest
+
+| Tracked file | Lines | Read state | Documentation impact |
+|---|---:|---|---|
+| `tests/integrated_numerical_tests/__init__.py` | 0 | READ-COMPLETE | NONE |
+| `tests/integrated_numerical_tests/julia_reference/__init__.py` | 0 | READ-COMPLETE | NONE |
+| `tests/integrated_numerical_tests/julia_reference/conftest.py` | 69 | READ-COMPLETE | NONE |
+| `tests/integrated_numerical_tests/julia_reference/data/algorithms.csv` | 23 | READ-COMPLETE | EVIDENCE D2-04 |
+| `tests/integrated_numerical_tests/julia_reference/data/controller_constants.csv` | 21 | READ-COMPLETE | NONE |
+| `tests/integrated_numerical_tests/julia_reference/ne_gate.py` | 247 | READ-COMPLETE | NONE |
+| `tests/integrated_numerical_tests/julia_reference/test_julia_reference.py` | 197 | READ-COMPLETE | NONE |
+| `tests/integrated_numerical_tests/test_chunking.py` | 53 | READ-COMPLETE | NONE |
+| `tests/integrated_numerical_tests/test_dt_min_hang.py` | 115 | READ-COMPLETE | EVIDENCE D2-09 |
+| `tests/integrated_numerical_tests/test_numerical_equivalence.py` | 33 | READ-COMPLETE | NONE |
+| `tests/integrated_numerical_tests/test_ode_loop.py` | 623 | READ-COMPLETE | EVIDENCE D2-03 |
+| `tests/integrated_numerical_tests/test_output_functions.py` | 741 | READ-COMPLETE | NONE |
+| `tests/integrated_numerical_tests/test_rejection_liveness.py` | 37 | READ-COMPLETE | EVIDENCE D2-09 |
+| `tests/integrated_numerical_tests/test_status_staining.py` | 121 | READ-COMPLETE | EVIDENCE D2-09 |
+| `tests/integrated_numerical_tests/test_step_algorithms.py` | 503 | READ-COMPLETE | NONE |
+| `tests/integrated_numerical_tests/test_step_controllers.py` | 507 | READ-COMPLETE | NONE |
+
+Integrated numerical test subtotal is 16 text files and 3,290 physical
+lines.
+
+## Integrator unit and reference test manifest
+
+| Tracked file | Lines | Read state | Documentation impact |
+|---|---:|---|---|
+| `tests/integrators/__init__.py` | 0 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/__init__.py` | 0 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_base_algorithm_step.py` | 129 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_dirk_tableaus.py` | 225 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_explicit_euler.py` | 48 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_generic_dirk.py` | 201 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_generic_erk_tableaus.py` | 84 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_generic_firk.py` | 69 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_generic_rosenbrock_w.py` | 59 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_init.py` | 248 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_last_step_caching_integration.py` | 21 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_ode_explicitstep.py` | 54 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_ode_implicitstep.py` | 297 | READ-COMPLETE | EVIDENCE D2-01, D2-02 |
+| `tests/integrators/algorithms/test_rosenbrock_tableaus.py` | 54 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_step_algorithms.py` | 791 | READ-COMPLETE | NONE |
+| `tests/integrators/algorithms/test_tableau_properties.py` | 108 | READ-COMPLETE | NONE |
+| `tests/integrators/cpu_reference/__init__.py` | 37 | READ-COMPLETE | STYLE-AI-01, D2-12 |
+| `tests/integrators/cpu_reference/algorithms.py` | 2,069 | READ-COMPLETE | NONE |
+| `tests/integrators/cpu_reference/cpu_ode_system.py` | 523 | READ-COMPLETE | NONE |
+| `tests/integrators/cpu_reference/cpu_utils.py` | 869 | READ-COMPLETE | STYLE-AI-01, D2-12, EVIDENCE D2-11 |
+| `tests/integrators/cpu_reference/loops.py` | 323 | READ-COMPLETE | EVIDENCE D2-11 |
+| `tests/integrators/cpu_reference/step_controllers.py` | 219 | READ-COMPLETE | EVIDENCE D2-11 |
+| `tests/integrators/cpu_reference/test_cpu_utils.py` | 246 | READ-COMPLETE | NONE |
+| `tests/integrators/loops/__init__.py` | 0 | READ-COMPLETE | NONE |
+| `tests/integrators/loops/test_buffer_settings.py` | 125 | READ-COMPLETE | NONE |
+| `tests/integrators/loops/test_interp_vs_symbolic.py` | 56 | READ-COMPLETE | NONE |
+| `tests/integrators/loops/test_ode_loop.py` | 70 | READ-COMPLETE | NONE |
+| `tests/integrators/loops/test_ode_loop_config.py` | 281 | READ-COMPLETE | EVIDENCE D2-07 |
+| `tests/integrators/matrix_free_solvers/__init__.py` | 0 | READ-COMPLETE | EVIDENCE D2-11 |
+| `tests/integrators/matrix_free_solvers/conftest.py` | 836 | READ-COMPLETE | EVIDENCE D2-06, D2-11 |
+| `tests/integrators/matrix_free_solvers/test_base_solver.py` | 167 | READ-COMPLETE | EVIDENCE D2-11 |
+| `tests/integrators/matrix_free_solvers/test_bicgstab.py` | 199 | READ-COMPLETE | EVIDENCE D2-11 |
+| `tests/integrators/matrix_free_solvers/test_linear_solver.py` | 807 | READ-COMPLETE | EVIDENCE D2-06, D2-11 |
+| `tests/integrators/matrix_free_solvers/test_newton_krylov.py` | 494 | READ-COMPLETE | EVIDENCE D2-11 |
+| `tests/integrators/step_control/test_adaptive_step_controller.py` | 484 | READ-COMPLETE | NONE |
+| `tests/integrators/step_control/test_controllers.py` | 272 | READ-COMPLETE | NONE |
+| `tests/integrators/step_control/test_fixed_step_controller.py` | 179 | READ-COMPLETE | NONE |
+| `tests/integrators/step_control/test_gain_specs.py` | 133 | READ-COMPLETE | EVIDENCE D2-11 |
+| `tests/integrators/step_control/test_gustafsson_controller.py` | 89 | READ-COMPLETE | EVIDENCE D2-11 |
+| `tests/integrators/step_control/test_init.py` | 92 | READ-COMPLETE | EVIDENCE D2-11 |
+| `tests/integrators/test_IntegratorRunSettings.py` | 50 | READ-COMPLETE | NONE |
+| `tests/integrators/test_SingleIntegratorRun.py` | 242 | READ-COMPLETE | NONE |
+| `tests/integrators/test_SingleIntegratorRunCore.py` | 1,071 | READ-COMPLETE | EVIDENCE D2-05 |
+| `tests/integrators/test_init.py` | 65 | READ-COMPLETE | NONE |
+| `tests/integrators/test_memory_heuristics.py` | 116 | READ-COMPLETE | EXISTING INT-15 |
+| `tests/integrators/test_norms.py` | 673 | READ-COMPLETE | EVIDENCE D2-08 |
+| `tests/integrators/test_stage_predictors.py` | 404 | READ-COMPLETE | EVIDENCE D2-03, EXISTING INT-15 |
+
+Integrator unit and reference test subtotal is 47 files and 13,579
+physical lines. The two test subtotals reconcile to 63 files and 16,869
+physical lines.
+
+## Symbolic-link mirrors
+
+Git records each entry below with mode `120000` and the one-line payload
+`AGENTS.md`. The filesystem resolves each link to the sibling `AGENTS.md`
+already listed and read above. They were not counted as duplicate text.
+
+| Tracked file | Payload lines | State | Target |
+|---|---:|---|---|
+| `src/cubie/integrators/CLAUDE.md` | 1 | MIRROR-RECONCILED | `src/cubie/integrators/AGENTS.md` |
+| `src/cubie/integrators/algorithms/CLAUDE.md` | 1 | MIRROR-RECONCILED | `src/cubie/integrators/algorithms/AGENTS.md` |
+| `src/cubie/integrators/loops/CLAUDE.md` | 1 | MIRROR-RECONCILED | `src/cubie/integrators/loops/AGENTS.md` |
+| `src/cubie/integrators/matrix_free_solvers/CLAUDE.md` | 1 | MIRROR-RECONCILED | `src/cubie/integrators/matrix_free_solvers/AGENTS.md` |
+| `src/cubie/integrators/step_control/CLAUDE.md` | 1 | MIRROR-RECONCILED | `src/cubie/integrators/step_control/AGENTS.md` |
+
+## Exclusion and binary inventory
+
+| Tracked file | Size | State | Reason |
+|---|---:|---|---|
+| `tests/integrated_numerical_tests/julia_reference/data/README.md` | 29 lines | EXCLUDED-PRIOR-AUDIT | The user-facing lane already audited every line and recorded `UFR-030`. |
+| `tests/integrated_numerical_tests/julia_reference/data/julia_reference_ne.npz` | 4,171,336 bytes | BINARY-INVENTORIED | NumPy archive with no text lines. |
+
+## AI-language receipt
+
+The supplied false-drama and framing examples were searched across all 108
+text files after the line-by-line read. No matching instance was found.
+Two documentation-bearing test docstrings directly discuss AI authorship.
+
+### STYLE-AI-01
+
+| Location | Exact current text | Exact proposed replacement |
+|---|---|---|
+| `tests/integrators/cpu_reference/__init__.py:1-6` | `Reference CPU implementations used across integrator tests.` followed by `I've let genAI agents run fairly free on this module, adding many of the over-engineered and pointless checks and complicated chains that it loves to add, as all we really want in here is a reference implementation of the GPU integrator components.` | Keep only `Reference CPU implementations used across integrator tests.` |
+| `tests/integrators/cpu_reference/cpu_utils.py:626-628` | `Return Horner evaluations and range flag for coefficients. Busybody AI over-checking left in place.` | `Return Horner evaluations and range flag for coefficients.` |
+
+These replacements remove framing, editorial judgment, and AI-authorship
+commentary without changing any instruction or behavioral description.
+
+## Freshness and completeness reconciliation
+
+The complete read produced twelve supplemental issue groups. Existing
+artifacts already cover the public-page registry gaps, public status list,
+missing API targets, memory heuristics, stage prediction, and public
+damped-Newton claim. Those findings are marked `EXISTING` in the manifest
+and are not duplicated as public-page proposals.
+
+No tracked text file is absent from the tables. The category equation is
+`108 text + 5 mirrors + 1 prior-audit exclusion + 1 binary = 115 tracked
+entries`.

--- a/docs/review/integrator_supplemental_proposals.md
+++ b/docs/review/integrator_supplemental_proposals.md
@@ -1,0 +1,546 @@
+# Integrator source-document supplemental proposals
+
+## Scope
+
+This file records stale or missing documentation found during the complete
+read of `src/cubie/integrators/**`, `tests/integrators/**`, and the scoped
+integrated numerical tests. Existing review artifacts cover the public
+Sphinx pages. The D2 entries identify source-docstring and `AGENTS.md`
+locations absent from those artifacts.
+
+Em dashes and semicolons in `Current text` blocks are verbatim source
+quotations. Proposed prose contains neither mark.
+
+## D2-01 Remove the obsolete mass-matrix algorithm parameter
+
+Current location
+
+`src/cubie/integrators/algorithms/base_algorithm_step.py:170-172`
+
+Current text
+
+```rst
+   * - ``M``
+     - :class:`ImplicitStepConfig`
+     - Mass matrix for residual and Jacobian actions.
+```
+
+Proposed replacement
+
+Delete this row. The mass matrix is part of the ODE system and is rejected
+when supplied as an algorithm setting.
+
+Evidence
+
+- `src/cubie/integrators/SingleIntegratorRunCore.py:174-184`
+- `src/cubie/integrators/algorithms/base_algorithm_step.py:62-85`
+- `src/cubie/integrators/algorithms/ode_implicitstep.py:94-107`
+- `tests/integrators/algorithms/test_ode_implicitstep.py:132-150`
+
+## D2-02 Replace the removed `LinearSolver` class name
+
+Current locations
+
+- `src/cubie/integrators/algorithms/AGENTS.md:10-12`
+- `src/cubie/integrators/algorithms/AGENTS.md:30`
+- `src/cubie/integrators/algorithms/AGENTS.md:94-101`
+- `src/cubie/integrators/algorithms/AGENTS.md:153-157`
+
+Current text
+
+```text
+backward Euler (plain + predictor-corrector), and Crank-Nicolson. Implicit methods own
+a `NewtonKrylov` or `LinearSolver` from `../matrix_free_solvers/`. `get_algorithm_step()`
+resolves a name or `ButcherTableau` to the right factory.
+
+| `ode_implicitstep.py` | `ImplicitStepConfig` (beta, gamma, preconditioner_order) + `ODEImplicitStep`: owns a `NewtonKrylov`/`LinearSolver`, requests operator/preconditioner/residual helpers as immutable `SolverHelperRequest`s, resolves `preconditioner_type` into concrete kinds, routes solver-param updates; `is_implicit` → `True`. |
+
+- **Implicit** (`ODEImplicitStep`, owns a solver): `BackwardsEulerStep`,
+  `BackwardsEulerPCStep`, `CrankNicolsonStep`, `DIRKStep`, `FIRKStep`,
+  `GenericRosenbrockWStep`. All use **Newton-Krylov except `GenericRosenbrockWStep`**,
+  which is linearly-implicit and constructs a `LinearSolver` directly
+  (no Newton iteration). The class attribute `is_linear` (`True` on
+  `GenericRosenbrockWStep`, `False` elsewhere) exposes the distinction.
+
+- `cubie.integrators.matrix_free_solvers` — `NewtonKrylov`, `LinearSolver` (owned by
+  implicit steps).
+```
+
+Proposed replacements
+
+```text
+Nonlinear implicit methods own a `NewtonKrylov` solver. Linearly implicit
+methods own an `MRLinearSolver` or `BiCGSTABSolver`.
+`get_algorithm_step()` resolves a name or `ButcherTableau` to its factory.
+
+| `ode_implicitstep.py` | `ImplicitStepConfig` with beta, gamma, and preconditioner order. `ODEImplicitStep` owns `NewtonKrylov` for nonlinear algorithms and an `MRLinearSolver` or `BiCGSTABSolver` for linearly implicit algorithms. It requests operator, preconditioner, and residual helpers as immutable `SolverHelperRequest` values. It resolves `preconditioner_type` into concrete kinds and routes solver parameter updates. `is_implicit` is `True`. |
+
+- Implicit `ODEImplicitStep` implementations include `BackwardsEulerStep`,
+  `BackwardsEulerPCStep`, `CrankNicolsonStep`, `DIRKStep`, `FIRKStep`, and
+  `GenericRosenbrockWStep`. `BackwardsEulerStep`, `BackwardsEulerPCStep`,
+  `CrankNicolsonStep`, `DIRKStep`, and `FIRKStep` use `NewtonKrylov`.
+  `GenericRosenbrockWStep` is linearly implicit and constructs
+  an `MRLinearSolver` or `BiCGSTABSolver` directly. It does not run Newton
+  iteration. `is_linear` is `True` on `GenericRosenbrockWStep` and `False`
+  on the other implementations.
+
+- `cubie.integrators.matrix_free_solvers` provides `NewtonKrylov`,
+  `MRLinearSolver`, and `BiCGSTABSolver` for implicit steps.
+```
+
+Evidence
+
+- `src/cubie/integrators/algorithms/ode_implicitstep.py:255-280`
+- `src/cubie/integrators/algorithms/ode_implicitstep.py:286-318`
+- `src/cubie/integrators/matrix_free_solvers/__init__.py:8-42`
+- `tests/integrators/algorithms/test_ode_implicitstep.py:234-280`
+
+## D2-03 Add Gauss-Legendre-4 to both source inventories
+
+Current locations
+
+- `src/cubie/integrators/algorithms/AGENTS.md:37`
+- `src/cubie/integrators/algorithms/generic_firk_tableaus.py:15-28`
+
+Current text
+
+```text
+| `generic_firk_tableaus.py` | `FIRKTableau` + Gauss-Legendre-2 (default) and Radau IIA-5; `compute_embedded_weights_radauIIA`. |
+```
+
+```rst
+Constants
+---------
+:data:`GAUSS_LEGENDRE_2_TABLEAU`
+    Two-stage, fourth-order Gauss–Legendre tableau.
+
+:data:`RADAU_IIA_5_TABLEAU`
+    Three-stage, fifth-order Radau IIA tableau with second-order
+    embedded error estimate.
+
+:data:`FIRK_TABLEAU_REGISTRY`
+    Name → tableau mapping for alias-based lookup.
+
+:data:`DEFAULT_FIRK_TABLEAU`
+    Default tableau (Gauss–Legendre 2-stage).
+```
+
+Proposed replacements
+
+```text
+| `generic_firk_tableaus.py` | `FIRKTableau` with Gauss-Legendre-2 (default), Gauss-Legendre-4, and Radau IIA-5. `compute_embedded_weights_radauIIA` computes Radau IIA embedded weights from moment conditions. |
+```
+
+Proposed module entry
+
+```rst
+:data:`GAUSS_LEGENDRE_4_TABLEAU`
+    Four-stage, eighth-order Gauss-Legendre tableau without an
+    embedded error estimate.
+```
+
+Evidence
+
+- `src/cubie/integrators/algorithms/generic_firk_tableaus.py:157-214`
+- `src/cubie/integrators/algorithms/generic_firk_tableaus.py:216-224`
+- `tests/integrated_numerical_tests/test_ode_loop.py:75-93`
+- `tests/integrators/test_stage_predictors.py:83-87`
+- `tests/integrators/test_stage_predictors.py:267-269`
+
+`INT-10` and `UFR-009` record the public-page omission. D2-03 records the
+two source-document omissions.
+
+## D2-04 Correct the Rosenbrock23 method order
+
+Current location
+
+`src/cubie/integrators/algorithms/generic_rosenbrockw_tableaus.py:17-18`
+
+Current text
+
+```rst
+:data:`ROSENBROCK_23_SCIML_TABLEAU`
+    Three-stage, third-order SciML Rosenbrock-23 variant.
+```
+
+Proposed replacement
+
+```rst
+:data:`ROSENBROCK_23_SCIML_TABLEAU`
+    Three-stage, second-order SciML Rosenbrock23 method with a
+    third-order embedded error estimate.
+```
+
+Evidence
+
+- `src/cubie/integrators/algorithms/generic_rosenbrockw_tableaus.py:358-405`
+- `tests/integrated_numerical_tests/julia_reference/data/algorithms.csv:21`
+- `docs/source/API_reference/integrators/algorithms/generic_rosenbrock_tableaus.rst:33-34`
+
+## D2-05 Correct component registration and hot-swap mechanics
+
+Current locations
+
+- `src/cubie/integrators/AGENTS.md:52-67`
+- `src/cubie/integrators/AGENTS.md:85-90`
+
+Current text
+
+```text
+### Component assembly (`SingleIntegratorRunCore.__init__`)
+Order matters — each component seeds the next:
+1. `OutputFunctions` first (its compile flags + summary buffer heights feed `IVPLoop`).
+2. `_algo_step = get_algorithm_step(precision, settings)` — supplies
+   `controller_defaults.step_controller`, seeding the controller settings before user
+   overrides merge in.
+3. `_step_controller = get_controller(precision, controller_settings)`.
+4. `check_compatibility()` — if the algorithm is errorless but the controller is
+   adaptive, the controller is **silently replaced with `FixedStepController`** and a
+   `UserWarning` is issued (an errorless algorithm gives no error signal to adapt on).
+   Happens before the loop is created.
+5. `instantiate_loop()` — creates `IVPLoop` from the finalised sizes/flags/timing.
+6. `get_child_allocators(self._loop, self._algo_step, name='algorithm')` (and the
+   controller equivalent) — registers algo/controller buffers as children of the loop's
+   group. **Must be re-run after every algo/controller swap** (in `update()`,
+   `_switch_algos()`, `_switch_controllers()`, `build()`).
+
+### Hot-swap
+A new `"algorithm"`/`"step_controller"` in `update()` routes through
+`_switch_algos()`/`_switch_controllers()`, which call
+`buffer_registry.reset()`, rebuild the sub-component from the old settings as a base,
+and propagate defaults into `updates_dict`. Never call these directly — go through
+`update()`. Because the swap calls `buffer_registry.reset()`, any cached allocator
+references become stale.
+```
+
+Proposed replacement for step 6 and the hot-swap block
+
+```text
+6. `buffer_registry.register_child(self._loop, self._algo_step,
+name="algorithm")` and the controller equivalent register the active
+component subtrees under the loop.
+
+`_switch_algos()` and `_switch_controllers()` call
+`buffer_registry.clear_parent()` on the outgoing component. The methods
+build the replacement from the old settings. `update()` registers both
+active components under the loop. A swap invalidates allocator references
+for the outgoing subtree and preserves the sibling subtree.
+```
+
+Evidence
+
+- `src/cubie/integrators/SingleIntegratorRunCore.py:251-258`
+- `src/cubie/integrators/SingleIntegratorRunCore.py:700-718`
+- `src/cubie/integrators/SingleIntegratorRunCore.py:736-766`
+- `src/cubie/integrators/SingleIntegratorRunCore.py:817-832`
+- `tests/integrators/test_SingleIntegratorRunCore.py:579-622`
+
+## D2-06 Complete the internal result-code inventories
+
+Current locations
+
+- `src/cubie/integrators/AGENTS.md:40-50`
+- `src/cubie/integrators/matrix_free_solvers/AGENTS.md:75-81`
+
+Current text
+
+```text
+### CUBIE_RESULT_CODES — kernel status-bit meanings
+The status vocabulary is the package-central `CUBIE_RESULT_CODES(IntFlag)` (defined in
+`cubie/result_codes.py`, re-exported from this package and from `cubie`). Device functions
+capture its values as closure constants and OR them into the returned status word:
+`SUCCESS=0`, `MAX_NEWTON_ITERATIONS_EXCEEDED=2`,
+`MAX_LINEAR_ITERATIONS_EXCEEDED=4`, `STEP_TOO_SMALL=8` (controllers' reject-at-min),
+`DT_EFF_EFFECTIVELY_ZERO=16` and `MAX_LOOP_ITERS_EXCEEDED=32` (reserved, unemitted),
+`STAGNATION=64` (loop no-progress). Iteration counts are returned separately via the
+`counters` array, never packed into the status word. Host-side, decode via
+`cubie.result_codes.decode_status_codes` (exposed as `SolveResult.status_messages` /
+`Solver.status_messages`).
+```
+
+```text
+### Status codes & convergence
+- Status codes come from the package-central `CUBIE_RESULT_CODES` (`cubie/result_codes.py`,
+  re-exported from this package): `SUCCESS=0`,
+  `MAX_NEWTON_ITERATIONS_EXCEEDED=2`, `MAX_LINEAR_ITERATIONS_EXCEEDED=4` (captured as device
+  closure constants). `newton_krylov_solver` OR-combines these into a **low-bits** status
+  word — it does NOT pack the iteration count into high bits (counts go to `counters`).
+  Callers OR this word into their own step status.
+```
+
+Proposed replacement for the package inventory
+
+```text
+`SUCCESS=0`, `MAX_NEWTON_ITERATIONS_EXCEEDED=2`,
+`MAX_LINEAR_ITERATIONS_EXCEEDED=4`, `STEP_TOO_SMALL=8`,
+`DT_EFF_EFFECTIVELY_ZERO=16` (reserved and unemitted),
+`MAX_LOOP_ITERS_EXCEEDED=32` (reserved and unemitted), `STAGNATION=64`,
+`BICGSTAB_BREAKDOWN=128`, and `NEWTON_DIVERGENCE=256`.
+```
+
+Proposed replacement for the matrix-free inventory
+
+```text
+The matrix-free solvers emit `SUCCESS=0`,
+`MAX_NEWTON_ITERATIONS_EXCEEDED=2`,
+`MAX_LINEAR_ITERATIONS_EXCEEDED=4`,
+`BICGSTAB_BREAKDOWN=128`, and `NEWTON_DIVERGENCE=256`.
+```
+
+Evidence
+
+- `src/cubie/result_codes.py:22-58`
+- `src/cubie/integrators/matrix_free_solvers/bicgstab_solver.py:659-670`
+- `src/cubie/integrators/matrix_free_solvers/newton_krylov.py:498-510`
+- `tests/integrators/matrix_free_solvers/test_linear_solver.py:331-366`
+- `tests/integrators/matrix_free_solvers/conftest.py:73-105`
+
+`UFR-016` records the public result vocabulary. D2-06 records the internal
+inventories.
+
+## D2-07 State the absolute summary-ratio tolerance
+
+Current location
+
+`src/cubie/integrators/loops/AGENTS.md:96-100`
+
+Current text
+
+```text
+- `samples_per_summary` (on `ODELoopConfig`) raises `ValueError` if `summarise_every` is
+  not within 1% of an integer multiple of `sample_summaries_every`; a ≤1% deviation is
+  accepted with a `UserWarning` and `summarise_every` adjusted. Evaluated on every
+  `build()`.
+```
+
+Proposed replacement
+
+```text
+`samples_per_summary` rounds the ratio
+`summarise_every / sample_summaries_every` to the nearest integer. It
+accepts and warns when the absolute difference from that integer is at
+most `0.01`. It raises `ValueError` for a larger difference.
+```
+
+Evidence
+
+- `src/cubie/integrators/loops/ode_loop_config.py:245-295`
+- `tests/integrators/loops/test_ode_loop_config.py:182-212`
+
+## D2-08 Remove the nonexistent correction-tolerance warning
+
+Current location
+
+`src/cubie/integrators/matrix_free_solvers/AGENTS.md:113`
+
+Current text
+
+```text
+- Correction-norm `rtol` floors at 4 ULPs with a warning; Krylov norms keep raw values.
+```
+
+Proposed replacement
+
+```text
+Correction-norm `rtol` silently floors nonzero components at 4 ULPs.
+Krylov norms keep their requested values.
+```
+
+Evidence
+
+- `src/cubie/integrators/norms.py:24-33`
+- `tests/integrators/test_norms.py:632-647`
+- `tests/integrators/test_norms.py:650-673`
+
+## D2-09 Correct the compiled loop termination and return description
+
+Current locations
+
+- `src/cubie/integrators/loops/ode_loop.py:501-505`
+- `src/cubie/integrators/loops/ode_loop.py:548-551`
+
+Current text
+
+```text
+The loop terminates when every output schedule passes its stop time, or
+when the maximum number of iterations is reached.
+
+Status code aggregating errors and iteration counts.
+```
+
+Proposed replacement
+
+```text
+The loop terminates when every output schedule passes its stop time or
+an irrecoverable status is set.
+
+Status bit field containing loop, step, controller, and solver failure
+flags. Iteration counts are written to `iteration_counters_output`.
+```
+
+Evidence
+
+- `src/cubie/integrators/loops/ode_loop.py:691-736`
+- `src/cubie/integrators/loops/ode_loop.py:816-894`
+- `src/cubie/result_codes.py:36-47`
+- `tests/integrated_numerical_tests/test_rejection_liveness.py:19-37`
+- `tests/integrated_numerical_tests/test_status_staining.py:1-121`
+
+`MAX_LOOP_ITERS_EXCEEDED` is reserved and is not emitted by the loop.
+
+## D2-10 Remove two nonexistent solver features
+
+Current locations
+
+- `src/cubie/integrators/matrix_free_solvers/linear_solver.py:47-53`
+- `src/cubie/integrators/matrix_free_solvers/newton_krylov.py:20-22`
+
+Current text
+
+```text
+Line-search strategy ('steepest_descent' or 'minimal_residual').
+
+CUDAFactory subclass that compiles a damped Newton--Krylov solver.
+```
+
+Proposed replacements
+
+```text
+Linear correction strategy. Accepted values are
+`"steepest_descent"` and `"minimal_residual"`.
+
+CUDAFactory subclass that compiles a Newton-Krylov solver.
+```
+
+Evidence
+
+- `src/cubie/integrators/matrix_free_solvers/linear_solver.py:232-365`
+- `src/cubie/integrators/matrix_free_solvers/newton_krylov.py:293-515`
+- `src/cubie/integrators/matrix_free_solvers/AGENTS.md:102-116`
+
+`INT-04` records the stale public overview. D2-10 records the two
+source-docstring locations.
+
+## D2-11 Refresh the internal test map
+
+Current locations
+
+- `src/cubie/integrators/loops/AGENTS.md:105-108`
+- `src/cubie/integrators/matrix_free_solvers/AGENTS.md:124-131`
+- `src/cubie/integrators/step_control/AGENTS.md:77-80`
+
+Current text
+
+```text
+### Testing
+Tests in `tests/integrators/loops/`. Loop correctness is also exercised end-to-end in
+`tests/batchsolving/` and against `tests/integrators/cpu_reference.py`
+(`run_reference_loop()`).
+```
+
+```text
+### Testing
+Solver behaviour is exercised through the implicit algorithm steps under
+`tests/integrators/algorithms/`, verified against the plain CPU reference
+solvers in `tests/integrators/cpu_reference/cpu_utils.py`
+(`newton_solve`, `krylov_solve`). Any change to a device function's
+algorithm, signature, buffers, or status logic must be replicated in its
+CPU reference counterpart. Run e.g.
+`pytest tests/integrators/algorithms -k "newton or krylov or implicit"`.
+```
+
+```text
+### Testing
+Tests under `tests/integrators/step_control/` (`test_controllers.py`,
+`test_adaptive_step_controller.py`, `test_fixed_step_controller.py`); CPU reference in
+`tests/integrators/cpu_reference/step_controllers.py`.
+```
+
+Proposed replacement for the loop test map
+
+```text
+Tests live in `tests/integrators/loops/`. `tests/integrated_numerical_tests/`
+and `tests/batchsolving/` exercise loop behavior.
+`tests/integrators/cpu_reference/loops.py` defines `run_reference_loop()`.
+```
+
+Proposed replacement for the matrix-free test map
+
+```text
+Direct solver tests live in
+`tests/integrators/matrix_free_solvers/`. Implicit algorithm tests live in
+`tests/integrators/algorithms/`. The CPU reference implementations are in
+`tests/integrators/cpu_reference/cpu_utils.py`.
+```
+
+Proposed replacement for the step-control test map
+
+```text
+Tests live in `tests/integrators/step_control/`. The CPU reference is
+`tests/integrators/cpu_reference/step_controllers.py`.
+```
+
+Evidence
+
+- `tests/integrators/cpu_reference/loops.py:47-142`
+- `tests/integrators/matrix_free_solvers/conftest.py:1-836`
+- `tests/integrators/matrix_free_solvers/test_base_solver.py:1-167`
+- `tests/integrators/matrix_free_solvers/test_bicgstab.py:1-199`
+- `tests/integrators/matrix_free_solvers/test_linear_solver.py:1-807`
+- `tests/integrators/matrix_free_solvers/test_newton_krylov.py:1-494`
+- `tests/integrators/step_control/test_gain_specs.py:1-133`
+- `tests/integrators/step_control/test_gustafsson_controller.py:1-89`
+- `tests/integrators/step_control/test_init.py:1-92`
+
+## D2-12 Remove AI-authorship commentary from test docstrings
+
+Current location
+
+`tests/integrators/cpu_reference/__init__.py:1-6`
+
+Current text
+
+```text
+Reference CPU implementations used across integrator tests.
+
+I've let genAI agents run fairly free on this module, adding many of the
+over-engineered and pointless checks and complicated chains that it loves to
+add, as all we really want in here is a reference implementation of the
+GPU integrator components.
+```
+
+Proposed replacement
+
+```text
+Reference CPU implementations used across integrator tests.
+```
+
+Current location
+
+`tests/integrators/cpu_reference/cpu_utils.py:626-628`
+
+Current text
+
+```text
+Return Horner evaluations and range flag for ``coefficients``.
+
+Busybody AI over-checking left in place.
+```
+
+Proposed replacement
+
+```text
+Return Horner evaluations and range flag for ``coefficients``.
+```
+
+## Deduplication receipt
+
+The following findings were not repeated as supplemental proposals.
+
+- Public algorithm registry omissions are covered by `INT-10` and `UFR-009`.
+- Public result-code omissions are covered by `UFR-016`.
+- Missing public integrator API pages and memory-heuristic coverage are
+  covered by `INT-15`.
+- The public damped-Newton claim is covered by `INT-04`.
+- Rendered source punctuation is covered by `STYLE-DOC-01` through
+  `STYLE-DOC-03`.

--- a/docs/review/repository_support_inventory.md
+++ b/docs/review/repository_support_inventory.md
@@ -1,0 +1,161 @@
+# Repository support inventory
+
+## Scope
+
+This lane covers the tracked complement left after the documentation,
+package, integrator, and test lanes were assigned. The manifest was derived
+from `git ls-files` and reconciled against those lane boundaries.
+
+The complement contains 61 files, 65,778 text lines, and 2,306,969 bytes.
+All files decode as strict UTF-8.
+
+| Class | Files | Lines | Bytes | Review method |
+|---|---:|---:|---:|---|
+| Human-authored prose, code, and configuration | 44 | 11,478 | 420,194 | Every line read |
+| Generated, schema, fixture, and inventory data | 17 | 54,300 | 1,886,775 | Every byte traversed and structure checked |
+| Total | 61 | 65,778 | 2,306,969 | Reconciled with the tracked manifest |
+
+The complement excludes all `docs/**` files, mapped documentation pages,
+the Python package and test lanes, and every `AGENTS.md` or `CLAUDE.md`
+instruction mirror. Those files appear in the other review inventories.
+
+## Findings
+
+Four freshness findings and one generated-artifact finding remain after a
+comparison with the other files in `docs/review`.
+
+| ID | Evidence | Result |
+|---|---|---|
+| D3-F01 | `benchmarks/lorenz_mean_runtime.py:520-527`, `benchmarks/lorenz_mean_runtime.py:651-654` | Command help says the wall statistic is a median. The implementation computes the mean of the lowest `k` wall times. |
+| D3-F02 | `benchmarks/memory_location_sweep.py:1088`, `src/cubie/integrators/memory_heuristics.py:1` | Printed paste instructions omit the repository's `src/` directory. |
+| D3-F03 | `scratch_profile/bench_ncu_bicgstab.py:40`, `scratch_profile/bench_ncu_bigsys.py:29` | Both profiling scripts prepend a nonexistent personal worktree path. |
+| D3-F04 | `tests/_inventory.json:8483-8727`, `src/cubie/odesystems/symbolic/engine/printer.py:26`, `src/cubie/odesystems/symbolic/engine/printer.py:95` | The inventory describes the removed `numba_cuda_printer.py` and `CUDAPrinter`. Current code exports `IRPrinter` from `engine/printer.py`. |
+| D3-F05 | `tests/_inventory.json:21716`, `src/cubie/batchsolving/_utils.py:13-16`, `tests/query_inventory.py:25-33` | The inventory calls `_utils.py` empty although it exports `name_and_compile_kernel`. Its query tool points to the missing `tests/_convert_inventory.py`. |
+
+The inventory drift is wider than D3-F04 and D3-F05. A section-symbol
+comparison found 16 buckets containing names absent from their matched
+current source file. Confirmed examples include `CacheConfig` at
+`tests/_inventory.json:3701-3715`, `_check_saved_indices` at
+`tests/_inventory.json:17585-17592`, and `_align_run_counts` at
+`tests/_inventory.json:22319`. Current definitions are visible at
+`src/cubie/cubie_cache.py:680`,
+`src/cubie/outputhandling/output_config.py:290-337`, and
+`src/cubie/batchsolving/BatchInputHandler.py:808-841`. The generated
+inventory needs a complete refresh from current source and tests.
+
+No existing review artifact mentions these findings. A search covered every
+file already present in `docs/review`.
+
+## Language scan
+
+The supplied false-drama and framing phrases have zero literal matches in
+this complement.
+
+Twenty-eight human-authored lines contain an em dash. Twenty-seven use it as
+sentence punctuation and have proposed rewrites. The remaining occurrence at
+`benchmarks/ncu_algorithm_comparison.py:427` is a table missing-value glyph.
+It is not sentence punctuation and remains valid.
+
+The semicolon review separated prose from syntax. Syntax uses remain valid in
+shell snippets, Python one-line commands, content-security-policy strings,
+MIME types, and generated result delimiters. Every prose semicolon and every
+framing colon found in the benchmark and support descriptions has a rewrite
+in `repository_support_supplemental_proposals.md`.
+
+The generated test inventory contains 8 semicolons and 331 colons in
+`section` or `text` values. Its stale content makes line edits unsafe. The
+proposal regenerates it and applies the prose rule at the source of
+generation.
+
+## Validation receipts
+
+The read-only structure checks produced these results.
+
+- Python AST parsing passed for 15 support scripts.
+- YAML parsing passed for 11 GitHub configuration files.
+- HCL parsing passed for the Terraform lock file, four Terraform files, and
+  the Packer file.
+- TOML parsing passed for `pyproject.toml`.
+- PowerShell parsing passed for all three PowerShell tools.
+- Bash syntax checking passed for `cloudshell-iam.sh`.
+- JavaScript syntax checking passed for `cost_dashboard.js`.
+- HTML parsing passed for `cost_dashboard.html`.
+- `cellml_1_0.rng` compiled as Relax NG. `mathml2.rng` compiled through an
+  include wrapper with a `mathml.math` start rule.
+- All nine CellML documents parsed and validated against
+  `cellml_1_0.rng`. They contain no duplicate component names, duplicate
+  variable names, or dangling mapped-variable references.
+- Both RNC files have balanced braces, parentheses, and brackets.
+  `cellml_1_0.rnc` includes `mathml2.rnc`.
+- `cellml_units.txt` loaded into an empty Pint registry with 32 units and
+  the `mks` system.
+- `version.txt` contains the valid semantic version `0.3.6`.
+- `tests/_inventory.json` parsed into 100 buckets and 3,482 entries. Every
+  entry has the required typed fields and its `file` field matches its
+  bucket key. Content freshness failed as recorded above.
+
+## File manifest
+
+| File | Lines | Bytes | Review |
+|---|---:|---:|---|
+| `.gitattributes` | 4 | 211 | Read, no documentation issue |
+| `.github/dependabot.yml` | 11 | 536 | Read, no documentation issue |
+| `.github/runs-on.yml` | 60 | 3,096 | Read, no documentation issue |
+| `.github/workflows/build-windows-gpu-ami.yml` | 210 | 8,963 | Read, no documentation issue |
+| `.github/workflows/ci_cuda_tests.yml` | 698 | 35,264 | Read, no documentation issue |
+| `.github/workflows/ci_nocuda_tests.yml` | 66 | 2,412 | Read, no documentation issue |
+| `.github/workflows/ci_semver_manage.yml` | 93 | 3,332 | Read, no documentation issue |
+| `.github/workflows/cleanup-ami-builder.yml` | 38 | 1,327 | Read, no documentation issue |
+| `.github/workflows/copilot-setup-steps.yml` | 40 | 1,309 | Read, no documentation issue |
+| `.github/workflows/documentation.yml` | 48 | 1,402 | Read, no documentation issue |
+| `.github/workflows/test_pypi.yml` | 76 | 2,415 | Read, no documentation issue |
+| `.github/workflows/todo-actions.yml` | 16 | 456 | Read, no documentation issue |
+| `.gitignore` | 73 | 671 | Read, no documentation issue |
+| `LICENSE` | 21 | 1,089 | Read, no documentation issue |
+| `benchmarks/ab_gate.py` | 574 | 23,388 | Prose rewrite candidates |
+| `benchmarks/dense_prediction_ratio_sweep.py` | 689 | 24,522 | Prose rewrite candidates |
+| `benchmarks/lorenz_mean_runtime.py` | 704 | 26,006 | D3-F01 and prose rewrite candidates |
+| `benchmarks/memory_location_sweep.py` | 1,126 | 39,217 | D3-F02 and prose rewrite candidates |
+| `benchmarks/ncu_algorithm_comparison.py` | 821 | 25,659 | Prose rewrite candidates |
+| `benchmarks/ncu_algorithm_worker.py` | 299 | 9,380 | Prose rewrite candidates |
+| `benchmarks/vendor_julia_reference.py` | 136 | 5,700 | Prose rewrite candidates |
+| `blackbox/__init__.py` | 56 | 1,876 | Prose rewrite candidates |
+| `blackbox/blackbox1` | 1,201 | 41,946 | CellML structure clean |
+| `blackbox/blackbox2` | 7,062 | 298,860 | CellML structure clean |
+| `blackbox_solve_2.py` | 309 | 12,018 | Prose rewrite candidates |
+| `ci/requirements.ci.txt` | 13 | 156 | Read, no documentation issue |
+| `ci/tools/install_gpu_driver.ps1` | 154 | 6,055 | Read, no documentation issue |
+| `ci/tools/merge_junit.py` | 94 | 2,982 | Prose rewrite candidate |
+| `ci/tools/populate_uv_cache.ps1` | 97 | 3,502 | Read, no documentation issue |
+| `ci/tools/prepare_ci_image.ps1` | 208 | 7,807 | Read, no documentation issue |
+| `infra/fleet/.gitignore` | 7 | 92 | Read, no documentation issue |
+| `infra/fleet/.terraform.lock.hcl` | 76 | 4,344 | HCL structure clean |
+| `infra/fleet/bootstrap/cloudshell-iam.sh` | 553 | 18,862 | Read and syntax checked |
+| `infra/fleet/cost_dashboard.html` | 138 | 4,831 | Read and structure checked |
+| `infra/fleet/cost_dashboard.js` | 609 | 18,922 | Read and syntax checked |
+| `infra/fleet/cost_dashboard.py` | 2,238 | 84,104 | Prose rewrite candidates |
+| `infra/fleet/main.tf` | 191 | 6,105 | Read and structure checked |
+| `infra/fleet/outputs.tf` | 14 | 474 | Read and structure checked |
+| `infra/fleet/terraform.tfvars.example` | 13 | 528 | Read and structure checked |
+| `infra/fleet/variables.tf` | 50 | 1,658 | Read and structure checked |
+| `noxfile.py` | 61 | 2,547 | Prose rewrite candidates |
+| `packer/windows-gpu.pkr.hcl` | 177 | 5,834 | Read and structure checked |
+| `pyproject.toml` | 179 | 6,141 | Prose rewrite candidates |
+| `scratch_profile/bench_ncu_bicgstab.py` | 169 | 6,388 | D3-F03 and prose rewrite candidates |
+| `scratch_profile/bench_ncu_bigsys.py` | 156 | 5,387 | D3-F03 and prose rewrite candidates |
+| `src/cubie/vendored/cellmlmanip/LICENSE` | 34 | 1,821 | Read, no documentation issue |
+| `src/cubie/vendored/cellmlmanip/data/cellml_1_0.rnc` | 508 | 18,320 | RNC structure clean |
+| `src/cubie/vendored/cellmlmanip/data/cellml_1_0.rng` | 989 | 34,262 | Relax NG structure clean |
+| `src/cubie/vendored/cellmlmanip/data/cellml_units.txt` | 47 | 1,103 | Pint definitions load cleanly |
+| `src/cubie/vendored/cellmlmanip/data/mathml2.rnc` | 1,278 | 47,972 | RNC structure clean |
+| `src/cubie/vendored/cellmlmanip/data/mathml2.rng` | 3,450 | 102,803 | Relax NG include structure clean |
+| `src/cubie/vendored/cellmlmanip/version.txt` | 1 | 7 | Semantic version clean |
+| `tests/_inventory.json` | 27,201 | 801,479 | D3-F04 and D3-F05 |
+| `tests/fixtures/cellml/Fabbri_Linder.cellml` | 7,158 | 314,345 | CellML structure clean |
+| `tests/fixtures/cellml/_make_blackbox.py` | 155 | 5,749 | Read and syntax checked |
+| `tests/fixtures/cellml/basic_ode.cellml` | 23 | 721 | CellML structure clean |
+| `tests/fixtures/cellml/beeler_reuter_model_1977.cellml` | 1,246 | 46,832 | CellML structure clean |
+| `tests/fixtures/cellml/demir_clark_giles_1999.cellml` | 3,951 | 170,288 | CellML structure clean |
+| `tests/fixtures/cellml/ghk_singularity.cellml` | 51 | 1,741 | CellML structure clean |
+| `tests/fixtures/cellml/two_time_variables.cellml` | 29 | 874 | CellML structure clean |
+| `tests/fixtures/cellml/underscore_names.cellml` | 29 | 878 | CellML structure clean |

--- a/docs/review/repository_support_supplemental_proposals.md
+++ b/docs/review/repository_support_supplemental_proposals.md
@@ -1,0 +1,402 @@
+# Repository support supplemental proposals
+
+The file records review proposals. No existing source, test,
+configuration, or documentation file was changed.
+
+## Freshness corrections
+
+### D3-F01 Lorenz command help
+
+Evidence is at `benchmarks/lorenz_mean_runtime.py:520-527` and
+`benchmarks/lorenz_mean_runtime.py:651-654`.
+
+Replace the `ArgumentParser` description.
+
+```python
+description=(
+    "Kernel-runtime benchmark for the Lorenz ensemble. "
+    "Prints compile metrics and the mean of the lowest kernel and "
+    "wall times for each configuration. Use ab_gate.py for A/B "
+    "comparisons."
+)
+```
+
+The calculations at lines 520 through 523 and the result description at
+lines 525 through 527 use the mean of the lowest values.
+
+### D3-F02 Memory heuristic destination
+
+Evidence is at `benchmarks/memory_location_sweep.py:1088`. The target exists
+at `src/cubie/integrators/memory_heuristics.py`.
+
+Replace the printed destination.
+
+```python
+print("\npaste into src/cubie/integrators/memory_heuristics.py")
+```
+
+### D3-F03 Profiling script import roots
+
+Evidence is at `scratch_profile/bench_ncu_bicgstab.py:37-40` and
+`scratch_profile/bench_ncu_bigsys.py:26-29`. The referenced
+`C:\local_working_projects\cubie-bicgstab-review\src` directory does not
+exist.
+
+Use the checked-out repository containing each script.
+
+```python
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+```
+
+Apply the same replacement to both scripts.
+
+### D3-F04 and D3-F05 Test inventory regeneration
+
+The generated artifact at `tests/_inventory.json` contains distributed
+stale content.
+
+Confirmed drift locations include
+
+- `tests/_inventory.json:8483-8727` describes the removed
+  `numba_cuda_printer.py` and `CUDAPrinter`.
+- `tests/_inventory.json:21716` says `batchsolving/_utils.py` has no public
+  exports. The module exports `name_and_compile_kernel` at
+  `src/cubie/batchsolving/_utils.py:13-16`.
+- `tests/_inventory.json:3701-3715` describes the removed `CacheConfig`.
+- `tests/_inventory.json:17585-17592` describes the removed
+  `_check_saved_indices` method.
+- `tests/_inventory.json:22319` describes the removed `_align_run_counts`
+  method.
+- A source-symbol comparison found candidate drift in 16 of the 100 file
+  buckets.
+- `tests/query_inventory.py:29` names the missing
+  `tests/_convert_inventory.py` as its regeneration command.
+
+Regenerate all 100 buckets from current source and tests. The generated
+result must satisfy six checks.
+
+1. Every bucket resolves to a tracked source file.
+2. Every section symbol resolves to current code or is identified as an
+   inherited symbol.
+3. Every description states current behavior.
+4. Every `file` field equals its bucket key.
+5. The query command lists and retrieves every bucket.
+6. The regeneration command named by the query tool exists and reproduces
+   the checked-in JSON.
+
+If the inventory remains a maintained file without a generator, replace the
+missing-file branch in `tests/query_inventory.py:25-33` with truthful output.
+
+```python
+if not INVENTORY.exists():
+    print(f"ERROR: {INVENTORY} not found.", file=sys.stderr)
+    sys.exit(1)
+```
+
+The generator should remove the eight prose semicolons currently found in
+`text` values. Apply the table replacements.
+
+| Current location | Proposed text |
+|---|---|
+| `tests/_inventory.json:43` | Precision is removed from `output_settings`. The system precision is used. |
+| `tests/_inventory.json:1565` | Dictionary values are unpacked into the result. The original key is tracked. |
+| `tests/_inventory.json:2120` | Returns `(True, True)` when values change and invalidates the layouts. |
+| `tests/_inventory.json:4467` | Construction with `dxdt` succeeds. Optional fields default to `-1`. |
+| `tests/_inventory.json:4921` | Recomputes the hash and updates `gen_file` when the hash changes. |
+| `tests/_inventory.json:5138` | Checks the `gen_file` cache and marks the operation skipped on a cache hit. |
+| `tests/_inventory.json:5973` | Construction stores all fields and applies tuple converters to sequence fields. |
+| `tests/_inventory.json:16408` | Adaptive mode calls the controller. Acceptance requires `accept_step[0]` and no step failure. |
+
+The regenerated values contain many compact condition labels written as
+`condition: result`. Render them as factual sentences. For example, replace
+`In real CUDA: delegates to _is_cuda_array` with `Delegates to
+_is_cuda_array under real CUDA`.
+
+## Em dash rewrites
+
+The missing-value glyph at `benchmarks/ncu_algorithm_comparison.py:427`
+remains. It is table data, not sentence punctuation.
+
+### `benchmarks/ab_gate.py`
+
+Replace the affected prose at lines 4 through 18.
+
+```text
+For each installed CUDA backend the gate starts two persistent
+``lorenz_mean_runtime.py --worker`` processes. Side A imports ``cubie``
+from an ephemeral ``git worktree`` at ``--main``. The default is
+``origin/main`` and the worktree is removed afterward. Side B imports
+``cubie`` from the current repository. The gate ping-pongs short solve blocks
+between them in drift-balancing ABBA order. Each block reports the mean
+of its lowest ``k`` per-solve kernel times and the mean of its lowest
+``k`` per-solve wall times.
+
+Host scatter adds time. The wall floor excludes that scatter and detects
+changes that lengthen the end-to-end critical path or remove chunk-transfer
+overlap. Each verdict is the median paired percent
+delta. Kernel deltas gate at ``--threshold``. Wall deltas gate at
+``--wall-threshold``.
+```
+
+Replace the affected prose at lines 37 through 45.
+
+```text
+``host_overhead`` uses eight trajectories. Its sub-millisecond wall
+statistic measures the per-call host cost of ``Solver.solve``. The wall
+statistic gates in absolute milliseconds with
+``--host-overhead-threshold`` because a fixed per-call cost is a rounding
+error against the percentage thresholds used by the other configurations.
+It has no kernel row because the eight-trajectory kernel is launch
+dominated. Both workers run the current repository's benchmark script. Each side
+uses its assigned ``cubie`` import. A configuration announced by one worker
+is skipped with a notice.
+```
+
+Replace the affected prose at lines 47 through 60.
+
+```text
+Block design
+
+The floor of the kernel-time distribution tracks the compiled kernel's
+intrinsic cost and moves with GPU clock state.
+Running paired blocks seconds apart minimizes clock-state drift within the
+pair. The pairing cancels clock-state drift. Each side pays its process startup,
+JIT compilation, and grid construction costs once. A row is marked
+DISTRUST when at least two pairs lie on each side of the regression
+threshold. Rerun after increasing ``--pairs`` or reducing background GPU
+load before using a DISTRUST row. Constant background load increases
+absolute times but cancels from the deltas. Both workers hold their device
+pools concurrently. The default allocation is 0.7 GB per worker. Chunking
+depends on ``--n-runs``.
+```
+
+Replace the comment at lines 341 through 343.
+
+```python
+# Size the wave configuration to two full waves at side A's
+# occupancy and impose that count on both sides. An occupancy drop
+# on side B must then add a third wave.
+```
+
+### `benchmarks/lorenz_mean_runtime.py`
+
+Replace lines 4 through 10.
+
+```text
+The benchmark solves the Lorenz ensemble used by the GPUODEBenchmarks
+CuBIE runner with the same solver settings. One warm-up solve absorbs JIT
+compilation. ``timeit.repeat`` then runs one solve per repeat with garbage
+collection enabled. The first 20 post-warm-up solves are discarded because
+the GPU has not reached steady state. The statistic uses the next
+``repeats`` solves.
+```
+
+Replace the affected Radau description at lines 19 through 24.
+
+```text
+The implicit solves cost tens of milliseconds at the configured batch size. Generated
+symbol aliasing prevents Newton from reaching its iteration cap. Launch
+effects do not blur the measured runtime. Adaptive blocks stay within the gate's runtime
+budget.
+```
+
+Replace the affected descriptions at lines 43 through 64.
+
+```text
+``host_overhead`` runs the fixed configuration with eight trajectories.
+The positional ``n_runs`` value does not scale it. Its kernel runs in tens
+of microseconds. Its wall statistic measures the per-call host cost of
+``Solver.solve`` for every batch size.
+
+The kernel statistic is the mean of the lowest ``min_count`` per-solve
+kernel times recorded by the per-chunk CUDA events. The selected solves ran
+at full boost clock without on-GPU contention. They track the compiled
+kernel's intrinsic cost. The wall statistic is the mean of the lowest
+``min_count`` host times measured across ``Solver.solve``. Host delays add time. The
+wall floor excludes those delays and detects longer critical paths and lost
+chunk overlap. Wall thresholds account for host scatter.
+```
+
+Replace the affected compile-metric text at lines 66 through 76.
+
+```text
+Compile metrics include registers per thread, ptxas spill-store and
+spill-load byte counts, memory sizes, launch geometry, occupancy, SM count,
+run count, and chunk count. Spill counts come from the verbose link log for
+each cubin digest. They report code-generation counts. They do not report
+allocated bytes per thread or runtime traffic. The script clears caches at
+startup so the kernels link in the benchmark process unless
+``--no-clear-cache`` is given.
+``ab_gate.py`` supplies that option with a fresh cache directory. All
+metrics require a real GPU. The script exits under the CUDA simulator.
+```
+
+Replace lines 85 through 91.
+
+```text
+``--worker`` starts a persistent solve server for ``ab_gate.py``. It builds
+the solvers, loads the grids, runs one warm-up solve for each configuration,
+prints one ``@META`` line per configuration, and prints
+``@READY <config>...``. The wave configuration is omitted from ``@READY``
+because the gate supplies its size. The worker then accepts commands on
+standard input until `quit` or end of file.
+```
+
+### Other em dash locations
+
+Apply the direct replacements.
+
+| Location | Proposed text |
+|---|---|
+| `benchmarks/ncu_algorithm_comparison.py:8-11` | Every launch runs `2**20` trajectories, providing ten-plus occupancy waves at 24 resident blocks per SM on a 56-SM GPU. |
+| `benchmarks/ncu_algorithm_comparison.py:16-22` | MLIR strips line tables during LTO linking. Each algorithm is profiled with an `-lto` production arm followed by a `-nolto` source-attribution arm. The report places them next to each other. Use the non-LTO arm for source structure and the LTO arm for absolute measurements. |
+| `benchmarks/ncu_algorithm_comparison.py:49-53` | Disable "Profile from start". The worker brackets the launches with `cuda.profile_start()` and `cuda.profile_stop()`. The brackets exclude the preparation solve. |
+| `blackbox/__init__.py:8-11` | Every state, observable, and constant label is an opaque token such as `cN_vM`. The systems carry no domain semantics. They arrive unbuilt. CuBIE compiles their CUDA kernels on the first solve. |
+| `noxfile.py:40-46` | The cache key does not include the CUDA toolkit version. Wipe the shared cache before each cell to prevent a later cell from loading a kernel compiled by an earlier cell. |
+| `noxfile.py:53-55` | Nox runs the cells serially. Each cell keeps the project's `-n8` xdist setting used by local and CI test runs. |
+| `pyproject.toml:56-61` | The `mlir*` extras install CuBIE's `cubie-numba-cuda-mlir` build with pending native fixes. It uses the `numba_cuda_mlir` import package and must not be installed with the stock wheel. Python compatibility fixes are applied by `cubie._mlir_compat`. |
+| `scratch_profile/bench_ncu_bicgstab.py:24-29` | `nruns` defaults to 65,536, which supplies 256 blocks at block size 256 and saturates the 56 SMs on an RTX 4070 SUPER. `blocksize` defaults to 256. `limit_blocksize` first halves the block size when both `dynamic_sharedmem >= 32 KiB` and `blocksize > 32`. The performance stage stops at `blocksize == 32` regardless of footprint. A hardware stage permits `blocksize < 32` when the device's per-block limit requires it. The script prints the effective launch shape. |
+
+## Semicolon rewrites
+
+For every listed prose location, replace the semicolon with a period and
+capitalize the next clause. In compact function docstrings, use two
+sentences. In definition lists, move each item to its own sentence or list
+entry.
+
+- `benchmarks/ab_gate.py:7`, `benchmarks/ab_gate.py:25`,
+  `benchmarks/ab_gate.py:31`, `benchmarks/ab_gate.py:33`,
+  `benchmarks/ab_gate.py:36`, `benchmarks/ab_gate.py:44`,
+  `benchmarks/ab_gate.py:59`, `benchmarks/ab_gate.py:70`,
+  `benchmarks/ab_gate.py:130`, `benchmarks/ab_gate.py:175`,
+  `benchmarks/ab_gate.py:187`, `benchmarks/ab_gate.py:240`,
+  `benchmarks/ab_gate.py:252`, `benchmarks/ab_gate.py:264`,
+  `benchmarks/ab_gate.py:368`, `benchmarks/ab_gate.py:414`,
+  `benchmarks/ab_gate.py:444`, `benchmarks/ab_gate.py:450`,
+  `benchmarks/ab_gate.py:461`, `benchmarks/ab_gate.py:476`,
+  `benchmarks/ab_gate.py:485`, and `benchmarks/ab_gate.py:566`.
+- `benchmarks/dense_prediction_ratio_sweep.py:9`,
+  `benchmarks/dense_prediction_ratio_sweep.py:17`,
+  `benchmarks/dense_prediction_ratio_sweep.py:20`,
+  `benchmarks/dense_prediction_ratio_sweep.py:23`,
+  `benchmarks/dense_prediction_ratio_sweep.py:27`,
+  `benchmarks/dense_prediction_ratio_sweep.py:35`,
+  `benchmarks/dense_prediction_ratio_sweep.py:53`, and
+  `benchmarks/dense_prediction_ratio_sweep.py:502`.
+- `benchmarks/lorenz_mean_runtime.py:66-69`,
+  `benchmarks/lorenz_mean_runtime.py:75`,
+  `benchmarks/lorenz_mean_runtime.py:367`,
+  `benchmarks/lorenz_mean_runtime.py:375`,
+  `benchmarks/lorenz_mean_runtime.py:384`,
+  `benchmarks/lorenz_mean_runtime.py:406`,
+  `benchmarks/lorenz_mean_runtime.py:419`,
+  `benchmarks/lorenz_mean_runtime.py:471`,
+  `benchmarks/lorenz_mean_runtime.py:493`,
+  `benchmarks/lorenz_mean_runtime.py:593`,
+  `benchmarks/lorenz_mean_runtime.py:603`,
+  `benchmarks/lorenz_mean_runtime.py:608`, and
+  `benchmarks/lorenz_mean_runtime.py:686`.
+- `benchmarks/memory_location_sweep.py:12`,
+  `benchmarks/memory_location_sweep.py:67`,
+  `benchmarks/memory_location_sweep.py:320`, and
+  `benchmarks/memory_location_sweep.py:712`.
+- `benchmarks/ncu_algorithm_comparison.py:8`,
+  `benchmarks/ncu_algorithm_comparison.py:50`,
+  `benchmarks/ncu_algorithm_comparison.py:275`, and
+  `benchmarks/ncu_algorithm_comparison.py:808`.
+- `benchmarks/ncu_algorithm_worker.py:158` and
+  `benchmarks/ncu_algorithm_worker.py:243`.
+- `benchmarks/vendor_julia_reference.py:34` and
+  `benchmarks/vendor_julia_reference.py:48`.
+- `blackbox/__init__.py:9`, `blackbox_solve_2.py:51`, and
+  `ci/tools/merge_junit.py:1`.
+- `infra/fleet/cost_dashboard.py:15`,
+  `infra/fleet/cost_dashboard.py:20`,
+  `infra/fleet/cost_dashboard.py:30`,
+  `infra/fleet/cost_dashboard.py:64`,
+  `infra/fleet/cost_dashboard.py:95`,
+  `infra/fleet/cost_dashboard.py:126`,
+  `infra/fleet/cost_dashboard.py:1099`,
+  `infra/fleet/cost_dashboard.py:1123`,
+  `infra/fleet/cost_dashboard.py:1178`, and
+  `infra/fleet/cost_dashboard.py:1226`.
+- `scratch_profile/bench_ncu_bicgstab.py:21`,
+  `scratch_profile/bench_ncu_bicgstab.py:26`, and
+  `scratch_profile/bench_ncu_bigsys.py:20`.
+
+Keep semicolons that are part of Python command strings, generated report
+delimiters, CSS content-security policies, and MIME types. They are syntax,
+not prose structure.
+
+## Framing colon rewrites
+
+Apply replacements where the colon acts as sentence framing.
+
+| Location | Proposed text |
+|---|---|
+| `benchmarks/ab_gate.py:2` | `Block-interleaved A/B kernel-runtime gate comparing main with the worktree.` |
+| `benchmarks/ab_gate.py:47` | Use the heading `Block design`. |
+| `benchmarks/dense_prediction_ratio_sweep.py:43-45` | `float16 is not swept. No implicit-solver path runs at float16, and the seed comparison cannot discriminate at its tolerances. Its ceilings remain 0.0.` |
+| `benchmarks/lorenz_mean_runtime.py:6-10` | `The benchmark runs one warm-up solve, then runs one solve per timeit.repeat sample with garbage collection enabled. It discards 20 post-warm-up solves before calculating the statistic.` |
+| `benchmarks/lorenz_mean_runtime.py:12` | `Five configurations report compile metrics and two runtime statistics.` |
+| `benchmarks/lorenz_mean_runtime.py:33-34` | `Its wall time detects critical-path transfer, staging, writeback, and lost overlap costs that kernel events omit.` |
+| `benchmarks/lorenz_mean_runtime.py:37-42` | `The fixed configuration is sized to two full waves using 2 * SMs * blocks_per_SM * runs_per_block trajectories.` |
+| `benchmarks/lorenz_mean_runtime.py:72-76` | `The script clears caches at startup so kernels link in the benchmark process unless --no-clear-cache is given. ab_gate.py supplies that option with a fresh cache directory. The metrics require a real GPU.` |
+| `benchmarks/memory_location_sweep.py:23-24` | `The driver uses single-configuration mode internally and invokes one subprocess per configuration.` |
+| `benchmarks/memory_location_sweep.py:29-31` | `To calibrate a card, run the sweep, run --fit, and commit the emitted entry under the card's architecture code.` |
+| `benchmarks/memory_location_sweep.py:35-37` | `Timing uses the method in benchmarks/lorenz_mean_runtime.py. It records per-chunk CUDA events after one warm-up solve.` |
+| `benchmarks/memory_location_sweep.py:179-183` | `Every state in the nonlinear nearest-neighbour chain couples to its ring neighbours through one nonlinear term.` |
+| `benchmarks/memory_location_sweep.py:239-242` | `Both sides disable auto_memory. The sweep measures explicit placements and excludes the heuristics under calibration.` |
+| `benchmarks/ncu_algorithm_worker.py:148-151` | `Each arm builds its own system instance. Two solvers sharing one SymbolicODE mutate shared factory state, making kernel output depend on build order.` |
+| `blackbox_solve_2.py:61-62` | `Choose from state, observables, time, iteration_counters, and summaries.` |
+| `scratch_profile/bench_ncu_bicgstab.py:15` | Use the heading `Variants`. |
+| `scratch_profile/bench_ncu_bicgstab.py:31-35` | Use the heading `Metrics` followed by the metric list. |
+| `scratch_profile/bench_ncu_bigsys.py:13` | Use the heading `Variants`. |
+| `scratch_profile/bench_ncu_bigsys.py:22-24` | `Resident thread count sets the L1 and L2 capacity available to each 4 to 16 KB per-run working set under local placement.` |
+| `tests/fixtures/cellml/_make_blackbox.py:19-21` | `The transform preserves element order. Cellmlmanip uses document order, so output column i matches source column i.` |
+
+Retain colons required by reStructuredText `Usage::` blocks, numpydoc field
+syntax, URLs, endpoint names, format strings, type annotations, dictionary
+literals, and literal protocol labels. Each retained colon carries syntax or
+introduces a structured list.
+
+## Framing and emphasis cleanup
+
+Replace the simulator marker description at `pyproject.toml:105`.
+
+```toml
+"sim_only marks simulator-only debug tests"
+```
+
+Replace the trusted-publishing permission comments at
+`.github/workflows/ci_semver_manage.yml:75` and
+`.github/workflows/test_pypi.yml:55`.
+
+```yaml
+# Trusted publishing requires the OIDC `id-token: write` permission.
+```
+
+Replace the protected-environment framing at
+`.github/workflows/test_pypi.yml:58-59`.
+
+```yaml
+# The publishing job uses the protected testpypi environment.
+```
+
+Replace the one-line merge helper description at
+`ci/tools/merge_junit.py:1`.
+
+```python
+"""Merge JUnit reports. Retain node IDs supplied in NODES.json."""
+```
+
+Replace the output-category help at `blackbox_solve_2.py:59-62` with
+`Use 'state' for one state-output launch`.
+
+Replace the spot-price comment at `packer/windows-gpu.pkr.hcl:31` with
+`must clear`.

--- a/docs/review/root_batch_source_inventory.md
+++ b/docs/review/root_batch_source_inventory.md
@@ -1,0 +1,119 @@
+# Root and batch source coverage inventory
+
+## Scope and receipt
+
+This inventory covers the exact union of these tracked pathspecs.
+
+- Root-level `src/cubie/*.py`
+- Every tracked file under `src/cubie/batchsolving/**`, excluding
+  `CLAUDE.md` symlink duplicates
+- Root-level `tests/*.py`
+- Every tracked file under `tests/batchsolving/**`
+
+The manifest was built with `git ls-files`, sorted, and deduplicated. Every
+byte was decoded and every physical line was visited. Every non-empty Python
+file was also parsed into an AST and checked against the current Sphinx pages,
+the three existing review inventories, and the three existing rewrite-proposal
+artifacts.
+
+Receipt: **70 tracked text files, 45,405 physical lines, 0 binary assets**.
+The per-file counts below sum to 45,405 and the rows sum to 70.
+
+Instruction receipt: `AGENTS.md` (126 lines), `src/cubie/AGENTS.md`
+(210 lines), `src/cubie/batchsolving/AGENTS.md` (160 lines), and
+`src/cubie/batchsolving/arrays/AGENTS.md` (141 lines) were read in full before
+classification. The two batch instruction files are also rows in the scoped
+manifest.
+
+`Existing` means the documentation impact is already recorded in one of the
+six existing review artifacts. `Supplemental` points to a new proposal in
+`root_batch_supplemental_proposals.md`. `None` means the line review found no
+additional documentation impact.
+
+## Manifest
+
+| Tracked file | Physical lines | Coverage | Documentation impact |
+|---|---:|---|---|
+| `src/cubie/__init__.py` | 56 | READ-COMPLETE | Supplemental RB-06; confirms the undocumented top-level `TimeLogger` and `default_timelogger` exports. |
+| `src/cubie/_env.py` | 180 | READ-COMPLETE | Existing UFR-C01. |
+| `src/cubie/_mlir_compat.py` | 2,896 | READ-COMPLETE | None; internal backend shims agree with the package-root architecture mirror. |
+| `src/cubie/_numba_cuda_compat.py` | 1,057 | READ-COMPLETE | None; internal backend shims agree with the package-root architecture mirror. |
+| `src/cubie/_serialize.py` | 220 | READ-COMPLETE | Existing DG-09 and the package-root architecture mirror cover canonical config hashing. |
+| `src/cubie/_utils.py` | 793 | READ-COMPLETE | None beyond existing developer-guide configuration findings. |
+| `src/cubie/array_interpolator.py` | 1,151 | READ-COMPLETE | Supplemental RB-07; the documented direct-use class has no API-reference page, the prospective member list omitted `evaluation_function` and `coefficients`, and `update_from_dict` contains Markdown that is invalid in rendered RST. Existing UFR-013 and UFR-026 cover the stale timing key and example. |
+| `src/cubie/batchsolving/__init__.py` | 74 | READ-COMPLETE | Existing API-03; public batch exports are missing from the page tree. |
+| `src/cubie/batchsolving/_utils.py` | 47 | READ-COMPLETE | None; docstring-only internal module. |
+| `src/cubie/batchsolving/AGENTS.md` | 160 | READ-COMPLETE | Supplemental RB-01 and RB-02. |
+| `src/cubie/batchsolving/arrays/__init__.py` | 0 | READ-COMPLETE | None; tracked empty file. |
+| `src/cubie/batchsolving/arrays/AGENTS.md` | 141 | READ-COMPLETE | None; source and tests confirm the documented ownership, chunking, staging, and loan lifecycle. |
+| `src/cubie/batchsolving/arrays/BaseArrayManager.py` | 1,185 | READ-COMPLETE | Existing API-02, STYLE-DOC-02, and STYLE-DOC-03. |
+| `src/cubie/batchsolving/arrays/BatchInputArrays.py` | 585 | READ-COMPLETE | Existing API-02, STYLE-DOC-02, and STYLE-DOC-03. |
+| `src/cubie/batchsolving/arrays/BatchOutputArrays.py` | 581 | READ-COMPLETE | Existing API-02, STYLE-DOC-02, and STYLE-DOC-03. |
+| `src/cubie/batchsolving/BatchInputHandler.py` | 1,423 | READ-COMPLETE | Existing API-03; the public class lacks a page. STYLE-PROSPECTIVE-01 records its prospective autodoc punctuation and framing rewrites. |
+| `src/cubie/batchsolving/BatchSolverConfig.py` | 199 | READ-COMPLETE | Supplemental RB-01; existing UFR-012 and STYLE-DOC-02/03 cover user-facing kernel keys and punctuation. |
+| `src/cubie/batchsolving/BatchSolverKernel.py` | 1,663 | READ-COMPLETE | Existing API-03 and STYLE-DOC-01/02/03. |
+| `src/cubie/batchsolving/solver.py` | 1,324 | READ-COMPLETE | Supplemental RB-03 and RB-04; existing API-01/03 and UFR findings cover the other public behavior. |
+| `src/cubie/batchsolving/solveresult.py` | 1,080 | READ-COMPLETE | Supplemental RB-02. Existing result findings cover `SolveResult`; STYLE-PROSPECTIVE-01 records the prospective `DeviceSolveResult` autodoc findings. |
+| `src/cubie/batchsolving/SystemInterface.py` | 513 | READ-COMPLETE | Supplemental RB-05; existing STYLE-DOC-03 covers the rendered `update` wording. |
+| `src/cubie/batchsolving/writeback_watcher.py` | 407 | READ-COMPLETE | None; internal asynchronous transfer service is covered by the batch architecture mirror. |
+| `src/cubie/buffer_registry.py` | 1,254 | READ-COMPLETE | Existing DG-11 through DG-13. |
+| `src/cubie/cache_root.py` | 78 | READ-COMPLETE | Existing UFR-007 and UFR-C01. |
+| `src/cubie/cubie_cache.py` | 889 | READ-COMPLETE | Existing UFR-006, UFR-007, and UFR-012. |
+| `src/cubie/cuda_backend.py` | 123 | READ-COMPLETE | Existing UFR-001, UFR-002, and UFR-C01. |
+| `src/cubie/cuda_simsafe.py` | 734 | READ-COMPLETE | Existing UFR-C01 and UFR-029. |
+| `src/cubie/CUDAFactory.py` | 878 | READ-COMPLETE | Existing DG-07 through DG-10 and UFR-029. |
+| `src/cubie/result_codes.py` | 91 | READ-COMPLETE | Existing UFR-016, UFR-C05, INT-02, and INT-15. |
+| `src/cubie/time_logger.py` | 803 | READ-COMPLETE | Supplemental RB-03 and RB-06. RB-06 includes the semicolon and framing rewrites that its proposed `:members:` page would expose. Existing UFR-021 and UFR-022 cover capability claims. |
+| `tests/__init__.py` | 0 | READ-COMPLETE | None; tracked empty file. |
+| `tests/_precompile_hashing.py` | 146 | READ-COMPLETE | None; test helper only. |
+| `tests/_utils.py` | 2,405 | READ-COMPLETE | None; shared fixtures and test helpers only. |
+| `tests/banked_plugin.py` | 67 | READ-COMPLETE | None; pytest plugin helper only. |
+| `tests/batchsolving/arrays/test_basearraymanager.py` | 2,533 | READ-COMPLETE | Confirms existing API-02 and array architecture findings; no additional documentation impact. |
+| `tests/batchsolving/arrays/test_batchinputarrays.py` | 305 | READ-COMPLETE | Confirms existing API-02 and device-input lifecycle findings; no additional documentation impact. |
+| `tests/batchsolving/arrays/test_batchoutputarrays.py` | 565 | READ-COMPLETE | Confirms existing API-02 and output-allocation findings; no additional documentation impact. |
+| `tests/batchsolving/arrays/test_chunking.py` | 755 | READ-COMPLETE | Confirms existing UFR-014, UFR-C02, and API-02; no additional documentation impact. |
+| `tests/batchsolving/arrays/test_managed_array.py` | 52 | READ-COMPLETE | Confirms the arrays architecture mirror; no additional documentation impact. |
+| `tests/batchsolving/test_batch_input_handler.py` | 1,076 | READ-COMPLETE | Confirms existing API-03 and batching behavior; no additional documentation impact. |
+| `tests/batchsolving/test_BatchSolverConfig.py` | 211 | READ-COMPLETE | Confirms Supplemental RB-01 and existing ActiveOutputs findings. |
+| `tests/batchsolving/test_config_plumbing.py` | 795 | READ-COMPLETE | Confirms Supplemental RB-04 and existing UFR-012/UFR-C04 configuration findings. |
+| `tests/batchsolving/test_memory_pressure.py` | 391 | READ-COMPLETE | Confirms Supplemental RB-04 and existing UFR-014/UFR-C02 memory findings. |
+| `tests/batchsolving/test_runparams.py` | 318 | READ-COMPLETE | Confirms the batch architecture mirror; no additional documentation impact. |
+| `tests/batchsolving/test_solver_teardown.py` | 341 | READ-COMPLETE | Confirms Supplemental RB-02 and existing UFR-C02 cleanup findings. |
+| `tests/batchsolving/test_solver.py` | 2,042 | READ-COMPLETE | Confirms Supplemental RB-03/RB-04 and the existing API/UFR solver findings. |
+| `tests/batchsolving/test_solveresult.py` | 798 | READ-COMPLETE | Confirms Supplemental RB-02 and existing result findings. |
+| `tests/batchsolving/test_SolverKernel.py` | 559 | READ-COMPLETE | Confirms existing kernel API and timing-validation findings; no additional documentation impact. |
+| `tests/batchsolving/test_system_interface.py` | 382 | READ-COMPLETE | Confirms Supplemental RB-05. |
+| `tests/batchsolving/test_utils.py` | 27 | READ-COMPLETE | None; internal helper test only. |
+| `tests/batchsolving/test_writeback_watcher.py` | 564 | READ-COMPLETE | Confirms the batch architecture mirror; no additional documentation impact. |
+| `tests/conftest.py` | 1,644 | READ-COMPLETE | Existing DG-17 through DG-19 and UFR-028 cover test setup and fixture policy. |
+| `tests/numba_cache_locator.py` | 30 | READ-COMPLETE | None; subprocess cache helper only. |
+| `tests/precompile_plugin.py` | 633 | READ-COMPLETE | None; pytest precompile plugin only. |
+| `tests/query_inventory.py` | 130 | READ-COMPLETE | None; test-selection inventory helper only. |
+| `tests/system_fixtures.py` | 697 | READ-COMPLETE | Existing DG-18, DG-19, and UFR-028 cover fixture use. |
+| `tests/test_array_interpolator.py` | 1,406 | READ-COMPLETE | Confirms Supplemental RB-07 and existing UFR-013/UFR-026. |
+| `tests/test_buffer_registry.py` | 1,200 | READ-COMPLETE | Confirms existing DG-11 through DG-13. |
+| `tests/test_cache_config.py` | 692 | READ-COMPLETE | Confirms existing UFR-007 and UFR-012. |
+| `tests/test_cache_root.py` | 101 | READ-COMPLETE | Confirms existing UFR-007 and UFR-C01. |
+| `tests/test_cubie_cache.py` | 791 | READ-COMPLETE | Confirms existing UFR-006, UFR-007, and UFR-012. |
+| `tests/test_cuda_simsafe.py` | 60 | READ-COMPLETE | Confirms existing UFR-C01 and UFR-029. |
+| `tests/test_CUDAFactory.py` | 896 | READ-COMPLETE | Confirms existing DG-07 through DG-10. |
+| `tests/test_env.py` | 101 | READ-COMPLETE | Confirms existing UFR-C01 and Supplemental RB-03's disabled timing default. |
+| `tests/test_package_source_hash.py` | 69 | READ-COMPLETE | None beyond existing cache identity coverage. |
+| `tests/test_precompile_hashing.py` | 42 | READ-COMPLETE | None beyond existing cache identity coverage. |
+| `tests/test_result_codes.py` | 59 | READ-COMPLETE | Confirms existing UFR-016, UFR-C05, and INT-02. |
+| `tests/test_serialize.py` | 212 | READ-COMPLETE | Confirms existing DG-09 and the package-root architecture mirror. |
+| `tests/test_time_logger.py` | 851 | READ-COMPLETE | Confirms Supplemental RB-03/RB-06 and existing UFR-021/UFR-022. |
+| `tests/test_utils.py` | 874 | READ-COMPLETE | None beyond existing developer-guide configuration findings. |
+
+## Binary and non-text assets
+
+NONE. All 70 scoped tracked files are text.
+
+## Reconciliation
+
+- Manifest rows: 70
+- Text files: 70
+- Binary or non-text assets: 0
+- Physical lines: 45,405
+- READ-COMPLETE rows: 70
+- Unreconciled paths or lines: 0

--- a/docs/review/root_batch_supplemental_proposals.md
+++ b/docs/review/root_batch_supplemental_proposals.md
@@ -1,0 +1,365 @@
+# Root and batch supplemental documentation proposals
+
+## Scope
+
+These findings are new after reconciliation with the six existing review
+artifacts. Findings already recorded as DG, API, INT, STYLE, UFR, or SOD items
+are not repeated here. No source or existing documentation file was changed.
+
+## RB-01 Batch solver config mirror omits fields
+
+Location `src/cubie/batchsolving/AGENTS.md:22`
+
+Current text
+
+```markdown
+| `BatchSolverConfig.py` | `BatchSolverConfig(CUDAFactoryConfig)` — holds `precision`, `loop_fn`, `compile_flags`, `driver_coefficients_shape`. Cache policy is **not** a compile setting — it lives with the kernel's `CubieCacheHandler`. `ActiveOutputs(_CubieConfigBase)` — booleans for which output arrays are produced, built via `ActiveOutputs.from_compile_flags(...)`. |
+```
+
+Proposed replacement
+
+```markdown
+| `BatchSolverConfig.py` | `BatchSolverConfig(CUDAFactoryConfig)` holds `precision`, `loop_fn`, `compile_flags`, `max_registers`, `driver_coefficients_shape`, and `kernel_name`. Cache policy belongs to the kernel's `CubieCacheHandler` and is not a compile setting. `ActiveOutputs(_CubieConfigBase)` stores the enabled output arrays and is built by `ActiveOutputs.from_compile_flags(...)`. |
+```
+
+`max_registers` and `kernel_name` are fields on the frozen compile settings.
+The current mirror lists neither field. `max_registers` is also accepted by the
+public solver route.
+
+Evidence `src/cubie/batchsolving/BatchSolverConfig.py:132-191`,
+`src/cubie/batchsolving/solver.py:501-505`, and
+`tests/batchsolving/test_solver.py:1546-1556`.
+
+## RB-02 Result mirror assigns one lifecycle to two different classes
+
+Location `src/cubie/batchsolving/AGENTS.md:25`
+
+Current text
+
+```markdown
+| `solveresult.py` | `SolveSpec` (attrs config snapshot); `SolveResult` — owns the solve's host buffers via `OutputArrays.loan_host_arrays` (zero copy), applies NaN-on-error masking in place, carries the solve's `stream`, and derives `time`/`time_domain_array`/`summaries_array` plus `as_numpy`/`as_numpy_per_summary`/`as_pandas` lazily; `DeviceSolveResult` — device-array handles to the solve's output buffers plus the kernel's stream, returned by `Solver.solve(on_device=True)` with no D2H copy. Both are pure data containers: no stream or memory operations happen in this module. |
+```
+
+Proposed replacement
+
+```markdown
+| `solveresult.py` | `SolveSpec` stores the solve configuration. `SolveResult` owns the solve's host buffers through `OutputArrays.loan_host_arrays`, masks failed trajectories when requested, derives combined representations lazily, and releases disk-backed arrays through the memory manager on close, context exit, or collection. `DeviceSolveResult` stores device-array handles and the kernel stream without performing stream or memory operations. |
+```
+
+`SolveResult.close()` calls the memory manager to release spill mappings.
+`DeviceSolveResult` is the handles-only container. The current sentence applies
+the device result's behavior to both classes.
+
+Evidence `src/cubie/batchsolving/solveresult.py:102-111`,
+`src/cubie/batchsolving/solveresult.py:522-545`,
+`tests/batchsolving/test_solveresult.py:57-78`, and
+`tests/batchsolving/test_solver_teardown.py:213-245`.
+
+## RB-03 Rendered timing defaults disagree with signatures
+
+Locations `src/cubie/batchsolving/solver.py:278`,
+`src/cubie/batchsolving/solver.py:389`, and
+`src/cubie/time_logger.py:194`
+
+Current text
+
+```text
+time_logging_level : str or None, default='default'
+time_logging_level : str or None, default='default'
+verbosity : str or None, default='default'
+```
+
+Proposed replacement
+
+```text
+time_logging_level : str or None, default=None
+time_logging_level : str or None, default=None
+verbosity : str or None, default=None
+```
+
+The first two lines render through the current `solve_ivp` and `Solver` API
+pages. All three signatures default to `None`. `None` disables timing output
+until a level is selected.
+
+Evidence `src/cubie/batchsolving/solver.py:215-229`,
+`src/cubie/batchsolving/solver.py:420-434`,
+`src/cubie/time_logger.py:189-230`,
+`tests/batchsolving/test_solver.py:1911-1919`, and
+`tests/test_time_logger.py:62-86`.
+
+## RB-04 Configuration index omits accepted memory keys
+
+Location `docs/source/user_guide/configuration.rst:175-177`
+
+Current text
+
+```rst
+   * - Memory
+     - ``mem_proportion``, ``stream_group``
+     - :doc:`memory`
+```
+
+Proposed replacement
+
+```rst
+   * - Memory
+     - ``memory_manager``, ``stream_group``, ``mem_proportion``,
+       ``host_spill_threshold``, ``spill_directory``
+     - :doc:`memory`
+```
+
+Add these definitions to the same page.
+
+```rst
+``host_spill_threshold``
+   Host arrays larger than this byte count use disk-backed storage. ``None``
+   uses the memory manager default.
+
+``spill_directory``
+   Existing directory used for disk-backed host arrays. ``None`` uses the
+   system temporary directory.
+```
+
+UFR-012 already corrects the group count and the cache and kernel rows. It
+does not add the three missing memory keys. The solver accepts all five names
+through `ALL_MEMORY_MANAGER_PARAMETERS`.
+
+Evidence `src/cubie/memory/mem_manager.py:96-106`,
+`src/cubie/batchsolving/solver.py:372-384`,
+`src/cubie/batchsolving/solver.py:473-477`,
+`tests/batchsolving/test_solver.py:1559-1582`, and
+`tests/batchsolving/test_memory_pressure.py:82-166`.
+
+## RB-05 SystemInterface index description assigns CUDA execution work
+
+Location `docs/source/API_reference/batchsolving/index.rst:46-49`
+
+Current text
+
+```rst
+* :doc:`SystemInterface <system_interface>` – adapts :class:`cubie.odesystems.baseODE.BaseODE`
+  instances for CUDA execution.
+```
+
+Proposed replacement
+
+```rst
+* :doc:`SystemInterface <system_interface>`. Resolves state, observable, and
+  parameter labels and indices from a system's ``SystemValues`` objects and
+  merges label-based and index-based output selections.
+```
+
+`SystemInterface` does not compile or launch CUDA work. It owns host-side
+label, index, and value-routing operations.
+
+Evidence `src/cubie/batchsolving/SystemInterface.py:48-99`,
+`src/cubie/batchsolving/SystemInterface.py:166-379`, and
+`tests/batchsolving/test_system_interface.py:12-376`.
+
+## RB-06 Top-level timing exports have no API page
+
+Location `docs/source/API_reference/index.rst:8-17`
+
+Current text
+
+```rst
+.. toctree::
+   :maxdepth: 2
+   :caption: Modules
+   :titlesonly:
+
+   batchsolving/index
+   odesystems/index
+   integrators/index
+   outputhandling/index
+   memory
+   gui/index
+```
+
+Proposed addition to the toctree
+
+```rst
+   time_logger
+```
+
+Proposed new page `docs/source/API_reference/time_logger.rst`
+
+```rst
+Time logging
+============
+
+.. currentmodule:: cubie
+
+.. autoclass:: TimeLogger
+   :members:
+
+.. autodata:: default_timelogger
+```
+
+Prospective rendered source rewrites for the `:members:` page
+
+| Location | Current text | Proposed replacement |
+|---|---|---|
+| `src/cubie/time_logger.py:560` | `- 'verbose': Inline timing already printed; category summaries at end` | `- 'verbose': Event timings print inline. Category summaries print at the end.` |
+| `src/cubie/time_logger.py:561` | `- 'debug': Individual start/stop already printed; category summaries` | `- 'debug': Individual start and stop messages print during events. Category summaries print at the end.` |
+| `src/cubie/time_logger.py:683-685` | `This method is called by CUDAFactory subclasses to register timing events they will track. The category helps organize timing reports by operation type.` | `Register timing events for CUDAFactory subclasses. The category groups timing reports by operation type.` |
+| `src/cubie/time_logger.py:716` | `This method centralizes all printing logic in TimeLogger.` | `Messages print when the configured verbosity meets ``min_verbosity``.` |
+
+Apply RB-03 before rendering this page. `TimeLogger` and
+`default_timelogger` are top-level public exports. Current prose mentions both
+objects but the reference tree contains no definition page.
+
+Evidence `src/cubie/__init__.py:36-49`,
+`src/cubie/time_logger.py:189-230`,
+`src/cubie/time_logger.py:633-698`,
+`src/cubie/time_logger.py:801-803`, and
+`tests/test_time_logger.py:59-416`.
+
+## RB-07 Documented direct-use interpolator has no API page
+
+Locations `docs/source/API_reference/index.rst:8-17` and
+`docs/source/examples/array_interpolation_example.py:17`
+
+Current text
+
+```python
+from cubie.array_interpolator import ArrayInterpolator
+```
+
+The API-reference toctree quoted in RB-06 contains no interpolator page.
+
+Proposed addition to the toctree
+
+```rst
+   array_interpolator
+```
+
+Proposed new page `docs/source/API_reference/array_interpolator.rst`
+
+```rst
+Array interpolation
+===================
+
+.. currentmodule:: cubie.array_interpolator
+
+.. autoclass:: ArrayInterpolator
+   :members: evaluation_function, coefficients, update_from_dict, get_interpolated, plot_interpolated
+```
+
+Prospective `update_from_dict` docstring rewrite
+
+Location `src/cubie/array_interpolator.py:203-247`
+
+Current text
+
+```text
+## Input dictionary
+input_dict fields must include:
+
+    - ``"time"``: 1D float array of sample times corresponding to
+    input array values, or
+        - ``"driver_sample_period"``: uniform spacing between samples, and
+        - ``"t0"``: starting time of the input samples.
+    - ``[input_name]``: one-dimensional float array of samples for
+    each input, where ``input_name`` is the name of the input signal
+    as entered in the system definition.
+
+    Fields may optionally include:
+
+    - ``"order"``: polynomial order for spline interpolation,
+    default 3.
+    - ``"wrap"``: whether the input should wrap past the final
+    value when the last time index is exceeded. When False the
+    interpolator clamps to zero before ``t0`` and after the final
+    sample.
+    - ``"boundary_condition"``: boundary condition for splines.
+    Defaults to ``"clamped"`` when ``"wrap"`` is False and to
+    ``"periodic"`` when wrapping is enabled.
+
+The input arrays must all be one-dimensional and of the same length.
+
+The final interpolation result is an array of polynomial
+coefficients with shape (num_segments, num_inputs, order + 1),
+where num_segments is one less than the number of samples provided.
+
+## Interpolation behaviour
+If ``"boundary_condition"`` is None, then spline coefficients are
+calculated in segments, with no continuity constraints. Otherwise,
+the spline coefficients are fit simultaneously for all segments,
+and end conditions are enforced according to the boundary condition:
+
+- ``"natural"``: second derivative at the ends of the curve is set
+to zero.
+- ``"periodic"``: the first and last segments are identical. For
+this condition, the first and last samples must match. This is the
+default when "wrap" is True, to avoid introducing a discontinuity on
+wrap.
+
+These boundary conditions are identical to those in [SciPy's
+CubicSpline interpolator]<https://docs.scipy.org/doc/scipy/reference
+/generated/scipy.interpolate.CubicSpline.html>
+```
+
+Proposed replacement
+
+```rst
+Input dictionary
+~~~~~~~~~~~~~~~~
+
+Supply one one-dimensional sample array for each input name. All input
+arrays must have the same length. The sample count must be at least
+``order + 1``.
+
+Choose one sampling-time representation.
+
+``time``
+   One-dimensional sample-time array. Its length must match the input
+   arrays. Values must be strictly increasing and uniformly spaced.
+
+``driver_sample_period``
+   Scalar spacing between samples. Do not supply ``time`` with this
+   field.
+
+``t0``
+   Start time used with ``driver_sample_period``. The default is ``0.0``.
+
+The remaining fields configure interpolation.
+
+``order``
+   Polynomial order. The default is ``3``.
+
+``wrap``
+   Repeat the sampled input outside its time range when ``True``. Return
+   zero outside the range when ``False``. The default is ``True``.
+
+``boundary_condition``
+   One of ``"natural"``, ``"periodic"``, ``"clamped"``, or
+   ``"not-a-knot"``. Omission selects ``"periodic"`` when ``wrap`` is
+   true and ``"clamped"`` when ``wrap`` is false. Periodic interpolation
+   requires matching first and last samples. A non-wrapping clamped input
+   adds a zero-valued sample at each end and two transition segments.
+
+The coefficient array has shape ``(num_segments, num_inputs, order + 1)``.
+The boundary-condition names follow
+`SciPy CubicSpline <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.CubicSpline.html>`_.
+```
+
+The replacement applies UFR-013's timing correction and converts the Markdown
+headings, nested list, and link to RST. The example constructs this class
+directly and the solver exposes its instance through
+`Solver.driver_interpolator`.
+
+Evidence `src/cubie/array_interpolator.py:151-283`,
+`src/cubie/array_interpolator.py:625-790`,
+`src/cubie/batchsolving/solver.py:608-622`,
+`tests/test_array_interpolator.py:432-480`, and
+`tests/test_array_interpolator.py:1306-1406`.
+
+## Style and freshness receipt
+
+No additional false-drama staccato or intensifying frame was found in current
+rendered batch pages after accounting for STYLE-FRAME-01 and STYLE-DOC-03.
+All current em dash, semicolon, and non-structural colon findings in those pages
+are already recorded in STYLE-RST-01, STYLE-RST-02, STYLE-DOC-01,
+STYLE-DOC-02, and STYLE-DOC-03. The proposed replacement text above introduces
+no em dash or semicolon.

--- a/docs/review/systems_output_inventory.md
+++ b/docs/review/systems_output_inventory.md
@@ -1,0 +1,277 @@
+# Systems and output documentation inventory
+
+## Audit totals
+
+| Corpus | Files | Lines | Status |
+| --- | ---: | ---: | --- |
+| Scoped reStructuredText pages | 51 | 695 | Every line read |
+| Rendered autodoc source docstrings | 261 class or member objects plus 5 functions | 2,959 | Every line read |
+| Prospective autodoc docstrings for missing pages | 3 objects | 105 | Every line read; rewrites recorded in SOD-036 and SOD-037 |
+| Memory source | 6 | 3,129 | Line scan and public behavior audit complete |
+| ODE-system source | 53 | 24,782 | Line scan and public behavior audit complete |
+| Output-handling source | 27 | 6,092 | Line scan and public behavior audit complete |
+| GUI source | 3 | 873 | Line scan and static target audit complete |
+| Vendored source | 11 | 4,271 | Line scan complete, no CuBIE public API |
+| Relevant tests | 50 | 21,456 | Line scan and cited behavior audit complete |
+| Engine `CLAUDE.md` mirror | 1 | 1 | Read and compared with its 80-line `AGENTS.md` target |
+| Regular nested instruction files | 10 | 1,068 | Every line read and checked against source, tests, and documentation requirements |
+
+The source total is 39,147 lines. The audit used the current working tree,
+the code knowledge graph, package export lists, source definitions, and tests.
+
+Assigned-entry reconciliation is 51 RST pages, ten regular `AGENTS.md` files,
+and one regular `CLAUDE.md` mirror. These 62 lane entries are included in the
+parent review's 524 assigned entries.
+
+## Autodoc resolution
+
+There are 49 autodoc directives in scope.
+
+* 41 targets resolved at runtime with
+  `NUMBA_ENABLE_CUDASIM=1` under `.venv`.
+* `current_cupy_stream` resolved as a class but is declared with
+  `autofunction`. This is SOD-005.
+* Seven GUI targets were verified statically in source. Runtime import was
+  blocked by the absent optional `qtpy` package.
+* No other target was missing or had a directive-type mismatch.
+
+## Page inventory
+
+`Read` is `YES` for every row. `Runtime OK` means the module and target
+resolved with the directive's expected object type. `Static OK` means the
+definition exists but the optional GUI dependency prevented import.
+
+| Page | Lines | Read | Autodoc status | Freshness and completeness |
+| --- | ---: | --- | --- | --- |
+| `docs/source/API_reference/gui/constants_editor.rst` | 13 | YES | Static OK, `qtpy` absent | CLEAN |
+| `docs/source/API_reference/gui/index.rst` | 14 | YES | N/A | CLEAN |
+| `docs/source/API_reference/gui/pre_parse_editor.rst` | 10 | YES | Static OK, `qtpy` absent | CLEAN |
+| `docs/source/API_reference/gui/states_editor.rst` | 10 | YES | Static OK, `qtpy` absent | CLEAN |
+| `docs/source/API_reference/memory.rst` | 69 | YES | N/A | SOD-001, SOD-002, SOD-003, SOD-004, SOD-034, SOD-035 |
+| `docs/source/API_reference/memory/array_request.rst` | 9 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/memory/array_response.rst` | 9 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/memory/current_cupy_stream.rst` | 6 | YES | Type mismatch | SOD-005 |
+| `docs/source/API_reference/memory/default_memmgr.rst` | 6 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/memory/memory_manager.rst` | 8 | YES | Runtime OK | SOD-006, SOD-007, SOD-033 |
+| `docs/source/API_reference/memory/stream_groups.rst` | 9 | YES | Runtime OK | SOD-008, SOD-033 |
+| `docs/source/API_reference/odesystems/base_ode.rst` | 8 | YES | Runtime OK | SOD-017, SOD-033 |
+| `docs/source/API_reference/odesystems/create_ode_system.rst` | 6 | YES | Runtime OK | SOD-013, SOD-014, SOD-015, SOD-016 |
+| `docs/source/API_reference/odesystems/index.rst` | 62 | YES | N/A | SOD-009, SOD-010, SOD-011, SOD-036 |
+| `docs/source/API_reference/odesystems/ode_cache.rst` | 8 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/odesystems/ode_data.rst` | 8 | YES | Runtime OK | SOD-033 |
+| `docs/source/API_reference/odesystems/symbolic.rst` | 30 | YES | N/A | SOD-012 |
+| `docs/source/API_reference/odesystems/symbolic_ode.rst` | 8 | YES | Runtime OK | SOD-016, SOD-033 |
+| `docs/source/API_reference/odesystems/system_sizes.rst` | 8 | YES | Runtime OK | SOD-010 |
+| `docs/source/API_reference/odesystems/system_values.rst` | 8 | YES | Runtime OK | SOD-033 |
+| `docs/source/API_reference/outputhandling/batch_input_sizes.rst` | 9 | YES | Runtime OK | SOD-029 |
+| `docs/source/API_reference/outputhandling/batch_output_sizes.rst` | 9 | YES | Runtime OK | SOD-029 |
+| `docs/source/API_reference/outputhandling/index.rst` | 75 | YES | N/A | SOD-018, SOD-019, SOD-020, SOD-021 |
+| `docs/source/API_reference/outputhandling/output_array_heights.rst` | 9 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/output_compile_flags.rst` | 9 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/output_config.rst` | 8 | YES | Runtime OK | SOD-026, SOD-027, SOD-028 |
+| `docs/source/API_reference/outputhandling/output_function_cache.rst` | 9 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/output_functions.rst` | 8 | YES | Runtime OK | SOD-030 |
+| `docs/source/API_reference/outputhandling/register_metric.rst` | 6 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/single_run_output_sizes.rst` | 9 | YES | Runtime OK | SOD-029 |
+| `docs/source/API_reference/outputhandling/summary_metrics.rst` | 6 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/summarymetrics.rst` | 75 | YES | N/A | SOD-022, SOD-023, SOD-024, SOD-025, SOD-037 |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/d2xdt2_extrema.rst` | 8 | YES | Runtime OK | SOD-032 |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/d2xdt2_max.rst` | 8 | YES | Runtime OK | SOD-032 |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/d2xdt2_min.rst` | 8 | YES | Runtime OK | SOD-032 |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/dxdt_extrema.rst` | 8 | YES | Runtime OK | SOD-032 |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/dxdt_max.rst` | 8 | YES | Runtime OK | SOD-032 |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/dxdt_min.rst` | 8 | YES | Runtime OK | SOD-032 |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/extrema.rst` | 8 | YES | Runtime OK | SOD-032 |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/max.rst` | 8 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/max_magnitude.rst` | 8 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/mean.rst` | 8 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/mean_std_rms.rst` | 8 | YES | Runtime OK | SOD-032 |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/metric_func_cache.rst` | 9 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/min.rst` | 8 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/negative_peaks.rst` | 8 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/peaks.rst` | 8 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/rms.rst` | 8 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/std.rst` | 8 | YES | Runtime OK | SOD-032 |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/summary_metric.rst` | 9 | YES | Runtime OK | CLEAN |
+| `docs/source/API_reference/outputhandling/summarymetrics/metrics/summary_metrics.rst` | 8 | YES | Runtime OK | SOD-031 |
+| `src/cubie/odesystems/symbolic/engine/CLAUDE.md` | 1 | YES | N/A | SOD-038 |
+
+## Regular instruction-file manifest
+
+All line ranges are inclusive. `CURRENT` means the factual instructions match
+the cited source and tests. `STALE` identifies the exact proposal that restores
+freshness. Every row also carries SOD-046 for the corpus-wide punctuation and
+emphasis rewrite.
+
+| Path and exact range | Lines | Freshness status | Language status | Evidence and proposal |
+| --- | ---: | --- | --- | --- |
+| `src/cubie/gui/AGENTS.md:1-31` | 31 | CURRENT | STYLE | Definitions at `src/cubie/gui/constants_editor.py:37` and `src/cubie/gui/states_editor.py:29`; no `tests/gui` module in the code graph. SOD-046 |
+| `src/cubie/memory/AGENTS.md:1-165` | 165 | STALE at `:149-154` | STYLE | Memory implementation and four test modules checked. Duplicate test entry corrected by SOD-039. SOD-046 |
+| `src/cubie/odesystems/AGENTS.md:1-124` | 124 | STALE at `:6-13`, `:22`, `:124` | STYLE | Jacobian IR at `src/cubie/odesystems/symbolic/codegen/jacobian.py:233`; count consumers at `src/cubie/integrators/SingleIntegratorRunCore.py:161` and `src/cubie/outputhandling/output_sizes.py:274`. SOD-040, SOD-046 |
+| `src/cubie/odesystems/symbolic/AGENTS.md:1-117` | 117 | STALE at `:117` | STYLE | Generated header at `src/cubie/odesystems/symbolic/odefile.py:20-23`. SOD-041, SOD-046 |
+| `src/cubie/odesystems/symbolic/codegen/AGENTS.md:1-147` | 147 | STALE at `:6-21`, `:145-147` | STYLE | Jacobian returns at `src/cubie/odesystems/symbolic/codegen/jacobian.py:233` and `:297`; generated header at `src/cubie/odesystems/symbolic/odefile.py:20-23`. SOD-042, SOD-046 |
+| `src/cubie/odesystems/symbolic/parsing/AGENTS.md:1-127` | 127 | STALE at `:80-88`, `:111-115`, `:124-127` | STYLE | Vendored import at `src/cubie/odesystems/symbolic/parsing/cellml.py:24-36`; core dependencies at `pyproject.toml:29-37`. SOD-043, SOD-046 |
+| `src/cubie/odesystems/symbolic/structural/AGENTS.md:1-86` | 86 | CURRENT | STYLE | Structural implementation and five matching test modules checked. SOD-046 |
+| `src/cubie/outputhandling/AGENTS.md:1-104` | 104 | STALE at `:102-104` | STYLE | Backend-neutral imports at `src/cubie/outputhandling/save_state.py:19`, `update_summaries.py:29`, and `save_summaries.py:29`. SOD-044, SOD-046 |
+| `src/cubie/outputhandling/summarymetrics/AGENTS.md:1-114` | 114 | STALE at `:93-94`, `:112-114` | STYLE | Shift lifecycle at `src/cubie/outputhandling/summarymetrics/std.py:103` and `:152`; backend-neutral import at `mean.py:16`. SOD-045, SOD-046 |
+| `src/cubie/vendored/AGENTS.md:1-53` | 53 | CURRENT | STYLE | Snapshot headers, package data, local CellML changes, and dependency declarations checked against `src/cubie/vendored/numba_cuda_cache.py:1`, `src/cubie/vendored/cellmlmanip/`, and `pyproject.toml:9-37`. SOD-046 |
+| **Subtotal** | **1,068** | **3 CURRENT, 7 STALE** | **10 STYLE** | **Ten of ten files and every line accounted for** |
+
+### Instruction punctuation and language inventory
+
+| File | Em dash | Semicolon | Colon | Bold | Italic | Affected-line manifest |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `gui/AGENTS.md` | 1 | 6 | 2 | 0 | 1 | Em `24`; semicolon `7,20,22,25,27,30`; colon `1,20`; italic `8` |
+| `memory/AGENTS.md` | 12 | 31 | 11 | 7 | 0 | Em `10,16,24,27,28,34,107,117,143,151,162`; semicolon `23,24,25,33,35,38,41,61,76,78,82,84,91,95,108,110,114,115,116,118,145,153,158,162`; colon `1,16,35,63,70,71,73,80,85,103,147`; bold `10,12,38,72,107,124,131` |
+| `odesystems/AGENTS.md` | 16 | 14 | 15 | 7 | 3 | Em `7,21-24,44,49,78,80,83,85,91,98,99,105`; semicolon `13,23,62,84,89,96,111,115,120,121,124`; colon `1,8,21,23,36,37,60,70,72,80,81,87,94,110`; bold `7,47,70,78,81,84,87`; italic `46,82,93` |
+| `symbolic/AGENTS.md` | 10 | 15 | 9 | 2 | 1 | Em `19,30,45,64,70,76,92,94,98`; semicolon `14,23,28,40,41,46,58,63,106,111-114,117`; colon `1,7,15,30,33,38,49,72,89`; bold `75,81`; italic `101` |
+| `codegen/AGENTS.md` | 13 | 21 | 18 | 9 | 2 | Em `15-17,27,38,49,55,66,75,84,91,134`; semicolon `27,30,32,34,42,44,46,59,73,74,78,80,100,102,105,122,125,127,141,142`; colon `1,10,13,19,29-31,33-35,39,42,44,46,57,68,79,110`; bold `6,9,15-17,41,46,57,121`; italic `20,51` |
+| `parsing/AGENTS.md` | 18 | 41 | 8 | 2 | 2 | Em `6,7,13,25-30,34,35,51,54,64,69,71,98,114`; semicolon `10,14,21-24,27,29,30,39,41,49,50,65,69,72,77,81,83,86,91,95,113,114,119-122,125,126`; colon `1,10,30,40,47,56,99,108`; bold `95,99`; italic `51,57` |
+| `structural/AGENTS.md` | 3 | 11 | 12 | 0 | 0 | Em `12,61,83`; semicolon `14,27,32,44,48,63,66-68,70,82`; colon `1,6,14,22,25,27,33,41,53,60,73,80` |
+| `outputhandling/AGENTS.md` | 12 | 13 | 7 | 6 | 0 | Em `8,9,20,21,23-25,39,43,45,59,86`; semicolon `20,21,55,69,75,81,99,100,103,104`; colon `1,22,37,62,74,89,92`; bold `38,42,45,57,62,85` |
+| `summarymetrics/AGENTS.md` | 5 | 21 | 10 | 2 | 0 | Em `20,45,46,65,103`; semicolon `13,20,26,29-31,35,37,46,49,61,75,80,83,87,90,109,111,113`; colon `1,19,44,55,70,82,83,89,93`; bold `61,91` |
+| `vendored/AGENTS.md` | 4 | 11 | 7 | 1 | 0 | Em `15,19,33,41`; semicolon `14-16,21,27,29,31,33,39,44,52`; colon `1,15,38,46,49,50,52`; bold `24` |
+| **Total** | **94** | **184** | **99** | **36** | **9** | **SOD-046 removes all dashes, semicolons, and emphasis plus 83 prose colons. Sixteen syntax colons remain** |
+
+The ten `Parent:` metadata colons remain. The other retained colons occur in
+`memory/AGENTS.md:103`, `odesystems/AGENTS.md:21`, `:36`, and `:80`, and
+`summarymetrics/AGENTS.md:82` and `:83`. They encode a dictionary entry, type
+annotations, or lambda syntax. No en dash, listed empty-framing phrase, or
+false-drama staccato example occurs in these ten files.
+
+## Punctuation and language inventory
+
+### reStructuredText source
+
+| Character or tell | Count | Disposition |
+| --- | ---: | --- |
+| Em dash | 1 | Removed by SOD-004 |
+| En dash | 49 | All removed by SOD-003, SOD-010, SOD-012, SOD-020, SOD-023, and SOD-024 |
+| Semicolon | 0 | CLEAN |
+| Colon | 591 | One prose colon removed by SOD-001. The remaining 590 are required RST syntax |
+| Listed empty-framing phrases | 0 | CLEAN |
+| False-drama staccato examples | 0 | CLEAN |
+
+### rendered source docstrings
+
+| Character or tell | Count | Disposition |
+| --- | ---: | --- |
+| Em dash | 8 | SOD-014, SOD-015, and SOD-033 remove all occurrences |
+| En dash | 0 | CLEAN |
+| Semicolon | 12 | SOD-015 and SOD-033 remove all occurrences |
+| Colon | 137 | SOD-007, SOD-032, and SOD-033 remove avoidable prose colons. RST roles, numpydoc type declarations, and literal mappings retain the rest |
+| Readiness, convenience, automaticity, efficiency, class, or correctness framing | Detected | SOD-010, SOD-016, SOD-028, SOD-029, SOD-030, and SOD-031 |
+| Listed empty-framing phrases | 0 | CLEAN |
+| False-drama staccato examples | 0 | CLEAN |
+
+### prospective generated docstrings
+
+These counts cover `load_cellml_model`, `MeanStd`, and `StdRms`, which would
+become rendered by SOD-036 and SOD-037.
+
+| Character or tell | Current count | Count after proposed rewrite | Disposition |
+| --- | ---: | ---: | --- |
+| Em dash | 0 | 0 | CLEAN |
+| En dash | 0 | 0 | CLEAN |
+| Semicolon | 1 | 0 | Removed by SOD-036 |
+| Colon | 12 | 8 | SOD-036 and SOD-037 remove four prose colons. Eight numpydoc type declarations remain |
+| Readiness or function framing | 2 blocks | 0 | Removed by SOD-036 |
+| Listed empty-framing phrases | 0 | 0 | CLEAN |
+| False-drama staccato examples | 0 | 0 | CLEAN |
+
+## Completeness and freshness inventory
+
+### Package exports
+
+| Surface | Coverage |
+| --- | --- |
+| `cubie.memory.MemoryManager` | API page present. Rendered docstring has SOD-006, SOD-007, and SOD-033 |
+| `cubie.memory.default_memmgr` | API page present and current |
+| `cubie.memory.current_cupy_stream` | API page present with wrong directive type, SOD-005 |
+| `cubie.memory.NoCudaDeviceError` | Exported, no API or user/developer coverage, SOD-034 |
+| `cubie.memory.CuPyAsyncNumbaManager` | Exported on real GPU builds and assigned `None` under CUDA simulation. No API coverage. SOD-035 proposes a manual Python-domain page because `autoclass` cannot resolve the simulated value |
+| `cubie.odesystems.BaseODE` | API page present. Lazy-helper cache wording is stale, SOD-017 |
+| `cubie.odesystems.ODECache` | API page present and current |
+| `cubie.odesystems.ODEData` | API page present. Overview description corrected by SOD-010 |
+| `cubie.odesystems.SystemSizes` | API page present. Overview and rendered class framing corrected by SOD-010 |
+| `cubie.odesystems.SystemValues` | API page present. Overview description corrected by SOD-010 |
+| `cubie.odesystems.SymbolicODE` | API page present. Overview, readiness, and member punctuation issues are SOD-012, SOD-016, and SOD-033 |
+| `cubie.odesystems.create_ODE_system` | API page present. Input types and rendered prose are stale, SOD-013 through SOD-016 |
+| `cubie.odesystems.load_cellml_model` | Exported, no API page. Its prospective rendered docstring has stale dependency information and language findings covered by SOD-036 |
+| All ten `cubie.outputhandling` exports | API pages present |
+| Both `cubie.outputhandling.summarymetrics` exports | API pages present |
+| Both `cubie.gui` exports | API pages present. Runtime build requires optional Qt dependencies |
+
+### Public submodule surfaces without generated API coverage
+
+These symbols are public in their submodule or are named implementation
+capabilities. They are not exported from `cubie` unless stated above.
+
+| Domain | Missing or stale coverage |
+| --- | --- |
+| Memory allocation internals | `PinnedBuffer`, `ChunkBufferPool`, `InstanceMemorySettings`, pinned-budget accounting, pageable and memory-mapped host backing, idle-owner eviction, and active/passive limit modes have no developer page. The generic `MemoryManager` autodoc exposes members but does not explain the lifecycle as a coherent workflow. |
+| Memory module helpers | `total_system_ram`, `available_system_ram`, `host_headroom_bytes`, `defer_instance_teardown`, `run_instance_teardown`, `get_portioned_request_size`, `is_request_chunkable`, `replace_with_chunked_size`, `install_async_emm`, `placeholder_invalidate`, and `placeholder_dataready` are module-public names with no API page. `install_async_emm` has real-device and simulator definitions at `src/cubie/memory/cupy_emm.py:86` and `:97`. The placeholder hooks are at `src/cubie/memory/mem_manager.py:203` and `:211`. These names should either be documented for developers or made private. |
+| Solver-helper model | `SolverHelperKind`, `HelperKindTraits`, `resolve_preconditioner_kind`, `resolve_chained_kind`, `SolverHelperRequest`, `HelperResult`, and `SolverHelperCache` have no API page. The developer guide still describes string-based helper dispatch. |
+| Symbolic codegen exports | `generate_operator_apply_code`, `generate_cached_operator_apply_code`, `generate_prepare_jac_code`, `generate_cached_jvp_code`, `generate_n_stage_linear_operator_code`, `build_stage_jvp_assignments`, `generate_residual_code`, `generate_stage_residual_code`, `generate_n_stage_residual_code`, `build_stage_substitutions`, all seven exported preconditioner generators, `CUDA_FUNCTIONS`, `print_cuda`, and `print_cuda_multiple` have no generated API reference. |
+| Expression-engine exports | The 52 names in `cubie.odesystems.symbolic.engine.__all__` have no generated API reference. They include all IR node types, constructors, transforms, SymPy conversion functions, and printers. The developer codegen page gives only an overview. |
+| Structural exports | `structural_simplify`, `SimplifiedSystem`, `StructuralState`, `ExtraEquationsSystemError`, `ExtraVariablesSystemError`, and `InvalidSystemError` have no API reference. User documentation mentions structural simplification without documenting result or error types. |
+| Other symbolic capabilities | `IndexedBaseMap`, `IndexedBases`, `ODEFile`, CellML caching, callable inspection, auxiliary caching, and helper source/member identity have no generated API pages. |
+| Output sizing base | `ArraySizingClass` is module-public and undocumented as its own API. Its `nonzero` property is inherited into the four sizing pages. |
+| Metric infrastructure | `MetricConfig` is module-public but lacks an API page. `SummaryMetric`, `SummaryMetrics`, and `MetricFuncCache` have pages. |
+| Built-in metrics | Sixteen of 18 classes have pages. `MeanStd` and `StdRms` are missing, SOD-037. |
+| GUI helpers | `FloatLineEdit`, `PreParseEditor`, `edit_pre_parse_dicts`, `show_constants_editor`, and `show_states_editor` have pages. Package exports remain limited to `ConstantsEditor` and `StatesEditor`. |
+| Vendored code | No CuBIE public API is intended. `cellmlmanip` and the Numba CUDA cache snapshot are correctly absent from API navigation. Their consuming public behavior should be documented through CellML and cache pages. |
+
+### Cross-lane freshness findings handed to the owning reviewers
+
+* `docs/source/user_guide/memory.rst:14` through `:16` describes every solve as
+  allocating and freeing all device arrays. The registry retains allocations
+  until release or eviction.
+* `docs/source/user_guide/memory.rst:51` through `:54` describes chunks from
+  one solve as concurrent across stream groups. Stream groups coordinate
+  registered instances. Chunk staging is pipelined within the run stream.
+* `docs/source/user_guide/cellml.rst:55` through `:58` says only ODE CellML
+  models are supported and hedges about CellML 2.0. The loader accepts CellML
+  1.0 and 1.1 and the parser structurally simplifies DAE-shaped input.
+* `docs/source/developer_guide/adding_metrics.rst:23` through `:115` contains a
+  wrong registry import, obsolete callback signatures, a direct
+  `numba.cuda` import, and stale cadence configuration.
+* `docs/source/developer_guide/codegen.rst:71` through `:74` describes helper
+  dispatch by strings rather than `SolverHelperRequest`.
+
+## Sphinx build
+
+Sphinx is not installed in either available Python environment. No build was
+run because the requested dependency gate failed.
+
+System interpreter command:
+
+```text
+> python -m sphinx --version
+C:\Program Files\Python314\python.exe: No module named sphinx
+```
+
+Workspace virtual-environment command:
+
+```text
+> .\.venv\Scripts\python.exe -m sphinx --version
+C:\local_working_projects\cubie\.venv\Scripts\python.exe: No module named sphinx
+```
+
+The runtime autodoc probe also recorded the exact GUI import blocker:
+
+```text
+ModuleNotFoundError: No module named 'qtpy'
+```
+
+Static inspection resolved all seven GUI definitions in
+`src/cubie/gui/constants_editor.py` and `src/cubie/gui/states_editor.py`.
+
+## Instruction mirror inventory
+
+`src/cubie/odesystems/symbolic/engine/CLAUDE.md` contains one line,
+`AGENTS.md`, but is stored as Git mode `100644`. Every other nested
+`CLAUDE.md` mirror is mode `120000`. It therefore fails to expose the engine
+instructions on this checkout. SOD-038 records the exact repair. The target
+`src/cubie/odesystems/symbolic/engine/AGENTS.md` was read in full and agrees
+with the current IR, assignment, conversion, and printer implementation.

--- a/docs/review/systems_output_rewrite_proposals.md
+++ b/docs/review/systems_output_rewrite_proposals.md
@@ -1,0 +1,1603 @@
+# Systems and output documentation rewrite proposals
+
+## Scope
+
+This audit covers 51 reStructuredText pages and every source docstring
+rendered by their autodoc directives. Existing documentation and source files
+remain unchanged.
+
+Issue references use the line numbers in the current working tree.
+
+## Memory
+
+### SOD-001
+
+Location: `docs/source/API_reference/memory.rst:21`
+
+Current text:
+
+```rst
+The memory package coordinates GPU allocations across cubie. It exposes the
+package-level :class:`~cubie.memory.mem_manager.MemoryManager` through
+``default_memmgr`` so integrators can request array buffers and register CUDA
+streams without rewriting the coordination code. CuPy is the single device
+allocation provider on a real GPU: device arrays come from CuPy's memory
+pool and host staging buffers from CuPy's pinned memory pool. Supporting
+modules describe allocation requests, track chunked response metadata, and
+manage stream groups.
+```
+
+Replacement:
+
+```rst
+``cubie.memory`` coordinates device and host allocations for solver runs.
+``default_memmgr`` is the process-wide
+:class:`~cubie.memory.mem_manager.MemoryManager` used by solvers. On a real
+GPU, CuPy's asynchronous pool backs Numba device arrays and CuPy's pinned
+pool backs pinned host arrays. :class:`ArrayRequest` defines an allocation,
+:class:`ArrayResponse` reports its arrays and chunk layout, and
+:class:`StreamGroups` assigns registered instances to CUDA streams.
+```
+
+Reason: removes framing and the prose colon while naming the asynchronous
+device pool and the actual responsibilities. Evidence:
+`src/cubie/memory/__init__.py:24`, `src/cubie/memory/__init__.py:35`,
+`src/cubie/memory/cupy_emm.py:24`, `src/cubie/memory/array_requests.py:45`,
+`src/cubie/memory/array_requests.py:109`,
+`src/cubie/memory/stream_groups.py:34`.
+
+### SOD-002
+
+Location: `docs/source/API_reference/memory.rst:33`
+
+Current text:
+
+```rst
+``default_memmgr`` creates :class:`cubie.memory.mem_manager.MemoryManager`
+with stream grouping ready to configure. Typical callers obtain this
+singleton, register their instance identifier, and submit
+:class:`cubie.memory.array_requests.ArrayRequest` objects that describe the
+arrays they need.
+```
+
+Replacement:
+
+```rst
+``default_memmgr`` is created at package import. A solver registers itself,
+queues labelled :class:`cubie.memory.array_requests.ArrayRequest` objects,
+and receives an :class:`cubie.memory.array_requests.ArrayResponse` through
+its allocation callback.
+```
+
+Reason: removes "ready", "Typical callers", and the unsupported claim that
+the singleton creates stream grouping. Registration creates a group stream
+on demand. Evidence: `src/cubie/memory/__init__.py:33`,
+`src/cubie/memory/__init__.py:35`, `src/cubie/memory/mem_manager.py:725`,
+`src/cubie/memory/mem_manager.py:1889`,
+`src/cubie/memory/stream_groups.py:77`.
+
+### SOD-003
+
+Locations: `docs/source/API_reference/memory.rst:42`, `:44`, `:49`, `:50`,
+`:55`, `:60`
+
+Replace each current list item exactly as follows.
+
+| Current text | Replacement |
+| --- | --- |
+| `* :doc:\`default_memmgr <memory/default_memmgr>\` – default :class:\`MemoryManager\` instance shared across` plus line 43 | `* :doc:\`default_memmgr <memory/default_memmgr>\` is the process-wide :class:\`MemoryManager\` instance used by solvers.` |
+| `* :doc:\`MemoryManager <memory/memory_manager>\` – handles allocation requests and stream registration.` | `* :doc:\`MemoryManager <memory/memory_manager>\` registers owners, allocates arrays, selects host backing, and chunks run-axis allocations.` |
+| `* :doc:\`ArrayRequest <memory/array_request>\` – describes requested buffers, precision factories, and chunking.` | `* :doc:\`ArrayRequest <memory/array_request>\` defines shape, dtype, placement, chunk axis, and run count.` |
+| `* :doc:\`ArrayResponse <memory/array_response>\` – returns allocated buffers and metadata for callers.` | `* :doc:\`ArrayResponse <memory/array_response>\` contains allocated arrays, chunk count, chunk length, and per-chunk shapes.` |
+| `* :doc:\`StreamGroups <memory/stream_groups>\` – assigns host instances to CUDA streams and manages synchronisation policies.` | `* :doc:\`StreamGroups <memory/stream_groups>\` assigns instances to named groups that share dedicated CUDA streams.` |
+| `* :doc:\`current_cupy_stream <memory/current_cupy_stream>\` – context manager that binds a Numba stream to a CuPy stream so CuPy allocations and copies stay ordered with the Numba-launched kernel.` | `* :doc:\`current_cupy_stream <memory/current_cupy_stream>\` forwards a non-default Numba stream to CuPy for ordered allocations.` |
+
+Reason: removes six separator en dashes and corrects the stale "precision
+factories" and "synchronisation policies" descriptions. Evidence:
+`src/cubie/memory/array_requests.py:50`,
+`src/cubie/memory/array_requests.py:81`,
+`src/cubie/memory/array_requests.py:114`,
+`src/cubie/memory/stream_groups.py:35`,
+`src/cubie/memory/mem_manager.py:347`,
+`tests/memory/test_memmgmt.py:1382`.
+
+### SOD-004
+
+Location: `docs/source/API_reference/memory.rst:65`
+
+Current text:
+
+```rst
+The package requires :mod:`numba.cuda` for kernel launch, stream management,
+and context access. CuPy is required on a real GPU — it is CuBIE's single
+device memory allocator, imported at package import time through
+:mod:`cubie.cuda_simsafe`. Under the CUDA simulator (which never touches
+device memory) CuPy is not required and the import is skipped.
+```
+
+Replacement:
+
+```rst
+The active CUDA backend supplies launches, streams, and contexts through
+:mod:`cubie.cuda_simsafe`. Real-GPU execution requires CuPy for device and
+pinned-host allocation. CUDA simulation does not import CuPy.
+```
+
+Reason: removes the only em dash in the scoped RST corpus and avoids naming
+`numba.cuda` as the only backend. Evidence: `src/cubie/cuda_simsafe.py:1`,
+`src/cubie/memory/cupy_emm.py:19`, `src/cubie/memory/cupy_emm.py:24`,
+`src/cubie/memory/cupy_emm.py:94`.
+
+### SOD-005
+
+Location: `docs/source/API_reference/memory/current_cupy_stream.rst:6`
+
+Current text:
+
+```rst
+.. autofunction:: current_cupy_stream
+```
+
+Replacement:
+
+```rst
+.. autoclass:: current_cupy_stream
+   :members:
+```
+
+Reason: the target is a class context manager, not a function. Runtime
+resolution reported `TYPE-MISMATCH expected function`. Evidence:
+`src/cubie/memory/mem_manager.py:347`,
+`tests/memory/test_memmgmt.py:1391`.
+
+### SOD-006
+
+Location: `src/cubie/memory/mem_manager.py:582`
+
+Current text:
+
+```text
+Singleton interface coordinating GPU memory allocation and
+stream usage.
+```
+
+Replacement:
+
+```text
+Coordinate GPU memory allocation and stream usage.
+```
+
+Reason: `MemoryManager` does not enforce singleton construction. Only
+`default_memmgr` is the process-wide instance by convention. Evidence:
+`src/cubie/memory/mem_manager.py:581`, `src/cubie/memory/__init__.py:35`.
+
+### SOD-007
+
+Location: `src/cubie/memory/mem_manager.py:601`
+
+Current text:
+
+```text
+The manager accepts ArrayRequest objects and returns ArrayResponse instances
+that reference allocated arrays and chunking information. Active mode
+enforces per-instance VRAM proportions while passive mode mirrors standard
+allocation behaviour using chunking only when necessary.
+
+Construction succeeds without a device: the manager stays unsized and every
+decision needing a byte figure reprobes, then raises NoCudaDeviceError if no
+device answers.
+```
+
+Replacement:
+
+```text
+Queued ArrayRequest objects produce ArrayResponse objects containing allocated
+arrays and chunk metadata. Active mode applies per-instance VRAM caps.
+Passive mode uses device-wide free memory when calculating chunk sizes.
+
+Construction without a CUDA device leaves the manager unsized. Operations
+that need a device-memory size reprobe and raise NoCudaDeviceError if the
+probe fails.
+```
+
+Reason: removes the prose colon and vague "standard allocation" wording.
+Evidence: `src/cubie/memory/mem_manager.py:581`,
+`src/cubie/memory/mem_manager.py:677`,
+`src/cubie/memory/mem_manager.py:1577`,
+`tests/memory/test_memmgmt.py:1463`.
+
+### SOD-008
+
+Location: `src/cubie/memory/stream_groups.py:39`
+
+Current text:
+
+```text
+groups
+    Dictionary mapping group names to lists of instance identifiers. When
+    omitted, an empty mapping is created and populated with the "default"
+    group.
+streams
+    Dictionary mapping group names to CUDA streams. When omitted, each
+    group, including "default", receives a dedicated stream from
+    numba.cuda.stream on first use.
+...
+Each group has an associated CUDA stream that all instances in the group
+share for coordinated operations. The "default" group is created
+automatically.
+```
+
+Replacement:
+
+```text
+groups
+    Dictionary mapping group names to instance identifiers. The default is
+    an empty mapping.
+streams
+    Dictionary mapping group names to CUDA streams. A stream is created when
+    a group is first requested.
+...
+Instances in one group share its dedicated CUDA stream. Registering an
+instance in the "default" group creates that group and stream on demand.
+```
+
+Reason: default construction does not create a `default` group. The current
+rendered docstring contradicts the implementation and its explicit regression
+test. Evidence: `src/cubie/memory/stream_groups.py:64`,
+`src/cubie/memory/stream_groups.py:72`,
+`src/cubie/memory/stream_groups.py:158`,
+`tests/memory/test_stream_groups.py:18`.
+
+## ODE systems and symbolic generation
+
+### SOD-009
+
+Location: `docs/source/API_reference/odesystems/index.rst:22`
+
+Current text:
+
+```rst
+The :func:`create_ODE_system` helper is the main entry point. It consumes
+symbolic :mod:`sympy` equations and creates :class:`SymbolicODE` instances that
+inherit CUDA compilation behaviour from :class:`cubie.CUDAFactory`.
+:class:`BaseODE` sets the abstract requirements, and ``SymbolicODE`` is
+currently its concrete implementation. Base classes and data containers expose
+the precision-aware metadata required by integrator factories.
+```
+
+Replacement:
+
+```rst
+:func:`create_ODE_system` accepts equation strings, SymPy equations, or an
+explicit Python callable and returns :class:`SymbolicODE`. Symbolic DAE input
+is structurally simplified before CUDA source generation. :class:`BaseODE`
+defines the CUDA-backed system interface. :class:`ODEData`,
+:class:`SystemValues`, and :class:`SystemSizes` hold the values and dimensions
+used by integrator factories.
+```
+
+Reason: the current text omits strings, callables, and DAE simplification and
+uses removable framing. Evidence:
+`src/cubie/odesystems/symbolic/symbolicODE.py:102`,
+`src/cubie/odesystems/symbolic/parsing/parser.py:651`,
+`src/cubie/odesystems/baseODE.py:77`.
+
+### SOD-010
+
+Locations: `docs/source/API_reference/odesystems/index.rst:39` through `:52`
+
+Replace the seven current en-dash list items with:
+
+```rst
+* :doc:`create_ODE_system <create_ode_system>` accepts strings, SymPy
+  equations, and explicit Python callables.
+* :doc:`SymbolicODE <symbolic_ode>` generates and compiles device functions
+  for parsed systems.
+* :doc:`BaseODE <base_ode>` defines the CUDA-backed system interface.
+* :doc:`ODEData <ode_data>` stores states, parameters, constants,
+  observables, driver count, precision, and the mass matrix.
+* :doc:`SystemValues <system_values>` maps named system values to a packed
+  precision-specific array.
+* :doc:`SystemSizes <system_sizes>` stores state, observable, parameter,
+  constant, and driver counts.
+* :doc:`ODECache <ode_cache>` stores compiled right-hand-side and observable
+  functions plus lazily generated solver helpers.
+```
+
+The rendered `SystemSizes` class docstring also needs this replacement.
+
+Location: `src/cubie/odesystems/ODEData.py:117`
+
+Current text:
+
+```text
+This data class is passed to CUDA kernels so they can size device buffers
+and shared-memory structures correctly.
+```
+
+Replacement:
+
+```text
+Integrator, batch-solver, and output-sizing components read these counts from
+the ODE system.
+```
+
+Reason: removes separator en dashes, corrects the incomplete ODEData,
+SystemValues, and SystemSizes descriptions, and removes class and correctness
+framing from the rendered `SystemSizes` page. Evidence:
+`src/cubie/odesystems/ODEData.py:101`,
+`src/cubie/odesystems/ODEData.py:117`,
+`src/cubie/odesystems/ODEData.py:131`,
+`src/cubie/odesystems/SystemValues.py:44`,
+`src/cubie/odesystems/baseODE.py:57`,
+`src/cubie/integrators/SingleIntegratorRunCore.py:161`,
+`src/cubie/outputhandling/output_sizes.py:274`.
+
+### SOD-011
+
+Location: `docs/source/API_reference/odesystems/index.rst:57`
+
+Current text:
+
+```rst
+- :class:`SymbolicODE` subclasses :class:`cubie.CUDAFactory` so integrator loops
+  can request compiled CUDA device functions directly.
+- Precision handling relies on :mod:`cubie._utils` helpers and
+  :mod:`cubie.cuda_simsafe` to provide simulator-safe coercions.
+- Generated kernels are consumed by :mod:`cubie.integrators` factories during
+  loop construction.
+```
+
+Replacement:
+
+```rst
+* :class:`SymbolicODE` inherits :class:`BaseODE`, which inherits
+  :class:`cubie.CUDAFactory`.
+* :mod:`cubie.cuda_simsafe` supplies backend-neutral CUDA symbols.
+* Integrator factories consume the compiled system functions and requested
+  solver helpers.
+```
+
+Reason: states the inheritance chain and helper interface directly. Evidence:
+`src/cubie/odesystems/symbolic/symbolicODE.py:213`,
+`src/cubie/odesystems/baseODE.py:77`,
+`src/cubie/odesystems/baseODE.py:440`.
+
+### SOD-012
+
+Location: `docs/source/API_reference/odesystems/symbolic.rst:9`
+
+Current text:
+
+```rst
+The symbolic subpackage implements the SymPy-driven pipeline that generates CUDA
+kernels for right-hand-side evaluations and Newton–Krylov helpers. It parses
+symbolic systems, emits CUDA ``dxdt`` kernels, and packages metadata required by
+:class:`cubie.odesystems.SymbolicODE` so integrator loops can consume compiled
+functions directly.
+
+Key helpers
+-----------
+
+* ``builders`` – utilities that assemble CUDA source strings from SymPy
+  expressions.
+* ``codegen`` – orchestrates SymPy code generation for device kernels.
+* ``templates`` – shared Jinja templates for kernel emission.
+* ``transforms`` – symbolic transformations applied before code generation.
+
+Dependencies
+------------
+
+The code generation workflow relies on :mod:`sympy` for symbolic manipulation
+and :mod:`numba.cuda` for compiling emitted kernels. Generated code is cached via
+:class:`cubie.CUDAFactory` and consumed by :mod:`cubie.integrators` during loop
+assembly.
+```
+
+Replacement:
+
+```rst
+String and SymPy input is converted to the interned expression IR in
+``engine`` at the parse boundary. ``parsing`` normalises equations and routes
+DAE-shaped systems through ``structural`` simplification. ``codegen`` derives
+Jacobian and Jacobian-vector-product IR expressions and renders Python source
+for right-hand-side, observable, residual, linear-operator, and preconditioner
+device functions. ``generate_jacobian`` returns row-major IR expression rows.
+Operator and preconditioner code generators consume Jacobian or
+Jacobian-vector-product IR. Codegen does not emit a standalone Jacobian device
+function.
+:class:`cubie.odesystems.SymbolicODE` stores generated source through
+``ODEFile`` and compiles requested functions through the active CUDA backend.
+
+Components
+----------
+
+* ``engine`` defines expression nodes, differentiation, substitution, common
+  subexpression elimination, dependency ordering, and CUDA printing.
+* ``parsing`` accepts strings, SymPy equations, Python callables, and CellML.
+* ``structural`` simplifies and tears DAE systems.
+* ``codegen`` emits source factories from engine IR.
+
+Dependencies
+------------
+
+SymPy is used at the parse boundary. Generated modules import CUDA symbols
+from :mod:`cubie.cuda_simsafe`. Source files are stored by ``ODEFile`` under
+the configured cache root.
+```
+
+Reason: `builders`, `templates`, and `transforms` do not exist. SymPy is no
+longer the compute representation, Jinja is not used, and generated modules
+import `cuda_simsafe`. The replacement also removes all five en dashes.
+Evidence: `src/cubie/odesystems/symbolic/engine/__init__.py:1`,
+`src/cubie/odesystems/symbolic/parsing/parser.py:627`,
+`src/cubie/odesystems/symbolic/codegen/__init__.py:1`,
+`src/cubie/odesystems/symbolic/codegen/jacobian.py:15`,
+`src/cubie/odesystems/symbolic/codegen/linear_operators.py:44`,
+`src/cubie/odesystems/symbolic/codegen/preconditioners.py:623`,
+`src/cubie/odesystems/symbolic/odefile.py:20`.
+
+### SOD-013
+
+Location: `src/cubie/odesystems/symbolic/symbolicODE.py:120`
+
+Current text:
+
+```text
+Create a SymbolicODE from SymPy definitions.
+```
+
+Replacement:
+
+```text
+Create a SymbolicODE from equation strings, SymPy equations, or an explicit
+Python callable.
+```
+
+Reason: the rendered function summary omits two supported input paths.
+Evidence: `src/cubie/odesystems/symbolic/symbolicODE.py:102`,
+`src/cubie/odesystems/symbolic/symbolicODE.py:124`,
+`src/cubie/odesystems/symbolic/parsing/parser.py:651`.
+
+### SOD-014
+
+Location: `src/cubie/odesystems/symbolic/symbolicODE.py:162`
+
+Current text:
+
+```text
+Force MTK-style structural simplification (alias elimination, index
+reduction, tearing) before code generation, even for systems already in
+explicit form. DAE input — implicit equations (0 = g(...)), higher-order
+derivatives, derivative terms inside expressions, and algebraic unknowns —
+enables it automatically. Torn systems carry a singular mass matrix and
+require an implicit algorithm.
+```
+
+Replacement:
+
+```text
+Force structural simplification before code generation for an explicit
+system. Implicit equations, higher-order derivatives, derivative terms inside
+expressions, and algebraic unknowns enable structural simplification without
+this option. Torn systems carry a singular mass matrix and require an implicit
+algorithm.
+```
+
+Reason: removes two em dashes and the parenthetical process list while
+preserving the DAE behavior. Evidence:
+`src/cubie/odesystems/symbolic/parsing/parser.py:690`,
+`src/cubie/odesystems/symbolic/parsing/parser.py:722`.
+
+### SOD-015
+
+Location: `src/cubie/odesystems/symbolic/symbolicODE.py:179`
+
+Current text:
+
+```text
+Solver mass matrix for hand-formulated semi-explicit DAEs, paired row-for-row
+with the declared state order; None implies identity. Part of the system
+definition — fixed at construction; algorithms read it from the system.
+Singular matrices require an implicit algorithm. Incompatible with structural
+simplification, which derives its own.
+```
+
+Replacement:
+
+```text
+Solver mass matrix for a hand-formulated semi-explicit DAE, paired row for row
+with the declared state order. None selects the identity matrix. The matrix is
+fixed at system construction and is read by implicit algorithms. Structural
+simplification derives its own mass matrix and cannot be combined with this
+argument.
+```
+
+Reason: removes one em dash and two semicolons. Evidence:
+`src/cubie/odesystems/ODEData.py:194`,
+`src/cubie/odesystems/symbolic/symbolicODE.py:192`.
+
+### SOD-016
+
+Locations: `src/cubie/odesystems/symbolic/symbolicODE.py:189` and
+`src/cubie/odesystems/symbolic/symbolicODE.py:419`
+
+Current text:
+
+```text
+Fully constructed symbolic system ready for compilation.
+```
+
+Replacement:
+
+```text
+The created symbolic system.
+```
+
+Reason: removes empty intensification and readiness framing.
+
+### SOD-017
+
+Location: `src/cubie/odesystems/baseODE.py:188`
+
+Current text:
+
+```text
+Compile the dxdt system as a CUDA device function.
+...
+Cache containing the built dxdt function. Subclasses may add further solver
+helpers to this cache as needed.
+```
+
+Replacement:
+
+```text
+Compile the system's base device functions.
+...
+Cache containing the right-hand-side and observable functions plus an empty
+solver-helper member cache.
+```
+
+Reason: `ODECache` contains right-hand-side, observable, and helper members.
+Helpers are requested lazily rather than optionally added during `build`.
+Evidence: `src/cubie/odesystems/baseODE.py:57`,
+`src/cubie/odesystems/symbolic/symbolicODE.py:944`.
+
+## Output handling and metrics
+
+### SOD-018
+
+Location: `docs/source/API_reference/outputhandling/index.rst:25`
+
+Current text:
+
+```rst
+The output handling package manages CUDA device callbacks that save state
+trajectories and summary calculations from integration loops. It turns loop
+settings into checked configuration, builds the device functions through the
+CUDA factory tools, and provides sizing helpers so callers can allocate host and
+device buffers without repeating dimension logic.
+```
+
+Replacement:
+
+```rst
+``cubie.outputhandling`` validates requested outputs, compiles device
+functions that save time-domain values and summary metrics, and calculates
+the buffer dimensions used by batch solvers.
+```
+
+Reason: removes package framing and the purpose clause. Evidence:
+`src/cubie/outputhandling/output_config.py:199`,
+`src/cubie/outputhandling/output_functions.py:125`,
+`src/cubie/outputhandling/output_sizes.py:53`.
+
+### SOD-019
+
+Location: `docs/source/API_reference/outputhandling/index.rst:41`
+
+Current text:
+
+```rst
+:doc:`OutputFunctions <output_functions>` is the main interface. Create it with loop
+dimensions and requested outputs to compile CUDA functions that save solver
+state, refresh summary metrics, and write reductions back to host arrays. The
+factory keeps an :class:`OutputConfig` instance and rebuilds compiled callbacks
+when configuration changes.
+```
+
+Replacement:
+
+```rst
+:doc:`OutputFunctions <output_functions>` converts loop dimensions and output
+requests into :class:`OutputConfig`. Its cached device functions save selected
+values, update summary buffers, and write summary results to output arrays.
+Changing a compile setting invalidates the cached functions.
+```
+
+Reason: summary functions write device output slices, not host arrays. The
+replacement names the three function roles. Evidence:
+`src/cubie/outputhandling/output_functions.py:100`,
+`src/cubie/outputhandling/output_functions.py:245`,
+`src/cubie/outputhandling/save_summaries.py:189`.
+
+### SOD-020
+
+Locations: `docs/source/API_reference/outputhandling/index.rst:50` through
+`:67`
+
+Replace the ten current en-dash list items with:
+
+```rst
+* :doc:`OutputConfig <output_config>` validates requested values, indices,
+  output types, summary metrics, cadence, and precision.
+* :doc:`OutputCompileFlags <output_compile_flags>` carries boolean flags used
+  by compiled output functions.
+* :doc:`OutputArrayHeights <output_array_heights>` stores per-array heights.
+* :doc:`SingleRunOutputSizes <single_run_output_sizes>` stores single-run
+  output shapes.
+* :doc:`BatchInputSizes <batch_input_sizes>` stores batch input shapes.
+* :doc:`BatchOutputSizes <batch_output_sizes>` stores batch output shapes.
+* :doc:`OutputFunctions <output_functions>` compiles the save and summary
+  callbacks.
+* :doc:`OutputFunctionCache <output_function_cache>` stores the three compiled
+  callbacks for one factory configuration.
+* :doc:`summary_metrics <summary_metrics>` is the process-wide metric registry.
+* :doc:`register_metric <register_metric>` creates a decorator for a specified
+  metric registry.
+```
+
+Reason: removes ten separator en dashes and corrects the cache and decorator
+descriptions. Evidence: `src/cubie/outputhandling/output_functions.py:100`,
+`src/cubie/outputhandling/summarymetrics/metrics.py:98`.
+
+### SOD-021
+
+Location: `docs/source/API_reference/outputhandling/index.rst:72`
+
+Current text:
+
+```rst
+* Compiles CUDA callables through :class:`cubie.CUDAFactory` and
+  :mod:`numba.cuda`.
+* Loop buffers and output slices align with expectations from
+  :mod:`cubie.integrators.loops` and related algorithm factories.
+```
+
+Replacement:
+
+```rst
+* :class:`cubie.CUDAFactory` caches compiled output functions.
+* :mod:`cubie.cuda_simsafe` supplies the active CUDA backend.
+* Integrator loops pass per-run output slices to the compiled functions.
+```
+
+Reason: avoids naming `numba.cuda` as the only backend and removes vague
+"align with expectations" wording. Evidence:
+`src/cubie/outputhandling/output_functions.py:125`,
+`src/cubie/outputhandling/save_state.py:25`.
+
+### SOD-022
+
+Location: `docs/source/API_reference/outputhandling/summarymetrics.rst:36`
+
+Current text:
+
+```rst
+The ``summarymetrics`` package houses the summary metric registry used by output
+handling to accumulate reductions during integration. Importing the package
+creates :data:`summary_metrics` and eagerly imports the built-in metrics so that
+each registers its CUDA device update and save functions. External packages
+extend the system by decorating new metric classes with :func:`register_metric`.
+```
+
+Replacement:
+
+```rst
+Importing ``cubie.outputhandling.summarymetrics`` creates
+:data:`summary_metrics` and imports 18 built-in metric classes. The decorators
+instantiate the classes and register each metric object's name, sizes, output
+metadata, and object reference. :class:`SummaryMetrics` retrieves update and
+save device functions from those objects when the functions are requested. A
+custom metric subclasses :class:`SummaryMetric` and uses
+``@register_metric(summary_metrics)``.
+```
+
+Reason: removes package framing and states the decorator's required registry
+argument. Imports register metric instances and metadata. They do not eagerly
+retrieve the compiled update and save functions. Evidence:
+`src/cubie/outputhandling/summarymetrics/__init__.py:35`,
+`src/cubie/outputhandling/summarymetrics/__init__.py:38`,
+`src/cubie/outputhandling/summarymetrics/metrics.py:117`,
+`src/cubie/outputhandling/summarymetrics/metrics.py:403`,
+`src/cubie/outputhandling/summarymetrics/metrics.py:765`,
+`src/cubie/outputhandling/summarymetrics/metrics.py:788`,
+`tests/outputhandling/summarymetrics/test_summary_metrics.py:672`.
+
+### SOD-023
+
+Locations: `docs/source/API_reference/outputhandling/summarymetrics.rst:45`
+through `:49`
+
+Replacement:
+
+```rst
+* :doc:`summary_metrics <summary_metrics>` stores registered metric objects and
+  dispatches sizes, offsets, labels, units, and device functions.
+* :doc:`register_metric <register_metric>` creates a class decorator bound to a
+  :class:`SummaryMetrics` registry.
+* :doc:`SummaryMetric <summarymetrics/metrics/summary_metric>` defines the
+  metric compile settings and update/save function contract.
+* :doc:`SummaryMetrics <summarymetrics/metrics/summary_metrics>` dispatches
+  requested metrics and applies combined-metric substitution.
+* :doc:`MetricFuncCache <summarymetrics/metrics/metric_func_cache>` stores one
+  metric's update and save device functions.
+```
+
+Current text: the same five list entries use an en dash between each link and
+description.
+
+Reason: removes five separator en dashes and replaces generic descriptions
+with current responsibilities. Evidence:
+`src/cubie/outputhandling/summarymetrics/metrics.py:58`,
+`src/cubie/outputhandling/summarymetrics/metrics.py:125`,
+`src/cubie/outputhandling/summarymetrics/metrics.py:280`.
+
+### SOD-024
+
+Locations: `docs/source/API_reference/outputhandling/summarymetrics.rst:54`
+through `:69`
+
+Replace the current 16 en-dash entries with the following 18 entries:
+
+```rst
+* :doc:`Mean <summarymetrics/metrics/mean>` computes the arithmetic mean.
+* :doc:`Max <summarymetrics/metrics/max>` computes the maximum.
+* :doc:`Min <summarymetrics/metrics/min>` computes the minimum.
+* :doc:`RMS <summarymetrics/metrics/rms>` computes the root mean square.
+* :doc:`Std <summarymetrics/metrics/std>` computes standard deviation.
+* :doc:`MaxMagnitude <summarymetrics/metrics/max_magnitude>` computes the
+  maximum absolute value.
+* :doc:`Extrema <summarymetrics/metrics/extrema>` computes maximum and minimum.
+* :doc:`Peaks <summarymetrics/metrics/peaks>` records local maxima.
+* :doc:`NegativePeaks <summarymetrics/metrics/negative_peaks>` records local
+  minima.
+* :doc:`MeanStd <summarymetrics/metrics/mean_std>` computes mean and standard
+  deviation from one buffer.
+* :doc:`MeanStdRms <summarymetrics/metrics/mean_std_rms>` computes mean,
+  standard deviation, and root mean square from one buffer.
+* :doc:`StdRms <summarymetrics/metrics/std_rms>` computes standard deviation
+  and root mean square from one buffer.
+* :doc:`DxdtMax <summarymetrics/metrics/dxdt_max>` computes the maximum first
+  derivative.
+* :doc:`DxdtMin <summarymetrics/metrics/dxdt_min>` computes the minimum first
+  derivative.
+* :doc:`DxdtExtrema <summarymetrics/metrics/dxdt_extrema>` computes both first
+  derivative extrema.
+* :doc:`D2xdt2Max <summarymetrics/metrics/d2xdt2_max>` computes the maximum
+  second derivative.
+* :doc:`D2xdt2Min <summarymetrics/metrics/d2xdt2_min>` computes the minimum
+  second derivative.
+* :doc:`D2xdt2Extrema <summarymetrics/metrics/d2xdt2_extrema>` computes both
+  second derivative extrema.
+```
+
+Reason: `MeanStd` and `StdRms` are registered built-ins but have no API pages
+or overview entries. The replacement removes 16 separator en dashes and the
+unsupported intensifier "efficiently". Evidence:
+`src/cubie/outputhandling/summarymetrics/__init__.py:47`,
+`src/cubie/outputhandling/summarymetrics/mean_std.py:29`,
+`src/cubie/outputhandling/summarymetrics/std_rms.py:28`,
+`tests/outputhandling/summarymetrics/test_summary_metrics.py:672`.
+
+### SOD-025
+
+Location: `docs/source/API_reference/outputhandling/summarymetrics.rst:74`
+
+Current text:
+
+```rst
+* Compiles device functions via :class:`cubie.CUDAFactory` and :mod:`numba.cuda`.
+* Consumes save/update cadence configuration from :mod:`cubie.outputhandling`.
+```
+
+Replacement:
+
+```rst
+* :class:`cubie.CUDAFactory` caches each metric's update and save functions.
+* :mod:`cubie.cuda_simsafe` supplies the active CUDA backend.
+* :class:`cubie.outputhandling.OutputFunctions` propagates precision and
+  summary sampling cadence to registered metrics before compilation.
+```
+
+Reason: names the backend abstraction and the actual configuration boundary.
+Evidence: `src/cubie/outputhandling/output_functions.py:261`,
+`src/cubie/outputhandling/summarymetrics/metrics.py:357`.
+
+### SOD-026
+
+Location: `src/cubie/outputhandling/output_config.py:208`
+
+Current text:
+
+```text
+saved_state_indices
+    Indices of state variables to save. Defaults to an empty collection that
+    resolves to all states.
+saved_observable_indices
+    Indices of observable variables to save. Defaults to an empty collection
+    that resolves to all observables.
+```
+
+Replacement:
+
+```text
+saved_state_indices
+    State indices to save. An empty collection disables state output.
+saved_observable_indices
+    Observable indices to save. An empty collection disables observable
+    output.
+```
+
+Reason: empty arrays do not expand to all variables. The property gates output
+on a non-empty array. Evidence: `src/cubie/outputhandling/output_config.py:369`,
+`src/cubie/outputhandling/output_config.py:374`,
+`tests/outputhandling/test_output_config.py:305`.
+
+### SOD-027
+
+Location: `src/cubie/outputhandling/output_config.py:228`
+
+Current text:
+
+```text
+Private attributes store numpy arrays so that properties can manage circular
+dependencies between index validation and flag updates. The post-initialisation
+hook applies default indices, validates bounds, and ensures at least one output
+path is active.
+```
+
+Replacement:
+
+```text
+Post-initialisation derives flags from output_types, validates each index array,
+and rejects configurations without an active output.
+```
+
+Reason: removes implementation framing and a stale circular-dependency claim.
+Evidence: `src/cubie/outputhandling/output_config.py:290`.
+
+### SOD-028
+
+Location: `src/cubie/outputhandling/output_config.py:746`
+
+Current text:
+
+```text
+This class method provides a convenient interface for creating OutputConfig
+objects from the parameter format used by integrator classes. It handles None
+values appropriately by converting them to empty arrays.
+```
+
+Replacement:
+
+```text
+None index arguments are converted to empty int32 arrays before OutputConfig
+construction.
+```
+
+Reason: removes convenience framing and the empty qualifier "appropriately".
+Evidence: `src/cubie/outputhandling/output_config.py:756`.
+
+### SOD-029
+
+Locations: `src/cubie/outputhandling/output_sizes.py:163`, `:233`, `:287`
+
+| Current text | Replacement |
+| --- | --- |
+| `This class provides 2D array sizes (time × variable) for output arrays from a single integration run.` | `Shapes use the order time sample by variable.` |
+| `This class specifies the sizes of input arrays needed for batch processing, including initial conditions, parameters, and forcing terms.` | `Batch inputs contain initial-state, parameter, and driver-coefficient arrays.` |
+| `This class provides 3D array sizes (time × variable × run) for output arrays from batch integration runs.` | `Batch output shapes use the order time sample by variable by run.` |
+
+Reason: removes three class-framing sentences. Evidence:
+`src/cubie/outputhandling/output_sizes.py:160`,
+`src/cubie/outputhandling/output_sizes.py:230`,
+`src/cubie/outputhandling/output_sizes.py:284`.
+
+### SOD-030
+
+Locations: `src/cubie/outputhandling/output_functions.py:216` and `:253`
+
+Current text:
+
+```text
+Use this method for coordinated configuration updates alongside other
+components by passing silent=True so unrelated keys fall through without
+raising.
+
+This method is invoked lazily by CUDAFactory the first time a compiled function
+is requested. The resulting cache is reused until configuration settings
+change.
+```
+
+Replacement:
+
+```text
+silent=True ignores keys that are not OutputFunctions settings.
+
+CUDAFactory invokes build on the first compiled-function request and reuses the
+result until a compile setting changes.
+```
+
+Reason: removes method framing while preserving behavior. Evidence:
+`src/cubie/outputhandling/output_functions.py:189`,
+`src/cubie/outputhandling/output_functions.py:245`.
+
+### SOD-031
+
+Location: `src/cubie/outputhandling/summarymetrics/metrics.py:484`
+
+Current text:
+
+```text
+Invalid metric names trigger a warning and are removed from the returned list.
+Combined metrics are automatically substituted when multiple individual
+metrics can be computed more efficiently together.
+```
+
+Replacement:
+
+```text
+Invalid metric names trigger a warning and are removed. A registered combined
+metric replaces its complete constituent set.
+```
+
+Reason: removes the unqualified efficiency claim and automaticity emphasis.
+Evidence: `src/cubie/outputhandling/summarymetrics/metrics.py:410`,
+`tests/outputhandling/summarymetrics/test_summary_metrics.py:331`.
+
+### SOD-032
+
+Locations: source metric class docstrings at
+`src/cubie/outputhandling/summarymetrics/d2xdt2_extrema.py:33`,
+`d2xdt2_max.py:33`, `d2xdt2_min.py:33`, `dxdt_extrema.py:33`,
+`dxdt_max.py:33`, `dxdt_min.py:33`, `extrema.py:33`,
+`mean_std_rms.py:33`, and `std.py:33`
+
+Replace each `Uses ... buffer slots:` or `The metric uses ... buffer slots:`
+construction with direct slot assignments. Apply these exact sentence forms:
+
+```text
+D2xdt2Extrema uses four buffer slots. Slots 0 and 1 store the two previous
+values. Slots 2 and 3 store the maximum and minimum unscaled second
+derivatives. The outputs are the maximum and minimum second derivatives.
+
+D2xdt2Max and D2xdt2Min use three buffer slots. Slots 0 and 1 store the two
+previous values. Slot 2 stores the unscaled second-derivative extremum.
+
+DxdtExtrema uses three buffer slots. Slot 0 stores the previous value. Slots 1
+and 2 store the maximum and minimum unscaled derivatives. The outputs are the
+maximum and minimum derivatives.
+
+DxdtMax and DxdtMin use two buffer slots. Slot 0 stores the previous value.
+Slot 1 stores the unscaled derivative extremum.
+
+Extrema uses two buffer slots. Slot 0 stores the maximum and slot 1 stores the
+minimum. The outputs use the same order.
+
+MeanStdRms uses three buffer slots. They store the shift, the sum of shifted
+values, and the sum of squared shifted values.
+
+Std uses three buffer slots. They store the shift, the sum of shifted values,
+and the sum of squared shifted values.
+```
+
+Current text: the cited docstrings use a colon after the buffer-slot count and,
+for combined metrics, a second colon before the output order.
+
+Reason: removes eleven avoidable prose colons without dropping buffer layout.
+Evidence: the cited class definitions and
+`tests/outputhandling/summarymetrics/test_summary_metrics.py:691`.
+
+## Rendered source-docstring punctuation
+
+### SOD-033
+
+The following rendered public-member sentences contain every remaining em dash
+or semicolon in the scoped autodoc corpus. Apply the exact replacements below.
+
+| Location | Current text | Replacement |
+| --- | --- | --- |
+| `src/cubie/memory/mem_manager.py:851` | `Because each process owns its own manager, this stream is private to the process; synchronizing it never orders against the device-wide default stream.` | `Each process owns its manager and its group stream. Synchronizing the group stream does not order against the device-wide default stream.` |
+| `src/cubie/memory/mem_manager.py:1119` | `Garbage-collection finalizers call this instead of deregistering directly: GC runs inside whatever allocation triggered it — possibly while this manager iterates its registry, possibly on the transfer watcher's own thread — so the callback only appends.` | `Garbage-collection finalizers append a teardown instead of deregistering. Collection can run during a registry iteration or on the transfer watcher thread.` |
+| `src/cubie/memory/mem_manager.py:1433` | `Directory for "memmap" arrays; None = temp dir.` | `Directory for memory-mapped arrays. None uses the system temporary directory.` |
+| `src/cubie/memory/mem_manager.py:1488` | `Disk-backing size in bytes; None = the RAM default.` | `Disk-backing threshold in bytes. None uses 80 percent of total RAM.` |
+| `src/cubie/memory/mem_manager.py:1490` | `Permit the "pinned" choice; chunked staging passes False.` | `Permit pinned host allocation. Chunked staging passes False.` |
+| `src/cubie/memory/stream_groups.py:210` | `Removing an instance that is in no group is a no-op; the group and its stream are kept for the remaining members.` | `Removing an unregistered instance has no effect. Removing a registered instance keeps its group and stream.` |
+| `src/cubie/odesystems/baseODE.py:423` | `The consumer's cache policy, forwarded with every request made through the returned callable. Service context only — it never enters any identity.` | `The consumer's cache policy is forwarded with each request and is excluded from helper identity.` |
+| `src/cubie/odesystems/baseODE.py:447` | `Helpers that consume a mass matrix read the system's own mass; the matrix is part of the system definition, not an algorithm parameter.` | `Mass-consuming helpers read the system's mass. The mass matrix is part of the system definition and is not an algorithm parameter.` |
+| `src/cubie/odesystems/ODEData.py:307` | `Solver mass matrix; None implies identity.` | `Solver mass matrix. None selects the identity matrix.` |
+| `src/cubie/odesystems/symbolic/symbolicODE.py:395` | `DAE input — implicit equations, higher-order derivatives, derivative terms inside expressions, and algebraic unknowns — enables it automatically.` | `Implicit equations, higher-order derivatives, derivative terms inside expressions, and algebraic unknowns enable structural simplification.` |
+| `src/cubie/odesystems/symbolic/symbolicODE.py:410` | `Solver mass matrix for hand-formulated semi-explicit DAEs, paired row-for-row with the declared state order; None implies identity. The matrix is part of the system definition: it is fixed at construction and algorithms read it from the system.` | `The solver mass matrix for a hand-formulated semi-explicit DAE is paired row for row with the declared state order. None selects the identity matrix. The matrix is fixed at system construction and read by algorithms.` |
+| `src/cubie/odesystems/symbolic/symbolicODE.py:966` | `An exact repeated request returns the same member object; different bindings that share emitted source reuse one generated factory.` | `An identical request returns the same member object. Bindings with the same emitted source reuse one generated factory.` |
+| `src/cubie/odesystems/SystemValues.py:221` | `Values stay writable for containers whose stored values are runtime data (parameters, states, observables); the constants container seals fully because constant values are compile-critical.` | `Parameter, state, and observable values remain writable. Constant values are sealed because compilation captures them.` |
+
+Reason: removes all five em dashes and all ten semicolons found in rendered
+class and member docstrings. SOD-014 and SOD-015 remove the additional three em
+dashes and two semicolons in the rendered `create_ODE_system` docstring.
+
+## Missing pages
+
+### SOD-034
+
+Location: absent API page for `NoCudaDeviceError`
+
+Current text: absent.
+
+Replacement file `docs/source/API_reference/memory/no_cuda_device_error.rst`:
+
+```rst
+NoCudaDeviceError
+=================
+
+.. currentmodule:: cubie.memory
+
+.. autoclass:: NoCudaDeviceError
+```
+
+Add `memory/no_cuda_device_error` to `memory.rst`.
+
+Reason: `NoCudaDeviceError` is in `cubie.memory.__all__` and controls the
+documented no-device behavior. Evidence: `src/cubie/memory/__init__.py:37`,
+`src/cubie/memory/mem_manager.py:122`,
+`tests/memory/test_memmgmt.py:1463`.
+
+### SOD-035
+
+Location: absent API page for `CuPyAsyncNumbaManager`
+
+Current text: absent.
+
+Replacement file `docs/source/API_reference/memory/cupy_async_numba_manager.rst`:
+
+```rst
+CuPyAsyncNumbaManager
+=====================
+
+.. currentmodule:: cubie.memory.cupy_emm
+
+.. py:class:: CuPyAsyncNumbaManager(context)
+
+   External memory manager available on real-GPU builds. It allocates Numba
+   device memory through CuPy's asynchronous memory pool.
+
+   ``CuPyAsyncNumbaManager`` is ``None`` when CUDA simulation is enabled.
+```
+
+Add `memory/cupy_async_numba_manager` to `memory.rst`.
+
+Reason: the class is exported on real GPU builds and implements the sole
+device allocator. A manual Python-domain declaration remains build-valid under
+CUDA simulation, where the symbol is assigned `None` and `autoclass` cannot
+resolve a class. Evidence: `src/cubie/memory/__init__.py:24`,
+`src/cubie/memory/cupy_emm.py:26`,
+`src/cubie/memory/cupy_emm.py:94`.
+
+### SOD-036
+
+Location: absent API page for `load_cellml_model`
+
+Current text: absent.
+
+Replacement file `docs/source/API_reference/odesystems/load_cellml_model.rst`:
+
+```rst
+load_cellml_model
+=================
+
+.. currentmodule:: cubie.odesystems
+
+.. autofunction:: load_cellml_model
+```
+
+Add `load_cellml_model` to the ODE-system toctree and Core API list.
+
+Reason: `load_cellml_model` is a package-level public function and has only a
+user-guide mention. Evidence: `src/cubie/odesystems/__init__.py:24`,
+`src/cubie/odesystems/symbolic/parsing/cellml.py:184`,
+`tests/odesystems/symbolic/test_cellml.py:14`.
+
+Before adding the page, revise every affected part of its newly rendered
+docstring.
+
+Location: `src/cubie/odesystems/symbolic/parsing/cellml.py:194`
+
+Current text:
+
+```text
+Load a CellML model and return an initialized SymbolicODE system.
+
+This function uses the cellmlmanip library to parse CellML files
+and converts them into a ready-to-use SymbolicODE system with all
+differential equations and algebraic constraints properly configured.
+```
+
+Replacement:
+
+```text
+Load a CellML model into a SymbolicODE.
+```
+
+Location: `src/cubie/odesystems/symbolic/parsing/cellml.py:221`
+
+Current text:
+
+```text
+voltage_variable : str, optional
+    Name of the membrane voltage variable used by the singularity
+    rewrite. If None while fix_singularities is True, the
+    voltage state is auto-detected by name; when none is found a
+    UserWarning is issued and the rewrite is skipped. Ignored when
+    fix_singularities is False.
+```
+
+Replacement:
+
+```text
+voltage_variable : str, optional
+    Name of the membrane voltage variable used by the singularity
+    rewrite. When omitted and fix_singularities is True, state-name
+    matching selects the voltage variable. If no match exists, a
+    UserWarning is issued and the rewrite is skipped. Ignored when
+    fix_singularities is False.
+```
+
+Location: `src/cubie/odesystems/symbolic/parsing/cellml.py:233`
+
+Current text:
+
+```text
+SymbolicODE
+    Initialized ODE system ready for use with solve_ivp.
+    State variables are configured with initial values from the
+    CellML model, and algebraic equations are set up according
+    to the parameters and observables specifications.
+```
+
+Replacement:
+
+```text
+SymbolicODE
+    Symbolic system containing the model equations, selected parameters and
+    observables, and CellML initial values.
+```
+
+Remove the stale Raises entry at
+`src/cubie/odesystems/symbolic/parsing/cellml.py:241`:
+
+```text
+Current: ImportError. If cellmlmanip is not installed. Install with pip install cellmlmanip.
+Replacement: remove this Raises entry.
+```
+
+`cellmlmanip` is vendored and imported unconditionally from
+`cubie.vendored`. Evidence:
+`src/cubie/odesystems/symbolic/parsing/cellml.py:24`,
+`src/cubie/odesystems/symbolic/parsing/cellml.py:36`.
+
+Location: `src/cubie/odesystems/symbolic/parsing/cellml.py:254`
+
+Current text:
+
+```text
+Load a CellML model and run a simulation:
+```
+
+Replacement:
+
+```text
+Load and simulate a CellML model.
+```
+
+Replace the Notes block at
+`src/cubie/odesystems/symbolic/parsing/cellml.py:269` with:
+
+```text
+Notes
+-----
+CellML differential equations become states. Requested algebraic variables
+become observables. Other algebraic expressions remain auxiliaries. CellML
+initial values are retained.
+```
+
+The existing notes include implementation framing, an unqualified Physiome
+compatibility claim, and a claim that the vendored parser handles "complex"
+XML. The replacement retains the public conversion behavior. The current
+85-line docstring contains ten colons and one semicolon. These replacements
+retain eight numpydoc type colons and remove both prose colons and the
+semicolon.
+
+### SOD-037
+
+Locations: absent API pages for `MeanStd` and `StdRms`
+
+Current text: absent.
+
+Replacement files:
+
+```rst
+MeanStd
+-------
+
+.. currentmodule:: cubie.outputhandling.summarymetrics.mean_std
+
+.. autoclass:: MeanStd
+   :members:
+   :show-inheritance:
+```
+
+```rst
+StdRms
+======
+
+.. currentmodule:: cubie.outputhandling.summarymetrics.std_rms
+
+.. autoclass:: StdRms
+   :members:
+   :show-inheritance:
+```
+
+Add both files to the summary-metrics toctree.
+
+Before adding the pages, remove the prose colon from each newly rendered class
+docstring.
+
+Location: `src/cubie/outputhandling/summarymetrics/mean_std.py:34`
+
+Current text:
+
+```text
+Uses three buffer slots: shift (first value), sum of shifted values, and
+sum of squares of shifted values. The shift technique improves numerical
+stability for the variance calculation.
+
+The output array contains [mean, std] in that order.
+```
+
+Replacement:
+
+```text
+The buffer stores the first value, the sum of shifted values, and the sum of
+squared shifted values. Shifting reduces cancellation in the variance
+calculation. The output order is mean followed by standard deviation.
+```
+
+Location: `src/cubie/outputhandling/summarymetrics/std_rms.py:33`
+
+Current text:
+
+```text
+Uses three buffer slots: shift (first value), sum of shifted values, and
+sum of squares of shifted values. The shift technique improves numerical
+stability for the variance calculation.
+
+The output array contains [std, rms] in that order.
+```
+
+Replacement:
+
+```text
+The buffer stores the first value, the sum of shifted values, and the sum of
+squared shifted values. Shifting reduces cancellation in the variance
+calculation. The output order is standard deviation followed by RMS.
+```
+
+Reason: both classes are registered built-ins and are tested as combined
+metric substitutions. Each current ten-line class docstring contains one
+prose colon. The replacements contain none. Evidence:
+`src/cubie/outputhandling/summarymetrics/__init__.py:48`,
+`src/cubie/outputhandling/summarymetrics/__init__.py:49`,
+`src/cubie/outputhandling/summarymetrics/mean_std.py:34`,
+`src/cubie/outputhandling/summarymetrics/std_rms.py:33`,
+`tests/outputhandling/summarymetrics/test_summary_metrics.py:339`,
+`tests/outputhandling/summarymetrics/test_summary_metrics.py:343`.
+
+## Agent-instruction mirror
+
+### SOD-038
+
+Location: `src/cubie/odesystems/symbolic/engine/CLAUDE.md:1`
+
+Current text:
+
+```text
+AGENTS.md
+```
+
+Current Git mode: `100644` regular file.
+
+Replacement: store the same `AGENTS.md` link target with Git mode `120000`,
+matching every other nested `CLAUDE.md` mirror.
+
+Reason: the regular file displays the link target as its entire instruction
+document instead of resolving the 80-line engine guidance. Adjacent mirrors
+use mode `120000`. The authoritative guidance is
+`src/cubie/odesystems/symbolic/engine/AGENTS.md:1` through `:80` and agrees
+with the current engine source at
+`src/cubie/odesystems/symbolic/engine/expr.py:62`,
+`src/cubie/odesystems/symbolic/engine/assignments.py:32`, and
+`src/cubie/odesystems/symbolic/engine/printer.py:95`.
+
+## Regular instruction files
+
+### SOD-039
+
+Location: `src/cubie/memory/AGENTS.md:149` through `:154`
+
+Current text lists `test_memmgmt.py` twice and attaches the real-GPU CuPy
+qualification to the duplicate filename.
+
+Replacement:
+
+```markdown
+### Testing
+
+`tests/memory/` contains `test_array_requests.py`,
+`test_chunk_buffer_pool.py`, `test_memmgmt.py`, and
+`test_stream_groups.py`. The native-device-allocation and CuPy stream tests
+in `test_memmgmt.py` use the `cupy` and `nocudasim` markers. Other real-device
+tests use `nocudasim` as required.
+```
+
+Reason: gives the exact four-test-module inventory and identifies the marked
+tests without duplicating a filename. Evidence:
+`tests/memory/test_memmgmt.py:399`,
+`tests/memory/test_memmgmt.py:1380`,
+`tests/memory/test_array_requests.py:1`,
+`tests/memory/test_chunk_buffer_pool.py:1`, and
+`tests/memory/test_stream_groups.py:1`.
+
+### SOD-040
+
+Locations: `src/cubie/odesystems/AGENTS.md:6` through `:13`,
+`src/cubie/odesystems/AGENTS.md:22`, and
+`src/cubie/odesystems/AGENTS.md:124`
+
+Replacement for the affected purpose and key-file claims:
+
+```markdown
+`BaseODE(CUDAFactory)` defines the shared system interface and owns the
+`CUDAFactory` cache interaction, `ODEData` compile settings, and `SystemValues`
+mappings. `SymbolicODE` generates source for `dxdt`, observables, and requested
+solver helpers. Jacobian generation returns IR expression rows used by helper
+source generators. It does not emit a standalone Jacobian device function.
+`ODECache` stores compiled `dxdt`, observables, and solver-helper caches.
+`SystemSizes` stores component counts read by integrator, batch-solver, and
+output-sizing components.
+```
+
+Replacement dependency entry:
+
+```markdown
+- `attrs`, `numpy`, and `sympy`. CUDA compilation uses the active backend
+  exposed through `cubie.cuda_simsafe`.
+```
+
+Reason: removes the nonexistent Jacobian device function, the claim that the
+`SystemSizes` object is passed to kernels, and the deprecated-backend-only
+dependency description. Evidence:
+`src/cubie/odesystems/symbolic/codegen/jacobian.py:233`,
+`src/cubie/odesystems/symbolic/codegen/preconditioners.py:623`,
+`src/cubie/integrators/SingleIntegratorRunCore.py:161`,
+`src/cubie/outputhandling/output_sizes.py:274`, and
+`src/cubie/cuda_simsafe.py:1`.
+
+### SOD-041
+
+Location: `src/cubie/odesystems/symbolic/AGENTS.md:117`
+
+Current text:
+
+```markdown
+- `sympy`; `numpy` (`float32`, `ndarray`); `numba`/`numba.cuda` (generated header + precision types).
+```
+
+Replacement:
+
+```markdown
+- `sympy` and `numpy`. Generated modules import CUDA symbols and integer types
+  from `cubie.cuda_simsafe`, which exposes the active backend.
+```
+
+Reason: generated modules do not import `numba.cuda` directly. Evidence:
+`src/cubie/odesystems/symbolic/odefile.py:20` through `:23` and
+`src/cubie/cuda_simsafe.py:1`.
+
+### SOD-042
+
+Locations: `src/cubie/odesystems/symbolic/codegen/AGENTS.md:6` through `:21`
+and `src/cubie/odesystems/symbolic/codegen/AGENTS.md:145` through `:147`
+
+Replacement purpose text:
+
+```markdown
+Source-emitter functions return Python strings defining factories for CUDA
+device functions. `jacobian.py` is different. `generate_jacobian` returns
+row-major IR expression rows, and `generate_analytical_jvp` returns structured
+JVP assignments. Operator and preconditioner source generators consume those
+expressions. `SymbolicODE.get_solver_helper()` writes source-emitter output
+through `ODEFile`, imports the generated module, and calls the selected
+factory.
+
+The emitted callbacks implement the linear operator, nonlinear residual, and
+requested preconditioners used by implicit solvers. The operator is the
+Jacobian of the residual with respect to the stage increment. Their coefficient
+placement follows the equations in the sign-and-coefficient section.
+```
+
+Replacement dependency entry:
+
+```markdown
+- SymPy is used at the conversion boundary. Emitted modules obtain CUDA
+  symbols from `cubie.cuda_simsafe` and compile with the active backend.
+```
+
+Reason: not every public `generate_*` returns source, and codegen does not emit
+a standalone analytic Jacobian device function. The replacement also removes
+deprecated-backend-only wording. Evidence:
+`src/cubie/odesystems/symbolic/codegen/jacobian.py:233`,
+`src/cubie/odesystems/symbolic/codegen/jacobian.py:292`,
+`src/cubie/odesystems/symbolic/codegen/linear_operators.py:44`,
+`src/cubie/odesystems/symbolic/codegen/preconditioners.py:40`, and
+`src/cubie/odesystems/symbolic/odefile.py:20` through `:23`.
+
+### SOD-043
+
+Locations: `src/cubie/odesystems/symbolic/parsing/AGENTS.md:80` through `:88`,
+`src/cubie/odesystems/symbolic/parsing/AGENTS.md:111` through `:115`, and
+`src/cubie/odesystems/symbolic/parsing/AGENTS.md:124` through `:127`
+
+Replacement:
+
+```markdown
+### CellML
+
+`cellmlmanip` is vendored under `cubie.vendored.cellmlmanip` and imported at
+module scope. `load_cellml_model` therefore has no missing-cellmlmanip
+`ImportError` path. Numeric Dummy atoms become `sp.Float` or `sp.Integer`.
+Algebraic equations with numeric right-hand sides become constants or selected
+parameters. Other algebraic equations become observables or auxiliaries.
+`CellMLCache` stores at most five configurations per model under the configured
+cache root and keys entries by file content and serialized arguments.
+
+### Testing
+
+The parsing tests run without a GPU. CellML tests use the vendored parser and
+its core runtime dependencies.
+
+### External dependencies
+
+- `sympy`, `attrs`, and `numpy`. The vendored CellML parser uses the core
+  `lxml`, `networkx`, `Pint`, and `rdflib` dependencies.
+```
+
+Reason: the instruction still describes the pre-vendoring optional import and
+an `ImportError` that cannot occur from an absent external `cellmlmanip`
+package. Evidence:
+`src/cubie/odesystems/symbolic/parsing/cellml.py:24` through `:36` and
+`pyproject.toml:29` through `:37`.
+
+### SOD-044
+
+Location: `src/cubie/outputhandling/AGENTS.md:102` through `:104`
+
+Replacement:
+
+```markdown
+### External
+
+- `attrs` and `numpy`. Device-function modules import CUDA symbols and integer
+  types from `cubie.cuda_simsafe`.
+```
+
+Reason: output device factories do not import `numba.cuda` directly. Evidence:
+`src/cubie/outputhandling/save_state.py:19`,
+`src/cubie/outputhandling/update_summaries.py:29`, and
+`src/cubie/outputhandling/save_summaries.py:29`.
+
+### SOD-045
+
+Locations:
+`src/cubie/outputhandling/summarymetrics/AGENTS.md:93` through `:94` and
+`src/cubie/outputhandling/summarymetrics/AGENTS.md:112` through `:114`
+
+Current shift description:
+
+```markdown
+`buffer[0]` holds the window's first sample as the shift, set when
+`current_index == 0`.
+```
+
+Replacement:
+
+```markdown
+`buffer[0]` is initialized from the first summary sample when
+`current_index == 0`. Each save replaces it with the completed window's mean,
+which becomes the shift for the next window.
+```
+
+Replacement dependency entry:
+
+```markdown
+### External
+
+- `numpy`, `attrs`, and `math`. Metric modules import CUDA symbols from
+  `cubie.cuda_simsafe`.
+```
+
+Reason: the shift is not reset to the first sample of each window. It carries
+the previous window's mean after the initial sample. Metric modules also use
+the backend-neutral CUDA import. Evidence:
+`src/cubie/outputhandling/summarymetrics/std.py:103`,
+`src/cubie/outputhandling/summarymetrics/std.py:152`,
+`src/cubie/outputhandling/summarymetrics/mean_std.py:104`,
+`src/cubie/outputhandling/summarymetrics/mean_std.py:160`, and
+`src/cubie/outputhandling/summarymetrics/mean.py:16`.
+
+### SOD-046
+
+Locations: all ten regular instruction files listed in the matching inventory
+manifest.
+
+The 1,068-line corpus contains 94 em dashes, 184 semicolons, 99 colons, 36
+Markdown bold spans, and nine Markdown italic spans. Proposed normalization:
+
+* Replace all 94 em dashes with sentence boundaries or direct conjunctions.
+* Split every semicolon-joined clause. None of the 184 semicolons is required
+  by Markdown or an executable code block.
+* Remove 83 prose colons. Retain the ten `Parent:` metadata colons and six
+  inline-code colons in dictionary, type-annotation, and lambda syntax.
+* Remove all 45 emphasis spans. Preserve behavior-changing imperatives such as
+  `never call build directly` as unformatted sentences.
+* Replace framing such as "the odd one out", "algebraically locked together",
+  "the path is live, not disabled", "the expensive step", and "numerically
+  critical" with the factual behavior already stated beside it.
+
+The inventory records exact character counts and affected line numbers per
+file. No listed empty-framing phrase or false-drama staccato example occurs in
+this corpus.
+
+## Retained punctuation
+
+The scoped RST files contain 591 colon characters. All but the prose colon
+removed by SOD-001 are required reStructuredText directive, option, or role
+syntax. Examples include `.. autoclass::`, `:members:`, and `:doc:`. Removing
+them changes document semantics.
+
+The currently rendered source docstrings contain 137 colon characters.
+SOD-007, SOD-032, and SOD-033 remove every avoidable prose colon. The retained
+colons occur in
+reStructuredText roles, numpydoc `name : type` declarations, and literal
+dictionary examples such as ``{name: value}``. They carry syntax or type
+information.
+
+The three docstrings that would be exposed by SOD-036 and SOD-037 contain 12
+colon characters and one semicolon before rewriting. SOD-036 and SOD-037
+remove four prose colons and the semicolon. The remaining eight colons are
+numpydoc parameter type declarations in `load_cellml_model`.
+
+The 49 en dashes in scoped RST comprise 48 list separators and the
+`Newton–Krylov` compound. SOD-003, SOD-010, SOD-012, SOD-020, SOD-023, and
+SOD-024 remove all 49. The scoped RST corpus contains no semicolons. The one em
+dash is removed by SOD-004.
+
+No scoped RST or rendered target docstring contains the listed empty framing
+phrases or false-drama staccato examples. SOD-016, SOD-018, SOD-028, SOD-029,
+SOD-030, SOD-031, and SOD-036 remove the other detected readiness,
+convenience, automaticity, and efficiency framing. SOD-010 removes class and
+correctness framing from `SystemSizes`.
+
+The regular instruction corpus has its own punctuation accounting in SOD-046.
+Its 94 em dashes, 184 semicolons, 83 prose colons, and 45 emphasis spans are all
+proposed for removal. Sixteen colons remain because they encode parent
+metadata or inline code syntax.

--- a/docs/review/user_facing_inventory.md
+++ b/docs/review/user_facing_inventory.md
@@ -1,0 +1,319 @@
+# User-facing documentation review inventory
+
+## Coverage result
+
+The lane read 42 files and 6,973 lines. Every file below has status
+`read-complete`. Source comparisons used the current checkout. `CLEAN` means no
+specific factual contradiction or prohibited prose construction was found in
+this lane. It does not mean the file was executed.
+
+The lane then reread all 6,973 lines for meaning-level framing,
+qualification, hedging, emphasis, intensification, false drama, reader-role
+assignment, and high-bar colon or semicolon use. This second pass did not rely
+on the lexical-tell count below.
+
+| File | Lines | Freshness and completeness result | Proposal IDs |
+|---|---:|---|---|
+| `readme.md` | 125 | Backend and install description stale. Benchmark lacks a reproducibility record. Capability intensifiers and acknowledgement punctuation need revision. | UFR-001, UFR-002, UFR-003, UFR-S01, UFR-S02, UFR-C01 |
+| `infra/fleet/README.md` | 263 | Claims match current Fleet, workflow, dashboard, and IAM code. Dense punctuation, justification framing, and measured anecdotes remain. | UFR-031, UFR-S01, UFR-S02 |
+| `docs/Makefile` | 20 | Build syntax only. | CLEAN |
+| `docs/make.bat` | 35 | Build syntax only. | CLEAN |
+| `docs/source/conf.py` | 58 | Sphinx release is 0.0.4 while the package is 0.4.0. | UFR-004 |
+| `docs/source/_static/custom.css` | 5 | CSS declarations only. | CLEAN |
+| `docs/source/index.rst` | 26 | Former repository URL and wrong Reference Manual target. | UFR-005 |
+| `docs/source/getting_started.rst` | 139 | Opening contains framing. One-call compilation claim is false. | UFR-006, UFR-S01, UFR-S02, UFR-C01 |
+| `docs/source/examples/array_interpolation_example.py` | 147 | Stale class path and nonexistent compiled-function property. The module description contains an intensifier. | UFR-026, UFR-S01 |
+| `docs/source/examples/controller_step_analysis.py` | 888 | `OutputFunctions` is constructed with shifted, wrong positional arguments. The module and plotting docstrings contain intent and change-history framing. | UFR-027, UFR-S01 |
+| `docs/source/examples/cpu_gpu_driver_evaluator_comparison.py` | 212 | Current evaluator usage matches the checkout. The module docstring uses example framing. | UFR-S01 |
+| `docs/source/theory/cuda.rst` | 87 | Thread mapping, scaling, memory placement, on-chip storage, and TimeLogger claims are stale or unsupported. | UFR-022, UFR-S01, UFR-S02 |
+| `docs/source/theory/index.rst` | 16 | Entire opening is optionality framing. | UFR-S01 |
+| `docs/source/theory/jacobians.rst` | 79 | Describes the former SymPy compute pipeline instead of the current expression IR. Its opening describes the page instead of the mechanism. The finite-difference comparison uses unsupported qualitative judgments. | UFR-023, UFR-S01 |
+| `docs/source/theory/numerical_integration.rst` | 135 | Confuses Euler local and global error and gives a wrong Dormand-Prince stage count. Family descriptions contain subjective recommendations. | UFR-024, UFR-S01, UFR-S02 |
+| `docs/source/theory/solvers.rst` | 97 | Newton convergence, available preconditioners, and return-code packing are stale. Its opening describes the page instead of the mechanism. | UFR-025, UFR-S01, UFR-S02 |
+| `docs/source/tutorials/extracting_summaries.rst` | 138 | Metric inventory is current. Framing and punctuation need revision. | UFR-S01, UFR-S02 |
+| `docs/source/tutorials/first_sweep.rst` | 177 | Workflow is current. Framing and a false-drama conclusion need revision. | UFR-S01, UFR-S02 |
+| `docs/source/tutorials/index.rst` | 18 | Toctree matches the three tutorials. The introduction uses metaphorical and scale framing. | UFR-S01 |
+| `docs/source/tutorials/stiff_systems.rst` | 196 | Methods are current. Absolute and promotional solver descriptions need revision. | UFR-S01, UFR-S02 |
+| `docs/source/user_guide/batching.rst` | 97 | Grid-type and direct-array descriptions match current interfaces. The opening uses strength and page-description framing. | UFR-S01 |
+| `docs/source/user_guide/caching.rst` | 79 | Cache layer count, `cache` behavior, policy surface, and package invalidation are stale. | UFR-007, UFR-S02, UFR-C01 |
+| `docs/source/user_guide/cellml.rst` | 61 | CellML version and DAE caveats are wrong. | UFR-008, UFR-S02, UFR-C03 |
+| `docs/source/user_guide/choosing_algorithms.rst` | 244 | Omits Kvaerno3, Kvaerno5, and Gauss-Legendre order 8. Controller defaults are wrong. Subjective recommendations replace properties. | UFR-009, UFR-010, UFR-S01, UFR-S02, UFR-C04 |
+| `docs/source/user_guide/coming_from_matlab.rst` | 150 | `ode23s` mapping is wrong. Page-description and note framing need revision. Code semicolons are valid MATLAB syntax. | UFR-011, UFR-S01, UFR-S02 |
+| `docs/source/user_guide/coming_from_scipy.rst` | 156 | Direct Radau alias is omitted and one-call compile wording is false. The opening, batch heading, and note lead-in use framing. | UFR-006, UFR-011, UFR-S01, UFR-S02 |
+| `docs/source/user_guide/configuration.rst` | 213 | Group count, cache routing, `auto_memory`, kernel settings, and implicit-family controller statement are incomplete or wrong. The opening is document framing. | UFR-010, UFR-012, UFR-S01, UFR-S02, UFR-C01, UFR-C02 |
+| `docs/source/user_guide/drivers.rst` | 164 | Uses nonexistent `dt` driver key and omits uniform-spacing requirement. Opening is overframed. | UFR-013, UFR-S01, UFR-S02 |
+| `docs/source/user_guide/index.rst` | 28 | Toctree covers all current user-guide pages. The repository URL uses the former owner. | UFR-005 |
+| `docs/source/user_guide/memory.rst` | 54 | Allocation lifetime and stream-group concurrency claims are wrong. Cleanup and spill behavior are missing. The opening adds reader framing. | UFR-014, UFR-S01, UFR-S02, UFR-C02 |
+| `docs/source/user_guide/optional_arguments.rst` | 254 | Output selection default needs clarification. Definition prose is punctuation-heavy. Cache, memory, and DAE settings are incomplete. Reader-role, expertise, and default-quality framing needs revision. | UFR-015, UFR-S01, UFR-S02, UFR-C01, UFR-C02, UFR-C03 |
+| `docs/source/user_guide/results.rst` | 252 | Advertises rejected timing aliases and says observables save by default. Status vocabulary and device lifecycle are incomplete. Attribute, note, preference, and usefulness framing needs revision. | UFR-015, UFR-016, UFR-S01, UFR-S02, UFR-C05 |
+| `docs/source/user_guide/solving.rst` | 127 | Interface examples are current. Batch-performance framing and ASCII em dashes need revision. | UFR-S01, UFR-S02 |
+| `docs/source/user_guide/speed.rst` | 115 | Universal scaling, bottleneck, compile-time, buffer-placement, and precision claims are unsupported or stale. The logger-access lead-in assigns an action to the reader. | UFR-021, UFR-S01 |
+| `docs/source/user_guide/systems.rst` | 215 | Names nonexistent `GenericODE`, denies callable `user_functions`, and treats algebraic unknowns as invalid states. | UFR-017, UFR-S01, UFR-S02, UFR-C03 |
+| `docs/source/user_guide/timing.rst` | 344 | Timing model is otherwise detailed and current. `duration` is incorrectly marked required. Usefulness, reasonableness, and example framing need revision. | UFR-019, UFR-S01, UFR-S02 |
+| `docs/source/user_guide/troubleshooting.rst` | 88 | Newton instruction says tighter tolerances give more room. Status-specific diagnosis is missing. Advice and usefulness framing need revision. | UFR-020, UFR-S01, UFR-S02, UFR-C05 |
+| `docs/source/user_guide/userfunctions.rst` | 166 | Exposes internal parsing/codegen APIs, unpacks the wrong arity, and imports a backend directly. Case and tips framing need revision. | UFR-018, UFR-S01, UFR-S02 |
+| `src/cubie/writing_cuda_functions.md` | 44 | Stub and open questions do not provide binding factual instructions. | UFR-029 |
+| `tests/README.md` | 609 | Canonical claims conflict with the current suite. CUDA-check helper is absent. Contains AI-agent narrative. | UFR-028 |
+| `tests/integrated_numerical_tests/julia_reference/data/README.md` | 29 | Data inventory matches current named artifacts. Punctuation can be simplified. | UFR-030 |
+| `CHANGELOG.md` | 623 | Current through 0.4.0. No contradiction found within historical release context. Style review intentionally excluded by project policy. | CLEAN, historical exemption |
+
+## Punctuation receipt
+
+The scan counted punctuation characters, not only matching lines. The `---`
+column counts ASCII em-dash substitutes used inside prose words or clauses. It
+does not count RST heading underlines, Markdown rules, table rules, or source
+comments used as separators. The lexical-tell column is a narrow automated
+receipt. Manual findings are recorded under UFR-S01 and in the file inventory.
+
+Disposition codes are:
+
+- `K` keeps punctuation required by code, math, URLs, RST, CSS, Make, or a
+  literal mapping.
+- `S` rewrites prose under UFR-S01 or UFR-S02.
+- `R` replaces the containing section or file under a factual proposal.
+- `H` records historical changelog punctuation without proposing an edit.
+
+| File | `—` | prose `---` | `;` | `:` | lexical tells | Disposition |
+|---|---:|---:|---:|---:|---:|---|
+| `readme.md` | 3 | 0 | 1 | 27 | 0 | S, R, K for URLs |
+| `infra/fleet/README.md` | 7 | 0 | 18 | 35 | 1 | S, K for keys and URLs |
+| `docs/Makefile` | 0 | 0 | 0 | 4 | 0 | K |
+| `docs/make.bat` | 0 | 0 | 0 | 3 | 0 | K |
+| `docs/source/conf.py` | 0 | 0 | 0 | 16 | 0 | K |
+| `docs/source/_static/custom.css` | 0 | 0 | 3 | 5 | 0 | K |
+| `docs/source/index.rst` | 0 | 0 | 0 | 17 | 1 | R, K for RST and URL |
+| `docs/source/getting_started.rst` | 0 | 0 | 1 | 55 | 0 | S, R, K |
+| `docs/source/examples/array_interpolation_example.py` | 0 | 0 | 0 | 39 | 0 | K, R for stale lines, S |
+| `docs/source/examples/controller_step_analysis.py` | 0 | 0 | 0 | 224 | 0 | K, R for stale call, S |
+| `docs/source/examples/cpu_gpu_driver_evaluator_comparison.py` | 0 | 0 | 0 | 48 | 0 | K, S |
+| `docs/source/theory/cuda.rst` | 0 | 0 | 1 | 11 | 1 | R, S, K |
+| `docs/source/theory/index.rst` | 0 | 0 | 0 | 6 | 0 | S, K |
+| `docs/source/theory/jacobians.rst` | 0 | 0 | 0 | 48 | 0 | R, S, K |
+| `docs/source/theory/numerical_integration.rst` | 0 | 0 | 2 | 78 | 0 | R, S, K for math |
+| `docs/source/theory/solvers.rst` | 0 | 2 | 1 | 69 | 1 | R, S, K for math |
+| `docs/source/tutorials/extracting_summaries.rst` | 1 | 0 | 3 | 47 | 1 | S, K |
+| `docs/source/tutorials/first_sweep.rst` | 0 | 0 | 3 | 66 | 1 | S, K |
+| `docs/source/tutorials/index.rst` | 0 | 0 | 0 | 11 | 0 | S, K |
+| `docs/source/tutorials/stiff_systems.rst` | 0 | 0 | 4 | 53 | 2 | S, K |
+| `docs/source/user_guide/batching.rst` | 0 | 0 | 0 | 29 | 0 | S, K |
+| `docs/source/user_guide/caching.rst` | 1 | 1 | 1 | 13 | 0 | R, K |
+| `docs/source/user_guide/cellml.rst` | 2 | 0 | 1 | 7 | 0 | R, S, K |
+| `docs/source/user_guide/choosing_algorithms.rst` | 0 | 0 | 19 | 49 | 0 | R, S, K |
+| `docs/source/user_guide/coming_from_matlab.rst` | 2 | 0 | 17 | 52 | 0 | S, K for MATLAB |
+| `docs/source/user_guide/coming_from_scipy.rst` | 7 | 0 | 6 | 45 | 0 | R, S, K |
+| `docs/source/user_guide/configuration.rst` | 2 | 0 | 8 | 84 | 0 | R, S, K |
+| `docs/source/user_guide/drivers.rst` | 1 | 0 | 1 | 43 | 3 | R, S, K |
+| `docs/source/user_guide/index.rst` | 0 | 0 | 0 | 7 | 0 | R, K |
+| `docs/source/user_guide/memory.rst` | 0 | 1 | 0 | 9 | 0 | R, S, K |
+| `docs/source/user_guide/optional_arguments.rst` | 26 | 0 | 11 | 64 | 0 | S, R, K |
+| `docs/source/user_guide/results.rst` | 8 | 0 | 4 | 51 | 0 | S, R, K |
+| `docs/source/user_guide/solving.rst` | 0 | 1 | 2 | 66 | 0 | S, K |
+| `docs/source/user_guide/speed.rst` | 0 | 0 | 0 | 25 | 1 | R, K |
+| `docs/source/user_guide/systems.rst` | 1 | 0 | 4 | 61 | 0 | R, S, K |
+| `docs/source/user_guide/timing.rst` | 0 | 0 | 1 | 88 | 0 | R, S, K |
+| `docs/source/user_guide/troubleshooting.rst` | 0 | 0 | 3 | 19 | 0 | R, S, K |
+| `docs/source/user_guide/userfunctions.rst` | 2 | 0 | 2 | 43 | 0 | R, S, K |
+| `src/cubie/writing_cuda_functions.md` | 5 | 0 | 1 | 5 | 0 | R |
+| `tests/README.md` | 26 | 0 | 4 | 66 | 2 | R |
+| `tests/integrated_numerical_tests/julia_reference/data/README.md` | 3 | 0 | 1 | 7 | 0 | R, K |
+| `CHANGELOG.md` | 0 | 0 | 19 | 591 | 0 | H |
+
+### Prose dash and semicolon locations
+
+Every prose occurrence below is assigned to `S` or a containing `R` proposal.
+Occurrences omitted from this list are code, math, markup, URL, CSS, Make, or
+historical syntax assigned `K` or `H` in the receipt.
+
+- `readme.md`: em dash 101, 106, 112; semicolon 90.
+- `infra/fleet/README.md`: em dash 11 (twice), 34, 82, 99, 101, 149;
+  semicolon 21, 33, 70, 115, 116, 117, 128, 132, 142, 170, 173, 203, 221,
+  226, 231, 243, 261.
+- `docs/source/getting_started.rst`: semicolon 26.
+- `docs/source/theory/cuda.rst`: semicolon 23.
+- `docs/source/theory/numerical_integration.rst`: semicolon 33, 64.
+- `docs/source/theory/solvers.rst`: ASCII em dash 19, 53; semicolon 15.
+- `docs/source/tutorials/extracting_summaries.rst`: em dash 91; semicolon 6,
+  71, 134.
+- `docs/source/tutorials/first_sweep.rst`: semicolon 66, 69, 103.
+- `docs/source/tutorials/stiff_systems.rst`: semicolon 117, 119, 188, 195.
+- `docs/source/user_guide/caching.rst`: em dash 78; ASCII em dash 39;
+  semicolon 59.
+- `docs/source/user_guide/cellml.rst`: em dash 24, 50; semicolon 60.
+- `docs/source/user_guide/choosing_algorithms.rst`: semicolon 6, 21, 24, 87,
+  91, 100, 123, 127, 131, 146, 150, 165, 188, 192, 200, 208, 212, 222, 227.
+- `docs/source/user_guide/coming_from_matlab.rst`: prose em dash 58, 137;
+  prose semicolon 46, 50, 56, 69, 107. Semicolons 15-18 and 83-87 are MATLAB
+  code and remain `K`.
+- `docs/source/user_guide/coming_from_scipy.rst`: em dash 36, 69, 73, 75,
+  123, 124, 155; semicolon 6, 14, 61, 66, 89, 116.
+- `docs/source/user_guide/configuration.rst`: em dash 122, 197; semicolon 41,
+  45, 50, 82, 86, 94, 132, 205.
+- `docs/source/user_guide/drivers.rst`: em dash 141; semicolon 142.
+- `docs/source/user_guide/memory.rst`: ASCII em dash 42.
+- `docs/source/user_guide/optional_arguments.rst`: em dash 8, 24, 32, 43,
+  52, 77, 84, 91, 100, 106, 111, 130, 141, 150, 156, 160, 170, 177, 185,
+  191, 197, 206, 222, 226, 230, 250; semicolon 26, 34, 49, 54, 113, 167,
+  179, 180, 187, 192, 238.
+- `docs/source/user_guide/results.rst`: em dash 18, 42, 58, 59, 71, 84, 183,
+  209; ASCII em dash 49-51; semicolon 31, 70, 75, 86.
+- `docs/source/user_guide/solving.rst`: ASCII em dash 47, 125-127;
+  semicolon 98, 111.
+- `docs/source/user_guide/systems.rst`: em dash 177; semicolon 51, 122, 171,
+  181.
+- `docs/source/user_guide/timing.rst`: semicolon 237.
+- `docs/source/user_guide/troubleshooting.rst`: semicolon 32, 68, 85.
+- `docs/source/user_guide/userfunctions.rst`: em dash 58, 104; semicolon 149,
+  165.
+- `src/cubie/writing_cuda_functions.md`: em dash 6, 12, 24, 43, 44;
+  semicolon 27.
+- `tests/README.md`: all 26 em dashes and prose semicolons 101, 114, 487,
+  496 are covered by the whole-file replacement UFR-028.
+- `tests/integrated_numerical_tests/julia_reference/data/README.md`: em dash 7,
+  19, 22; semicolon 24.
+
+### Semantic prose locations
+
+The second pass read every line without relying on lexical matches. `S` below
+marks framing, qualifying, hedging, emphasis, intensification, false drama,
+reader-role assignment, subjective recommendation, anecdote, or change-history
+language. Exact replacements are under UFR-S01. A containing factual
+replacement is marked `R` when it removes the same construction.
+
+- `readme.md`: 11-22 R, 34-40 S, 49-63 R, 89-91 R, 125 R.
+- `infra/fleet/README.md`: 8-28 S, 93-102 S, 113-117 S, 145-176 S,
+  202-245 S.
+- `docs/source/index.rst`: 4-8 R.
+- `docs/source/getting_started.rst`: 4-6 S, 18-28 S, 33-36 S, 80-84 R,
+  62-64 S, 102-105 S, 128-133 S.
+- `docs/source/examples/array_interpolation_example.py`: 1-8 S and R,
+  110-112 R.
+- `docs/source/examples/controller_step_analysis.py`: 1-12 S, 298-324 R,
+  679-683 S.
+- `docs/source/examples/cpu_gpu_driver_evaluator_comparison.py`: 1-13 S.
+- `docs/source/theory/cuda.rst`: 4-6 S, 11-87 R.
+- `docs/source/theory/index.rst`: 4-7 S.
+- `docs/source/theory/jacobians.rst`: 4-6 S, 22-65 R.
+- `docs/source/theory/numerical_integration.rst`: 4-6 S, 11-22 S and R,
+  60-65 R, 77-78 S, 92-113 S, 131-135 S.
+- `docs/source/theory/solvers.rst`: 4-6 S, 17-19 S, 28-97 R.
+- `docs/source/tutorials/extracting_summaries.rst`: 4-9 S, 14-15 S,
+  63-68 S, 77-80 S, 89-98 S.
+- `docs/source/tutorials/first_sweep.rst`: 4-10 S, 15-21 S, 41-48 S,
+  68-70 S, 84-87 S, 103-111 S, 128 S, 166-167 S.
+- `docs/source/tutorials/index.rst`: 4-11 S.
+- `docs/source/tutorials/stiff_systems.rst`: 4-12 S, 39-42 S, 61-65 S,
+  97-106 S, 152-167 S, 185-196 S.
+- `docs/source/user_guide/batching.rst`: 4-5 S.
+- `docs/source/user_guide/caching.rst`: 4-79 R.
+- `docs/source/user_guide/cellml.rst`: 22-60 R.
+- `docs/source/user_guide/choosing_algorithms.rst`: 4-7 S, 17-35 R and S,
+  84-100 R and S, 143-173 R and S, 203-233 R and S.
+- `docs/source/user_guide/coming_from_matlab.rst`: 4-7 S, 40-58 S,
+  63-74 R, 136-149 S.
+- `docs/source/user_guide/coming_from_scipy.rst`: 4-8 S, 82-95 R,
+  97-102 S, 122-127 R, 145-146 S.
+- `docs/source/user_guide/configuration.rst`: 4-9 S, 20-213 R and S.
+- `docs/source/user_guide/drivers.rst`: 4-12 S, 74-87 S, 120-127 R and S,
+  135-152 S.
+- `docs/source/user_guide/index.rst`: 4-6 R.
+- `docs/source/user_guide/memory.rst`: 4-6 S, 11-16 R, 40-54 R and S.
+- `docs/source/user_guide/optional_arguments.rst`: 4-20 S, 69-73 S,
+  91-94 S, 177-201 S, 216-217 S, 219-251 R and S.
+- `docs/source/user_guide/results.rst`: 11 S, 47 S, 68-78 S, 121-131 R
+  and S, 179-184 S, 186-190 R, 208-210 S.
+- `docs/source/user_guide/solving.rst`: 4-13 S, 47-49 S, 74-78 S,
+  100-106 S, 117-120 S, 125-127 S.
+- `docs/source/user_guide/speed.rst`: 1-57 R, 78 S, 85-115 R.
+- `docs/source/user_guide/systems.rst`: 4-16 R, 100-151 S,
+  155-169 R, 176-182 S, 187-207 R.
+- `docs/source/user_guide/timing.rst`: 111-119 S, 245-258 R,
+  278-280 S, 311-315 S.
+- `docs/source/user_guide/troubleshooting.rst`: 21-35 R, 44-48 S,
+  64-69 S.
+- `docs/source/user_guide/userfunctions.rst`: 4-11 S, 13-150 R,
+  159-166 S.
+- `src/cubie/writing_cuda_functions.md`: 1-44 R.
+- `tests/README.md`: 1-609 R.
+- `tests/integrated_numerical_tests/julia_reference/data/README.md`: 1-29 R.
+- `CHANGELOG.md`: historical exemption. No style rewrite is proposed.
+
+Files absent from this list contain only build syntax, configuration syntax,
+stylesheet declarations, navigation structure, or code with no prose finding.
+
+### Prose colon locations requiring rewrite
+
+The following colons support framing or fragments rather than a required
+mapping, signature, directive, formula, table field, or complete list
+introduction. Their containing UFR-S01, UFR-S02, or factual replacement removes
+them.
+
+- `readme.md`: 125.
+- `docs/source/getting_started.rst`: 5, 18.
+- `docs/source/theory/numerical_integration.rst`: 20.
+- `docs/source/tutorials/extracting_summaries.rst`: 15, 80, 97.
+- `docs/source/tutorials/first_sweep.rst`: 18, 21, 48, 87, 166.
+- `docs/source/tutorials/stiff_systems.rst`: 154.
+- `docs/source/user_guide/caching.rst`: 4.
+- `docs/source/user_guide/coming_from_matlab.rst`: 4, 137.
+- `docs/source/user_guide/coming_from_scipy.rst`: 8 and the heading at 97.
+- `docs/source/user_guide/configuration.rst`: 5.
+- `docs/source/user_guide/drivers.rst`: 120.
+- `docs/source/user_guide/optional_arguments.rst`: 4, 69, 75, 98, 128,
+  148, 183, 195.
+- `docs/source/user_guide/results.rst`: 11, 47, 72.
+- `docs/source/user_guide/timing.rst`: 56, 79, 85, 314.
+- `docs/source/user_guide/userfunctions.rst`: 5, 20, 61, 108.
+- `src/cubie/writing_cuda_functions.md`: 3, 18, 26, 29, 34.
+- `tests/README.md`: all prose colons are covered by UFR-028.
+
+All other colon characters in the punctuation table are retained for code,
+math, URLs, RST structure, literal mappings, or complete introductions to
+lists, tables, examples, and formulas.
+
+## Completeness and freshness inventory
+
+| Missing or fragile topic | Current coverage | Required action |
+|---|---|---|
+| CUDA backend selection and environment variables | Split across README, getting started, troubleshooting, and source docstrings. | UFR-C01 |
+| Three cache layers and cache policy | Current cache page describes two layers and one overloaded argument. | UFR-007, UFR-C01 |
+| Managed allocation lifetime, spill, close, and context managers | Current memory page describes per-call allocation and release. | UFR-014, UFR-C02 |
+| DAE structural workflow | Capability bullet exists. No end-to-end guide covers simplification controls or mass matrices. | UFR-C03 |
+| Algorithm registry freshness | Narrative page already omits three registered methods. | UFR-009, UFR-C04 |
+| Controller defaults | Narrative statements generalize by family and are already false for DIRK. | UFR-010, UFR-C04 |
+| Driver sample timing contract | Current guide uses `dt` and omits uniform spacing. | UFR-013 |
+| Result bit flags and status diagnosis | The user-facing corpus documents two of eight nonzero failure flags. Six are missing (`src/cubie/result_codes.py:51-58`; `docs/source/user_guide/results.rst:220-228`). | UFR-016, UFR-C05 |
+| Device-result ownership and stream ordering | Mentioned in results but no complete lifecycle workflow. | UFR-C05 |
+| Reproducible performance evidence | README contains machine numbers without a repository measurement record. | UFR-003 |
+| Test policy source of truth | `tests/README.md` conflicts with the suite and root instructions. | UFR-028 |
+
+## CLAUDE.md duplicate inventory
+
+These paths were inventoried as duplicate instruction documents and were not
+counted again in the 6,973-line total.
+
+The following 19 files are symbolic links to the adjacent or root `AGENTS.md`:
+
+- `CLAUDE.md`
+- `src/cubie/CLAUDE.md`
+- `src/cubie/batchsolving/CLAUDE.md`
+- `src/cubie/batchsolving/arrays/CLAUDE.md`
+- `src/cubie/gui/CLAUDE.md`
+- `src/cubie/integrators/CLAUDE.md`
+- `src/cubie/integrators/algorithms/CLAUDE.md`
+- `src/cubie/integrators/loops/CLAUDE.md`
+- `src/cubie/integrators/matrix_free_solvers/CLAUDE.md`
+- `src/cubie/integrators/step_control/CLAUDE.md`
+- `src/cubie/memory/CLAUDE.md`
+- `src/cubie/odesystems/CLAUDE.md`
+- `src/cubie/odesystems/symbolic/CLAUDE.md`
+- `src/cubie/odesystems/symbolic/codegen/CLAUDE.md`
+- `src/cubie/odesystems/symbolic/parsing/CLAUDE.md`
+- `src/cubie/odesystems/symbolic/structural/CLAUDE.md`
+- `src/cubie/outputhandling/CLAUDE.md`
+- `src/cubie/outputhandling/summarymetrics/CLAUDE.md`
+- `src/cubie/vendored/CLAUDE.md`
+
+`src/cubie/odesystems/symbolic/engine/CLAUDE.md` is a regular file, not a
+symbolic link, and its SHA-256 differs from the adjacent `AGENTS.md`. It cannot
+be treated as a duplicate without a separate comparison. This is a coverage
+gap outside the 42-file user-facing lane and was reported to the root reviewer.

--- a/docs/review/user_facing_rewrite_proposals.md
+++ b/docs/review/user_facing_rewrite_proposals.md
@@ -1,0 +1,1150 @@
+# User-facing documentation rewrite proposals
+
+## Scope and method
+
+This ledger covers 42 files and 6,973 lines. It includes the repository
+README, the Sphinx narrative pages and examples assigned to this lane, the
+Fleet runbook, the CUDA-writing guide, the test guide, the Julia-reference
+data README, and the changelog. Every line was read. Factual claims were
+checked against the current source, tests, package metadata, workflow files,
+and infrastructure code. The changelog was checked only for release-history
+contradictions because project policy forbids editing it.
+
+Every line was reread in a separate semantic pass for framing, qualification,
+hedging, emphasis, intensification, false drama, reader-role assignment, and
+high-bar colon or semicolon use. Syntax punctuation and changelog history were
+retained.
+
+The proposals do not edit any source document. Locations refer to the current
+working tree on 2026-08-06.
+
+## Factual and completeness rewrites
+
+### UFR-001: Replace the README implementation summary
+
+**Location:** `readme.md:11-22`
+
+**Proposed text:**
+
+> CuBIE JIT-compiles CUDA kernels for batches of independent ODE and DAE
+> initial-value problems. It provides `solve_ivp` and `Solver` interfaces for
+> parameter and initial-condition sweeps. The default compiler backend is
+> numba-cuda-mlir. The deprecated numba-cuda backend supports Python 3.10 and
+> the CUDA simulator.
+>
+> CuBIE generates system-specific right-hand-side, Jacobian-vector product,
+> residual, and preconditioner functions. Implicit algorithms use the generated
+> operators in matrix-free linear and nonlinear solves.
+
+**Reason:** The current paragraph names numba-cuda as the sole backend and
+mixes a machine-specific speed claim into the product definition. Backend
+resolution prefers MLIR.
+
+**Evidence:** `src/cubie/cuda_backend.py:1-17`,
+`src/cubie/cuda_backend.py:42-62`, `pyproject.toml:45-67`.
+
+### UFR-002: Replace the README installation option count
+
+**Location:** `readme.md:49-63`
+
+**Proposed text:**
+
+> Select one CUDA backend extra. `mlir-cuda12` and `mlir-cuda13` install the
+> default MLIR backend with toolkit and CuPy wheels. `cuda12` and `cuda13`
+> install the deprecated numba-cuda backend with toolkit and CuPy wheels. Use
+> `mlir` or `cuda` when a compatible system CUDA toolkit is already installed.
+> The MLIR backend requires Python 3.11 or later. Python 3.10 and the CUDA
+> simulator require numba-cuda.
+
+**Reason:** Six extras exist, not four. The bare system-toolkit extras are
+missing from the page.
+
+**Evidence:** `pyproject.toml:45-67`, `src/cubie/cuda_backend.py:45-50`.
+
+### UFR-003: Make the README benchmark reproducible or remove it
+
+**Location:** `readme.md:11-13`, `readme.md:89-91`, `readme.md:125`
+
+**Proposed text:**
+
+> The example constructs 1,048,576 combinations of initial values and
+> parameters. Compilation and execution time depend on the selected backend,
+> algorithm, output configuration, GPU, and cache state.
+
+Remove the `~10000x` headline and footnote unless the repository also records
+the benchmark command, CuBIE revision, backend and package versions, CPU
+parallelism, warm-up policy, cache state, output equivalence, tolerances, and
+raw results.
+
+**Reason:** The reported timings cannot be reproduced from the repository and
+are presented as a general property of CuBIE.
+
+### UFR-004: Synchronize the Sphinx release metadata
+
+**Location:** `docs/source/conf.py:9-12`
+
+**Proposed code:**
+
+```python
+from importlib.metadata import version
+
+project = "cubie"
+copyright = "2025-2026, Chris Cameron"
+author = "Chris Cameron"
+release = version("cubie")
+```
+
+**Reason:** Sphinx reports 0.0.4 while package metadata and the changelog report
+0.4.0.
+
+**Evidence:** `pyproject.toml:13-21`, `CHANGELOG.md:3`.
+
+### UFR-005: Correct the documentation landing page
+
+**Location:** `docs/source/index.rst:4-8`,
+`docs/source/user_guide/index.rst:4-6`
+
+**Proposed text:**
+
+> CuBIE integrates batches of initial-value problems on NVIDIA GPUs. Source
+> code is at `github.com/cubiepy/cubie
+> <https://github.com/cubiepy/cubie>`__. :doc:`getting_started` documents
+> installation and the first solve. The :doc:`User Guide <user_guide/index>`
+> documents workflows. The :doc:`API Reference <API_reference/index>`
+> documents functions and classes.
+
+Use the source-code sentence and repository URL in the user-guide index.
+Retain its existing toctree.
+
+**Reason:** Both indexes point to the former repository owner. The landing
+page's Reference Manual link also points back to the user guide.
+
+**Evidence:** `git remote -v` reports `cubiepy/cubie`; the toctree at
+`docs/source/index.rst:14-19` contains the separate API reference.
+
+### UFR-006: Correct the one-call compilation description
+
+**Location:** `docs/source/getting_started.rst:80-84`,
+`docs/source/user_guide/coming_from_scipy.rst:122-127`
+
+**Proposed text:**
+
+> `solve_ivp` constructs a `Solver` for each call. Reuse a `Solver` to retain
+> the in-process compiled objects and managed allocations between solves. The
+> disk cache reuses a compiled kernel across separate solver instances and
+> Python sessions when the cache identity matches.
+
+**Reason:** `solve_ivp` reconstructs the object graph, but a compatible disk
+cache can avoid recompilation. “Builds and compiles on every call” is false.
+
+**Evidence:** `src/cubie/batchsolving/solver.py:215-244`,
+`src/cubie/cubie_cache.py:680-748`.
+
+### UFR-007: Replace the cache page
+
+**Location:** `docs/source/user_guide/caching.rst:4-79`
+
+**Proposed structure and text:**
+
+> CuBIE has three on-disk cache layers under one cache root. They store
+> generated source, CellML parse results, and compiled kernels. The default
+> root is `<cwd>/generated`. Set `CUBIE_CACHE_DIR` before importing CuBIE or
+> call `set_cache_root` to change the shared root.
+>
+> `Solver(cache=True)` enables compiled-kernel persistence. `cache=False`
+> disables compiled-kernel persistence for that solver. It does not disable
+> generated-source or CellML caches. `cache="flush_on_change"` selects the
+> flush-on-change policy. Any other string or `Path` selects a compiled-kernel
+> cache directory.
+>
+> The loose policy keywords are `cache_enabled`, `cache_mode`,
+> `max_cache_entries`, and `cache_dir`. `cache_mode` accepts `"hash"` and
+> `"flush_on_change"`.
+>
+> Package source changes are part of the compiled-kernel index key. Compatible
+> cache entries are invalidated when CuBIE package source changes.
+
+**Reason:** The current page says there are two layers, says `cache=False`
+disables code generation and forces recompilation, omits the CellML layer and
+four policy keywords, and says package-code changes are not keyed. Each claim
+contradicts the cache implementation.
+
+**Evidence:** `src/cubie/cache_root.py:34-50`,
+`src/cubie/cache_root.py:67-75`, `src/cubie/cubie_cache.py:135-145`,
+`src/cubie/cubie_cache.py:680-719`, `src/cubie/cubie_cache.py:740-747`,
+`src/cubie/cubie_cache.py:548-565`.
+
+### UFR-008: Correct CellML version and DAE support
+
+**Location:** `docs/source/user_guide/cellml.rst:52-61`
+
+**Proposed text:**
+
+> CuBIE accepts valid CellML 1.0 and 1.1 files. CellML 2.0 is not supported.
+> The loader preserves differential equations and algebraic constraints.
+> DAE-shaped symbolic input is routed through structural simplification before
+> code generation.
+
+**Reason:** The current caveat says only ODE-based models are supported and
+hedges about CellML 2.0. The loader has an explicit 1.0/1.1 contract and the
+parser routes algebraic constraints through structural simplification.
+
+**Evidence:** `src/cubie/odesystems/symbolic/parsing/cellml.py:195-204`,
+`src/cubie/odesystems/symbolic/parsing/parser.py:651-658`.
+
+### UFR-009: Add omitted algorithms and fix adaptive DIRK claims
+
+**Location:** `docs/source/user_guide/choosing_algorithms.rst:108-150`
+
+**Proposed additions:**
+
+| Name | Order | Adaptive | Notes |
+|---|---:|:---:|---|
+| `kvaerno3` | 3 | Yes | Four-stage ESDIRK with an embedded estimate. |
+| `kvaerno5` | 5 | Yes | Seven-stage ESDIRK with an embedded estimate. |
+| `firk_gauss_legendre_4` | 8 | No | Four-stage Gauss-Legendre FIRK. |
+
+Replace “the only adaptive DIRK tableau” for `l_stable_sdirk_4` with
+“Five-stage adaptive SDIRK.”
+
+**Evidence:** `src/cubie/integrators/algorithms/generic_dirk_tableaus.py:156-193`,
+`src/cubie/integrators/algorithms/generic_dirk_tableaus.py:203-285`,
+`src/cubie/integrators/algorithms/generic_dirk_tableaus.py:429-438`,
+`src/cubie/integrators/algorithms/generic_firk_tableaus.py:157-196`,
+`src/cubie/integrators/algorithms/generic_firk_tableaus.py:219-224`.
+
+### UFR-010: Correct controller defaults
+
+**Location:** `docs/source/user_guide/choosing_algorithms.rst:225-233`,
+`docs/source/user_guide/configuration.rst:194-201`
+
+**Proposed text:**
+
+> Each algorithm supplies its own controller defaults. Adaptive DIRK tableaus
+> use the PI controller. Algorithms without an error estimate use fixed-step
+> control. Algorithm registrations define the controller defaults for every
+> family.
+
+**Reason:** The pages state that implicit families use Gustafsson. Adaptive
+DIRK explicitly defaults to PI.
+
+**Evidence:** `src/cubie/integrators/algorithms/generic_dirk.py:81-93`.
+
+### UFR-011: Correct MATLAB and SciPy method mappings
+
+**Location:** `docs/source/user_guide/coming_from_matlab.rst:63-72`,
+`docs/source/user_guide/coming_from_scipy.rst:82-92`
+
+**Proposed rows:**
+
+| Source method | CuBIE method |
+|---|---|
+| MATLAB `ode23s` | `"ode23s"` |
+| MATLAB `ode15s` | No direct equivalent. |
+| SciPy `Radau` | `"radau"` |
+| SciPy `BDF`, `LSODA` | No direct equivalent. |
+
+**Evidence:**
+`src/cubie/integrators/algorithms/generic_rosenbrockw_tableaus.py:416-424`,
+`src/cubie/integrators/algorithms/generic_firk_tableaus.py:219-224`.
+
+### UFR-012: Complete the configuration index
+
+**Location:** `docs/source/user_guide/configuration.rst:4-9`,
+`docs/source/user_guide/configuration.rst:63-95`,
+`docs/source/user_guide/configuration.rst:175-184`
+
+**Proposed changes:**
+
+- Replace “six underlying settings groups” with “seven loose-keyword groups.”
+- Add `auto_memory` with default `True` to `Solver.__init__`.
+- Add cache policy keys `cache_enabled`, `cache_mode`,
+  `max_cache_entries`, and `cache_dir` to the Cache group.
+- State that only `"flush_on_change"` is a cache-mode spelling. Other strings
+  select a path.
+- List every `ALL_KERNEL_PARAMETERS` entry in the Kernel group rather than only
+  `max_registers`.
+
+**Reason:** `Solver` routes output, memory, step-control, algorithm, loop,
+cache, and kernel keyword sets. The explicit `auto_memory` argument and most
+cache policy settings are absent.
+
+**Evidence:** `src/cubie/batchsolving/solver.py:420-433`,
+`src/cubie/batchsolving/solver.py:459-513`,
+`src/cubie/cubie_cache.py:135-145`,
+`src/cubie/cubie_cache.py:740-747`.
+
+### UFR-013: Correct sampled-driver timing keys
+
+**Location:** `docs/source/user_guide/drivers.rst:120-127`
+
+**Proposed text:**
+
+> Supply sample timing with either a one-dimensional `"time"` array or a
+> scalar `"driver_sample_period"`. `"t0"` is optional with
+> `"driver_sample_period"` and defaults to zero. A `"time"` array must be
+> strictly increasing and uniformly spaced.
+
+**Reason:** `"dt"` is not a recognized driver key and uniform spacing is not
+documented.
+
+**Evidence:** `src/cubie/array_interpolator.py:151-156`,
+`src/cubie/array_interpolator.py:365-425`.
+
+### UFR-014: Correct memory lifetime and stream-group behavior
+
+**Location:** `docs/source/user_guide/memory.rst:11-16`,
+`docs/source/user_guide/memory.rst:40-54`
+
+**Proposed text:**
+
+> CuBIE allocates device memory through CuPy. Managed allocations remain
+> registered with a live solver and are released when the owner closes or is
+> collected. Host output backing becomes eligible for reuse after its prior
+> result owner is collected.
+>
+> A solve that does not fit its memory budget is divided along the run axis.
+> Its chunks are submitted in order on the solver's stream. Stream groups
+> coordinate the memory shares and CUDA streams of solver instances. They do
+> not run chunks from one solve concurrently.
+
+**Reason:** The page says every solve allocates and frees its device arrays and
+that stream groups run multiple chunks concurrently. The object lifecycle and
+kernel loop contradict both statements.
+
+**Evidence:** `src/cubie/memory/mem_manager.py:1128-1177`,
+`src/cubie/batchsolving/arrays/BaseArrayManager.py:916-946`,
+`src/cubie/batchsolving/BatchSolverKernel.py:731-803`.
+
+### UFR-015: Correct output defaults and legacy timing names
+
+**Location:** `docs/source/user_guide/results.rst:121-128`,
+`docs/source/user_guide/results.rst:186-190`,
+`docs/source/user_guide/optional_arguments.rst:222-239`
+
+**Proposed text:**
+
+> `save_every` controls time-domain snapshots. `summarise_every` controls
+> summary windows. `sample_summaries_every` controls sampling within a summary
+> window. `dt_save`, `dt_summarise`, and `dt_update_summaries` are rejected
+> legacy names.
+>
+> `output_types` defaults to `["state"]`. State and observable selection lists
+> default to all indices. An output is produced when its output type is active.
+> Add `"observables"` to record observables.
+
+**Reason:** The page advertises rejected legacy aliases and says observables
+are saved by default.
+
+**Evidence:** `src/cubie/batchsolving/solver.py:117-119`,
+`src/cubie/batchsolving/solver.py:192-212`,
+`src/cubie/outputhandling/output_functions.py:158-184`,
+`src/cubie/outputhandling/output_config.py:120-151`,
+`src/cubie/outputhandling/output_config.py:299-305`.
+
+### UFR-016: Document the complete result status vocabulary
+
+**Location:** `docs/source/user_guide/results.rst:205-230`
+
+**Proposed addition:**
+
+> `status_codes` is an `int32` bit field. `status_messages` maps each failed run
+> index to the names of all set flags. The nonzero flags are
+> `MAX_NEWTON_ITERATIONS_EXCEEDED`, `MAX_LINEAR_ITERATIONS_EXCEEDED`,
+> `STEP_TOO_SMALL`, `DT_EFF_EFFECTIVELY_ZERO`, `MAX_LOOP_ITERS_EXCEEDED`,
+> `STAGNATION`, `BICGSTAB_BREAKDOWN`, and `NEWTON_DIVERGENCE`.
+
+**Evidence:** `src/cubie/result_codes.py:22-58`,
+`src/cubie/result_codes.py:61-88`,
+`src/cubie/batchsolving/solveresult.py:754-772`.
+
+### UFR-017: Correct system terminology and callable support
+
+**Location:** `docs/source/user_guide/systems.rst:4-16`,
+`docs/source/user_guide/systems.rst:155-169`,
+`docs/source/user_guide/systems.rst:187-207`
+
+**Proposed text:**
+
+> `create_ODE_system` returns a `SymbolicODE`. `BaseODE` is its abstract
+> interface. There is no `GenericODE` class.
+>
+> `user_functions` and `user_function_derivatives` work with string and Python
+> callable system definitions. CuBIE inlines non-device callables that evaluate
+> on symbolic arguments. Device functions remain symbolic calls in generated
+> code.
+>
+> Explicit ODE states require derivatives. Symbolic systems accept algebraic
+> unknowns and implicit equations. Structural simplification produces a mass
+> matrix when the reduced system requires one.
+
+**Evidence:** `src/cubie/odesystems/__init__.py:18-32`,
+`src/cubie/odesystems/symbolic/parsing/function_parser.py:38-75`,
+`src/cubie/odesystems/symbolic/symbolicODE.py:102-119`,
+`src/cubie/odesystems/symbolic/symbolicODE.py:160-170`.
+
+### UFR-018: Replace internal user-function examples with public API
+
+**Location:** `docs/source/user_guide/userfunctions.rst:13-106`,
+`docs/source/user_guide/userfunctions.rst:116-150`
+
+**Proposed changes:**
+
+- Build examples with `create_ODE_system`, not the internal `parse_input` and
+  code-generation functions.
+- Import `cuda` with `from cubie.cuda_simsafe import cuda` so examples use the
+  resolved backend.
+- Remove five-value `parse_input` unpacking. The internal function currently
+  returns six values.
+- Keep the public statement that derivative helpers are needed by methods that
+  generate Jacobian terms.
+
+**Replacement example:**
+
+```python
+from cubie import create_ODE_system
+from cubie.cuda_simsafe import cuda
+
+
+@cuda.jit(device=True)
+def myfunc(a, b):
+    return a * b
+
+
+@cuda.jit(device=True)
+def myfunc_grad(a, b, index):
+    if index == 0:
+        return b
+    if index == 1:
+        return a
+    return 0.0
+
+
+system = create_ODE_system(
+    ["dx = myfunc(x, y)", "dy = x"],
+    states={"x": 1.0, "y": 0.0},
+    user_functions={"myfunc": myfunc},
+    user_function_derivatives={"myfunc": myfunc_grad},
+)
+```
+
+**Evidence:** `src/cubie/odesystems/symbolic/parsing/parser.py:953-972`,
+`src/cubie/odesystems/symbolic/symbolicODE.py:102-119`,
+`src/cubie/cuda_simsafe.py:1-17`.
+
+### UFR-019: Correct the duration default
+
+**Location:** `docs/source/user_guide/timing.rst:245-258`
+
+**Proposed text:**
+
+> `duration` defaults to `1.0` and must be non-negative.
+
+**Evidence:** `src/cubie/batchsolving/BatchSolverKernel.py:130`,
+`src/cubie/_utils.py:442-458`.
+
+### UFR-020: Correct the Newton-convergence troubleshooting instruction
+
+**Location:** `docs/source/user_guide/troubleshooting.rst:21-35`
+
+**Proposed first items:**
+
+1. Inspect `result.status_messages` to distinguish Newton failure, linear
+   failure, divergence, and step-size failure.
+2. Reduce `dt` or `dt_max` when the nonlinear problem is too large for the
+   current step.
+3. Increase `newton_max_iters` when the status reports the iteration limit and
+   additional iterations continue to reduce the update.
+
+**Reason:** Tightening `atol` and `rtol` does not “give the solver more room.”
+It requests stricter error control and also influences derived inner
+tolerances.
+
+**Evidence:** `src/cubie/result_codes.py:22-58`,
+`src/cubie/integrators/matrix_free_solvers/newton_krylov.py:270-317`,
+`src/cubie/integrators/matrix_free_solvers/newton_krylov.py:450-480`.
+
+### UFR-021: Replace the performance page's universal claims
+
+**Location:** `docs/source/user_guide/speed.rst:1-57`,
+`docs/source/user_guide/speed.rst:85-115`
+
+**Proposed text:**
+
+> Measure performance with the production backend and target GPU. Batch size,
+> system size, algorithm, precision, output cadence, cache state, and host
+> transfers affect the result. No fixed GPU-to-CPU crossover applies.
+>
+> Reduce saved variables and save frequency when the output is not required.
+> Use on-device summaries for aggregate-only output. Declare a value as a
+> constant when it is unchanged across the batch. Changing a
+> constant changes compiled-system identity.
+>
+> `TimeLogger` reports host phases and registered CUDA event durations. It does
+> not report occupancy or memory usage.
+>
+> Working buffers default to local placement unless a component declares a
+> different setting. Treat location overrides and `max_registers` as measured,
+> hardware-specific tuning parameters.
+>
+> Reuse a `Solver` for repeated batches with compatible compile settings.
+
+**Reason:** The current page asserts linear scaling, nearly free additional
+runs, a universal memory bottleneck, an unsupported 30-second compile bound,
+automatic buffer placement, and fixed precision advice. These are not API
+guarantees.
+
+**Evidence:** `src/cubie/time_logger.py:189-231`,
+`src/cubie/time_logger.py:547-593`,
+`src/cubie/integrators/loops/ode_loop_config.py:127-169`,
+`src/cubie/batchsolving/solver.py:420-433`.
+
+### UFR-022: Rewrite CUDA execution and memory claims
+
+**Location:** `docs/source/theory/cuda.rst:11-16`,
+`docs/source/theory/cuda.rst:26-43`,
+`docs/source/theory/cuda.rst:45-87`
+
+**Proposed text:**
+
+> CuBIE launches independent trajectories across a two-dimensional CUDA block.
+> One-lane algorithms assign one trajectory per lane. Tiled algorithms assign
+> multiple lanes per trajectory. The achievable concurrency depends on the
+> algorithm's thread and memory requirements and the target GPU.
+>
+> Constants are captured in generated code. Runtime parameters and state are
+> stored in per-run working buffers. Matrix-free helpers avoid materializing a
+> dense Jacobian per trajectory. Selected outputs are written to device output
+> arrays. Summary accumulators use registered working buffers and write their
+> requested results to output arrays.
+>
+> Buffer locations are compile settings with local and shared choices.
+> `TimeLogger` reports timing events. Use CUDA profiling tools for occupancy and
+> hardware counters.
+
+**Reason:** The page promises near-perfect efficiency, a fixed 10x single-run
+penalty, a break-even batch size, one thread for every algorithm, all
+intermediate data on chip, default shared-memory packing, and TimeLogger
+occupancy reporting. The implementation does not guarantee those properties.
+
+**Evidence:** `src/cubie/batchsolving/BatchSolverKernel.py:728-729`,
+`src/cubie/batchsolving/BatchSolverKernel.py:757-800`,
+`src/cubie/integrators/loops/ode_loop_config.py:127-169`,
+`src/cubie/time_logger.py:547-593`.
+
+### UFR-023: Correct the Jacobian pipeline
+
+**Location:** `docs/source/theory/jacobians.rst:22-41`
+
+**Proposed text:**
+
+> CuBIE computes derivative operators by differentiating its symbolic
+> expression IR.
+>
+> CuBIE parses string and SymPy input through SymPy, then converts supported
+> expressions to its hash-consed expression IR. Differentiation, common
+> subexpression processing, assignment planning, and source emission operate on
+> the IR. The generated helpers apply Jacobian-vector products without storing
+> a dense Jacobian for each trajectory.
+
+**Reason:** The page says differentiation and code-generation optimization run
+on SymPy expressions. Those compute passes now run on the internal IR.
+
+**Evidence:** `src/cubie/odesystems/symbolic/engine/__init__.py:1-9`,
+`src/cubie/odesystems/symbolic/engine/from_sympy.py:71-88`,
+`src/cubie/odesystems/symbolic/engine/expr.py:1076-1102`.
+
+### UFR-024: Correct Euler error and Dormand-Prince stage count
+
+**Location:** `docs/source/theory/numerical_integration.rst:19-22`,
+`docs/source/theory/numerical_integration.rst:60-65`
+
+**Proposed text:**
+
+> Forward Euler has local truncation error proportional to `h^2` and accumulated
+> global error proportional to `h`. Halving `h` approximately halves the global
+> error in the asymptotic regime.
+>
+> An embedded pair shares stage evaluations between its main and embedded
+> formulas. CuBIE's Dormand-Prince 5(4) tableau has seven stages.
+
+**Reason:** The current page calls the halved quantity local error and says the
+tableau has six stages.
+
+**Evidence:** `docs/source/theory/numerical_integration.rst:53-55`,
+`src/cubie/integrators/algorithms/generic_erk_tableaus.py:751-770` and the
+seven-row `DORMAND_PRINCE_54_TABLEAU` definition in the same module.
+
+### UFR-025: Correct nonlinear solver, preconditioner, and status descriptions
+
+**Location:** `docs/source/theory/solvers.rst:28-46`,
+`docs/source/theory/solvers.rst:65-82`,
+`docs/source/theory/solvers.rst:84-97`
+
+**Proposed text:**
+
+> CuBIE's Newton-Krylov solver uses an update-norm contraction estimate. It
+> accepts a small first update or an update whose estimated remaining error is
+> below the scaled bound. Nonfinite updates, excessive contraction estimates,
+> and stagnation terminate an iteration early.
+>
+> Implicit methods support Neumann and Jacobi preconditioners. A sequence of
+> preconditioner names creates one chained generated helper.
+>
+> Run status is stored as `CUBIE_RESULT_CODES` bit flags. Iteration counts are
+> stored in a separate `iteration_counters` output. They are not packed into
+> the high bits of a return code.
+
+**Evidence:**
+`src/cubie/integrators/matrix_free_solvers/newton_krylov.py:270-317`,
+`src/cubie/integrators/matrix_free_solvers/newton_krylov.py:450-480`,
+`src/cubie/integrators/algorithms/ode_implicitstep.py:119-140`,
+`src/cubie/integrators/algorithms/ode_implicitstep.py:540-585`,
+`src/cubie/result_codes.py:22-88`.
+
+### UFR-026: Repair the array-interpolation example
+
+**Location:** `docs/source/examples/array_interpolation_example.py:3-7`,
+`docs/source/examples/array_interpolation_example.py:110-112`
+
+**Proposed code:**
+
+```python
+device_values[boundary_condition] = evaluate_on_device(
+    interp.evaluation_function,
+    interp.coefficients,
+    dense_times,
+)
+```
+
+Change the class reference to `cubie.array_interpolator.ArrayInterpolator`.
+
+**Reason:** The documented module path and `device_function` attribute do not
+exist. The public compiled property is `evaluation_function`.
+
+**Evidence:** `src/cubie/array_interpolator.py:151-156`,
+`src/cubie/array_interpolator.py:625-634`.
+
+### UFR-027: Repair the controller-analysis example
+
+**Location:** `docs/source/examples/controller_step_analysis.py:298-324`
+
+**Proposed code:**
+
+```python
+return OutputFunctions(
+    max_states=system.sizes.states,
+    max_observables=system.sizes.observables,
+    precision=system.precision,
+    output_types=solver_settings["output_types"],
+    saved_state_indices=solver_settings["saved_state_indices"],
+    saved_observable_indices=solver_settings["saved_observable_indices"],
+    summarised_state_indices=solver_settings["summarised_state_indices"],
+    summarised_observable_indices=(
+        solver_settings["summarised_observable_indices"]
+    ),
+)
+```
+
+**Reason:** The current positional call supplies the parameter count as the
+observable count, supplies `output_types` as `precision`, shifts every later
+argument, and omits precision.
+
+**Evidence:** `src/cubie/outputhandling/output_functions.py:125-169`.
+
+### UFR-028: Replace the stale test guide
+
+**Location:** `tests/README.md:1-609`
+
+**Proposed replacement:**
+
+> # CuBIE test guide
+>
+> Use the shared session-scoped fixtures in `tests/conftest.py` and their
+> default parameter sets unless the task grants an exception. Do not add mocks
+> or patches without an explicit user exception. Do not weaken assertions.
+>
+> Subdirectory `conftest.py` files define isolated protocols for Julia reference
+> data, matrix-free solver fixtures, symbolic parser fixtures, and memory
+> singleton state. Read the nearest test instructions and existing fixture
+> contract before adding a fixture.
+>
+> Run targeted simulator tests, then verify device behavior with the real-GPU
+> suite. The repository `AGENTS.md` defines the commands and marker exclusions.
+
+**Reason:** The current guide asserts that local fixtures and test classes do
+not exist, although the current suite contains many of both. It says every
+device-function access triggers a two-minute build, uses an absent
+`.claude/check_cuda.py` script, omits current marker exclusions, and contains
+instructions about previous AI agents rather than test behavior.
+
+**Evidence:** a repository scan found local `@pytest.fixture` definitions in
+multiple current test files and many current `class Test...` groups;
+`.claude/check_cuda.py` is absent; current commands are in `AGENTS.md`.
+
+### UFR-029: Replace the CUDA-writing stub with binding instructions
+
+**Location:** `src/cubie/writing_cuda_functions.md:1-44`
+
+**Proposed replacement:**
+
+> # Writing CUDA device functions in CuBIE
+>
+> Import CUDA symbols from `cubie.cuda_simsafe`. Do not import a backend package
+> directly. Obtain compiled functions through cached factory properties.
+>
+> Capture configuration-dependent booleans and scalar values in `build`. The
+> compiler specializes the generated device function for those values. Use
+> runtime predicates for values that vary between lanes or calls.
+>
+> Use `selp` for per-lane value selection when both candidate values are already
+> available. Do not use it to force unconditional evaluation of expensive or
+> unsafe work.
+>
+> Gate warp-coherent loop exits with `activemask` and the required `all_sync` or
+> `any_sync` vote. Select the vote from the loop's acceptance condition and
+> document that condition next to the exit.
+>
+> Register scratch buffers through `buffer_registry`. Keep configurable buffer
+> locations in compile settings. Pass persistence through buffer registration.
+> Follow `src/cubie/AGENTS.md` for factory, cache, import, precision, and buffer
+> contracts.
+
+**Reason:** The current file is a stub containing open questions, hedging, and
+nonbinding framing. Those statements do not provide factual instructions.
+
+**Evidence:** `src/cubie/integrators/algorithms/backwards_euler.py:118-134`.
+
+### UFR-030: Normalize the Julia-reference data README
+
+**Location:**
+`tests/integrated_numerical_tests/julia_reference/data/README.md:7-25`
+
+**Proposed text:**
+
+> `julia_reference_ne.npz` stores the golden state arrays and the fixed and
+> adaptive sweep grids. `algorithms.csv` maps CuBIE aliases to
+> DifferentialEquations.jl constructors, orders, and families.
+> `controller_constants.csv` stores the controller constants resolved by the
+> Julia runner. The CuBIE gate applies those constants for the matched adaptive
+> comparisons.
+
+**Reason:** This preserves the content while removing dash-led and
+semicolon-joined clause framing.
+
+### UFR-031: Keep Fleet facts and split dense clauses
+
+**Location:** `infra/fleet/README.md:8-28`, `infra/fleet/README.md:113-123`,
+`infra/fleet/README.md:125-143`, `infra/fleet/README.md:145-176`,
+`infra/fleet/README.md:202-245`, `infra/fleet/README.md:260-263`
+
+The infrastructure claims checked against current code are fresh. Preserve the
+facts and split each semicolon or dash-joined sentence into independent factual
+sentences. Apply these exact transformations throughout the listed ranges.
+
+- Replace `A; B` with `A. B`.
+- Replace parenthetical em-dash clauses with a separate sentence.
+- Convert the dashboard feature sentence at lines 113-117 into a bullet list
+  with one feature per item.
+- Replace “cost latency, not red legs” with “Launch failures leave the job
+  queued while Fleet retries with backoff.”
+- Remove measured anecdotes from parentheticals unless their command and raw
+  measurement are recorded.
+
+**Evidence:** `infra/fleet/cost_dashboard.py:66-86`,
+`infra/fleet/cost_dashboard.py:639`,
+`infra/fleet/cost_dashboard.py:2109`,
+`infra/fleet/cost_dashboard.py:2219-2227`, `infra/fleet/main.tf:43-86`,
+`.github/workflows/ci_cuda_tests.yml:416-441`,
+`infra/fleet/bootstrap/cloudshell-iam.sh:22-24`.
+
+## Framing and punctuation rewrites
+
+### UFR-S01: Remove explicit framing and intensifiers
+
+Apply the following sentence replacements.
+
+| Location | Proposed text |
+|---|---|
+| `docs/source/getting_started.rst:4-6` | “CuBIE integrates batches formed from initial values, parameter sets, or both.” |
+| `docs/source/getting_started.rst:62-64` | “`create_ODE_system` accepts equation strings and Python functions. Pass either form to `solve_ivp`.” |
+| `docs/source/theory/index.rst:4-7` | “CuBIE uses numerical integration algorithms, generated derivative operators, nonlinear solvers, and CUDA execution.” |
+| `docs/source/theory/cuda.rst:26-28` | “CuBIE uses Numba-compatible backends to JIT-compile Python functions into CUDA kernels.” |
+| `docs/source/theory/numerical_integration.rst:77-78` | “The selected tableau determines the stability region. A-stable tableaus include the left half-plane. L-stable tableaus additionally damp modes in the stiff limit.” |
+| `docs/source/theory/solvers.rst:17-19` | “The stage equation is nonlinear in :math:`k_i` and requires a root solve.” |
+| `docs/source/tutorials/extracting_summaries.rst:63-68` | “A 50-unit summary interval produces one window for this run. A shorter interval produces one statistic per window. If `summarise_every` is omitted, CuBIE derives a whole-run window and warns because changing `duration` then changes compile settings.” |
+| `docs/source/tutorials/extracting_summaries.rst:77-80` | “Summary arrays use `[window, summary, run]` indexing. `as_numpy_per_summary` returns one `[window, variable, run]` array per metric.” |
+| `docs/source/tutorials/extracting_summaries.rst:89-92` | “Metrics that share an accumulator are computed by one generated metric function. Result keys retain the requested metric names.” |
+| `docs/source/tutorials/extracting_summaries.rst:94-98` | Use the heading “Reduce saved output.” Delete “Two more levers.” |
+| `docs/source/tutorials/first_sweep.rst:41-48` | “The function definition must be available through Python source inspection. A script, module, or notebook cell is supported. `exec` and `python -c` definitions are not. Equivalent equation strings avoid source inspection.” |
+| `docs/source/tutorials/first_sweep.rst:68-70` | “String definitions infer state names from `dx = ...` left-hand sides. Function definitions require `states` to associate returned derivatives with state names.” |
+| `docs/source/tutorials/first_sweep.rst:166-167` | Delete the paragraph. |
+| `docs/source/tutorials/stiff_systems.rst:39-42` | “`method=\"radau\"` selects the fifth-order Radau IIA fully implicit method.” |
+| `docs/source/tutorials/stiff_systems.rst:61-65` | “Rosenbrock-W methods perform a linear solve at each stage without Newton iteration. Crank-Nicolson and DIRK methods solve nonlinear stage equations.” |
+| `docs/source/tutorials/stiff_systems.rst:152-156` | “`method="rosenbrock"` selects a linearly implicit Rosenbrock-W method. Explicit `atol` and `rtol` values record the requested error scale for failure diagnosis.” |
+| `docs/source/user_guide/drivers.rst:4-8` | “Use `t` in a system definition for explicit time dependence. Use a driver for a named time-dependent input supplied as a function or sampled array.” |
+| `docs/source/user_guide/choosing_algorithms.rst:17` | Replace “Recommended family” with “Algorithm family.” |
+| `docs/source/user_guide/choosing_algorithms.rst:32-35` | “`erk` selects `dormand-prince-54`. `dirk` selects `l_stable_dirk_3`. `firk` selects `firk_gauss_legendre_2`. `rosenbrock` selects `ros3p`.” |
+| `docs/source/user_guide/coming_from_matlab.rst:40-58` | “MATLAB `y(1)` and `y(2)` map to Python `y[0]` and `y[1]`. CuBIE accepts `y.x` and `y.v` attribute access. Declare parameters as named function arguments and in `parameters`. Return derivatives as a list or a dictionary. MATLAB `[0 20]` maps to `duration=20.0` with optional `t0`. `RelTol`, `AbsTol`, and `MaxStep` map to `rtol`, `atol`, and `dt_max`. `result` stores batch output arrays.” |
+| `docs/source/user_guide/solving.rst:47-49` | “CuBIE accepts a single IVP and is designed for batches. Arrays of initial values or parameters create a batch.” |
+| `docs/source/user_guide/systems.rst:176-182` | “Integration algorithms request generated linear operators, Jacobian-vector products, preconditioners, residuals, and time-derivative helpers through `SymbolicODE.get_solver_helper`.” |
+| `docs/source/user_guide/optional_arguments.rst:216-217` | “`algorithm` accepts a custom `ButcherTableau` instance.” |
+| `docs/source/user_guide/speed.rst:78` | “`default_timelogger` provides programmatic access to the logger.” |
+
+The second semantic pass found the following additional constructions. Apply
+these exact replacements. These findings include meaning-level framing and
+intensification that a seed-phrase scan does not detect.
+
+- `readme.md:34-40` becomes “Supply time-dependent forcing as functions or
+  sampled arrays. Save selected states or observables. Compute summary metrics
+  on the GPU without retaining full trajectories. CuBIE chunks batches to fit
+  device and host memory. The cache reuses compatible compiled kernels.”
+- `infra/fleet/README.md:26-28` becomes “The fleets define no `schedule`.
+  RunsOn warm pools use on-demand capacity. This account has no on-demand
+  G-instance quota.”
+- `infra/fleet/README.md:93-102` becomes “The runners do not enable the
+  `s3-cache` extra. It requires a `runs-on/action@v2` step in every job. Without
+  that step, the sidecar intercepts the GitHub artifact service and
+  `actions/upload-artifact` receives a non-JSON `CreateArtifact` response.
+  Runners available to public repositories must not use the shared S3 cache
+  bucket. CuBIE is public. `setup-uv` uses GitHub's cache service.”
+- `docs/source/getting_started.rst:18-28` becomes “A backend extra is required.
+  `mlir-cuda12` and `mlir-cuda13` install numba-cuda-mlir with toolkit wheels.
+  `mlir` uses a compatible system toolkit. The deprecated numba-cuda backend is
+  available through `cuda12`, `cuda13`, or `cuda`. Use numba-cuda for Python
+  3.10, the CUDA simulator, or as the documented fallback after an MLIR error.”
+- `docs/source/getting_started.rst:33-36` becomes “Define an ODE system, then
+  solve a batch of initial-value problems.”
+- `docs/source/getting_started.rst:102-105` becomes “:doc:`Coming from SciPy
+  <user_guide/coming_from_scipy>` maps SciPy interfaces to CuBIE.
+  :doc:`Coming from MATLAB <user_guide/coming_from_matlab>` maps MATLAB
+  interfaces to CuBIE.”
+- `docs/source/getting_started.rst:128-133` becomes “Install Pandas for
+  DataFrame output. Install Matplotlib for driver plots and plots created from
+  result arrays.”
+- `docs/source/examples/array_interpolation_example.py:1-8` becomes a module
+  docstring stating “Plot CUDA driver-array interpolation against SciPy
+  references. The script builds harmonic sampled data, evaluates four boundary
+  conditions on CUDA, and compares the results with `CubicSpline`. It requires
+  SciPy, NumPy, Matplotlib, and a CUDA-capable device or the CUDA simulator.”
+- `docs/source/examples/cpu_gpu_driver_evaluator_comparison.py:1-13` becomes a
+  module docstring stating “Compare CPU and GPU driver evaluators on shared
+  input samples. The script evaluates one sampled sequence with
+  `ArrayInterpolator` and the CPU `DriverEvaluator`. Each subplot shows one
+  endpoint-handling mode. It requires NumPy, Matplotlib, and a CUDA-capable
+  device or the CUDA simulator.”
+- `docs/source/examples/controller_step_analysis.py:1-12` becomes a module
+  docstring stating “Visualise CPU reference controller step sizes for selected
+  ODE systems. The module uses the integration-test configuration and plots
+  accepted and rejected steps for each controller and system. The CPU reference
+  determines the plotted step sizes.”
+- `docs/source/examples/controller_step_analysis.py:679-683` becomes “Render
+  accepted and rejected steps. Each system uses two plot rows. The upper row
+  shows step-size history. The lower row shows states and drivers.”
+- `docs/source/theory/cuda.rst:4-6` becomes “CuBIE executes batch ODE solves
+  through CUDA on NVIDIA GPUs.”
+- `docs/source/theory/jacobians.rst:4-6` becomes “Implicit algorithms and
+  Rosenbrock-W methods use derivatives of the right-hand-side function
+  :math:`f(t, x)`. CuBIE generates the required derivative operators from its
+  symbolic expression IR.”
+- `docs/source/theory/numerical_integration.rst:4-6` becomes “CuBIE provides
+  explicit Runge-Kutta, diagonally implicit Runge-Kutta, fully implicit
+  Runge-Kutta, and Rosenbrock-W algorithms.
+  :doc:`/user_guide/choosing_algorithms` lists the registered methods.”
+- `docs/source/theory/numerical_integration.rst:92-113` becomes “ERK tableaus
+  are strictly lower triangular. DIRK tableaus are lower triangular with
+  nonzero diagonal entries and solve one nonlinear stage system at a time.
+  FIRK tableaus couple all stages in one nonlinear system. Rosenbrock-W methods
+  perform a linear solve at each stage and do not run Newton iteration.”
+- `docs/source/theory/numerical_integration.rst:131-135` becomes “PI, PID, and
+  Gustafsson controllers update the step size from current or prior error
+  information. Their registered gains and per-algorithm defaults determine the
+  update.”
+- `docs/source/theory/solvers.rst:4-6` becomes “DIRK and FIRK methods solve
+  nonlinear stage equations at each time step. CuBIE uses generated operators
+  in Newton-Krylov solves.”
+- `docs/source/tutorials/extracting_summaries.rst:4-9` becomes “Summary outputs
+  reduce per-run storage by computing requested metrics during integration.
+  `output_types` accepts summary metric names. Omitting `"state"` prevents
+  state-trajectory output.”
+- `docs/source/tutorials/extracting_summaries.rst:14-15` becomes “The
+  Lotka-Volterra system from :doc:`first_sweep` has oscillating state
+  trajectories.”
+- `docs/source/tutorials/first_sweep.rst:4-10` becomes “The Lotka-Volterra
+  example sweeps two parameters and maps final state values to a heatmap.”
+- `docs/source/tutorials/first_sweep.rst:15-21` becomes
+  “:func:`~cubie.odesystems.symbolic.symbolicODE.create_ODE_system` accepts a
+  Python function whose arguments are time, state, and named values. Return
+  derivatives in state order. Access states and named values by attribute,
+  name, or index.”
+- `docs/source/tutorials/first_sweep.rst:84-87` becomes “With
+  `grid_type="combinatorial"`, CuBIE solves every combination of the supplied
+  parameter values. The 1,000-value `b_values` and `d_values` arrays produce
+  1,000,000 initial-value problems.”
+- `docs/source/tutorials/first_sweep.rst:103-111` becomes “Scalar initial
+  values are shared across runs. Arrays sweep an initial state. `method="ode45"`
+  selects the adaptive fifth-order Dormand-Prince pair. `save_every=0.5`
+  records a snapshot every half time unit. CuBIE chunks batches that exceed the
+  device-memory budget.”
+- `docs/source/tutorials/first_sweep.rst:128` becomes “Check the per-run status
+  codes before using the result.”
+- `docs/source/tutorials/index.rst:4-11` becomes “1.
+  :doc:`first_sweep` constructs a parameter-sweep heatmap. 2.
+  :doc:`extracting_summaries` computes GPU-side summary metrics without state
+  trajectories. 3. :doc:`stiff_systems` uses implicit integration and sampled
+  forcing.”
+- `docs/source/tutorials/stiff_systems.rst:4-12` becomes “A stiff system mixes
+  fast and slow dynamics. Explicit-method step sizes remain limited by the
+  fastest stable timescale after that component has decayed. Implicit methods
+  have larger stability regions. Solve the Van der Pol system with an implicit
+  method. Inspect status codes after a failed run. Supply sampled forcing
+  through a driver.”
+- `docs/source/tutorials/stiff_systems.rst:97-106` becomes “`STEP_TOO_SMALL`
+  reports that the required step is below `dt_min`. Loosen `atol` and `rtol`
+  when the requested error is below the arithmetic or model resolution. Lower
+  `dt_min` when the dynamics require a smaller step. A vector `atol` sets a
+  separate absolute tolerance for each state.”
+- `docs/source/tutorials/stiff_systems.rst:163-167` becomes “Write closed-form
+  forcing directly in the equations with the time symbol `t`. Equations using
+  `t` do not use driver arrays or interpolation.”
+- `docs/source/tutorials/stiff_systems.rst:185-196` is deleted because it
+  repeats the preceding instructions as a framed recap.
+- `docs/source/user_guide/batching.rst:4-5` becomes “CuBIE solves batches of
+  independent initial-value problems in parallel. Parameter arrays and initial
+  value arrays define the batch.”
+- `docs/source/user_guide/choosing_algorithms.rst:4-7` becomes “Pass an
+  algorithm name as `method` to :func:`~cubie.solve_ivp` or as `algorithm` to
+  :class:`~cubie.Solver`. Names are case-insensitive.”
+- `docs/source/user_guide/choosing_algorithms.rst:19-30` uses these decision
+  notes. “ERK uses explicit stages. `dormand-prince-54` is the ERK family
+  default.” “DIRK runs a nonlinear solve for each stage. Rosenbrock-W runs a
+  linear solve for each stage.” “FIRK couples all stages. `radau_iia_5` is a
+  three-stage method of order five with an embedded estimate.” “`euler` and
+  `backwards_euler` are fixed-step methods.”
+- `docs/source/user_guide/choosing_algorithms.rst:84-100` describes
+  `dormand-prince-54` as the seven-stage embedded 5(4) ERK default, `tsit5` as
+  an embedded 5(4) method, and `dormand-prince-853` as an order-eight method
+  with fifth- and third-order estimators. Delete “industry standard,” “good
+  default,” “often slightly more efficient,” and “useful.”
+- `docs/source/user_guide/choosing_algorithms.rst:143-173` states tableau name,
+  stage count, order, embedded-estimate availability, and aliases. Delete
+  “excellent for stiff problems.”
+- `docs/source/user_guide/choosing_algorithms.rst:211-233` becomes “`fixed`
+  uses a constant step. `i` uses the current error. `pi` uses current and prior
+  error. `pid` uses the change in error history. `gustafsson` uses prior
+  error ratios and, for implicit methods, the Newton iteration count. Each
+  algorithm supplies its registered controller defaults.”
+- `docs/source/user_guide/coming_from_matlab.rst:4-7` becomes “CuBIE accepts a
+  right-hand-side function, an algorithm name, and solver tolerances. MATLAB
+  `ode45(f, [0 20], [1; 0], opts)` maps to CuBIE
+  `solve_ivp(..., method="ode45", duration=20.0, ...)`.”
+- `docs/source/user_guide/coming_from_matlab.rst:136-149` becomes “Equation
+  strings preserve variable names and use Python operators. Use `**` for
+  exponentiation. MATLAB's `^` operator is not accepted.”
+- `docs/source/user_guide/coming_from_scipy.rst:4-8` becomes “CuBIE accepts a
+  SciPy-style right-hand-side function when its body uses supported arithmetic,
+  scalar calls, branches, and constant-bound loops. Parameters are declared by
+  name. CuBIE returns batch arrays and uses `duration` and regular output
+  intervals.”
+- `docs/source/user_guide/coming_from_scipy.rst:97-102` uses the heading
+  “Parameter batches” and the sentence “Arrays of parameter or initial values
+  define a batch that one call integrates on the GPU.”
+- `docs/source/user_guide/coming_from_scipy.rst:145-146` becomes
+  “`Solver.solve` defaults to `grid_type="verbatim"`. `solve_ivp` defaults to
+  `grid_type="combinatorial"`.”
+- `docs/source/user_guide/configuration.rst:4-9` becomes “The entry-point
+  parameters of :func:`~cubie.solve_ivp`, :class:`~cubie.Solver`, and
+  :meth:`~cubie.Solver.solve` route to output, memory, step-control, algorithm,
+  loop, cache, and kernel settings groups.”
+- `docs/source/user_guide/drivers.rst:4-12` becomes “Use the time symbol `t`
+  for explicit time dependence in a system equation. Use a driver for a named
+  time-dependent input supplied as sampled values.”
+- `docs/source/user_guide/drivers.rst:74-87` becomes “Use sampled drivers when
+  forcing values are available at discrete times. CuBIE interpolates those
+  values for fixed or adaptive steps. Sampling cadence determines the stored
+  driver-array length.”
+- `docs/source/user_guide/drivers.rst:120-122` becomes “Declare each driver name
+  in the system's `drivers` argument. Reference the driver by its bare name in
+  the function body.”
+- `docs/source/user_guide/drivers.rst:135-152` becomes “`order` sets the spline
+  polynomial degree and defaults to `3`. With `wrap=True`, samples repeat
+  periodically. With `wrap=False`, the interpolator adds transition segments
+  between zero and the endpoint values outside the sampled interval.
+  `boundary_condition` accepts `"natural"`, `"periodic"`, `"clamped"`, or
+  `"not-a-knot"`. It defaults to `"periodic"` with wrapping and `"clamped"`
+  without wrapping.”
+- `docs/source/user_guide/memory.rst:4-6` becomes “CuBIE manages VRAM and
+  divides batches that exceed the configured memory budget.”
+- `docs/source/user_guide/optional_arguments.rst:4-15` becomes “Pass solver
+  options as keywords to :func:`~cubie.solve_ivp`, the :class:`~cubie.Solver`
+  constructor, or :meth:`~cubie.batchsolving.solver.Solver.solve`. CuBIE routes
+  each accepted keyword to its settings group. Omitted or `None` values use the
+  default. Unknown names raise `KeyError`.”
+- Delete `docs/source/user_guide/optional_arguments.rst:20`.
+- `docs/source/user_guide/optional_arguments.rst:69-73` becomes
+  “`step_controller` accepts `"fixed"`, `"i"`, `"pi"`, `"pid"`, or
+  `"gustafsson"`. Each algorithm defines its default controller.”
+- `docs/source/user_guide/optional_arguments.rst:91-94` becomes “Proposed gains
+  inside the interval from `deadband_min` through `deadband_max` are replaced
+  with `1.0`. Set both values to `1.0` to disable the interval.”
+- `docs/source/user_guide/optional_arguments.rst:177-181` becomes
+  “`minimal_residual` minimizes the residual along its search direction.
+  `steepest_descent` uses the gradient direction. `bicgstab` selects the
+  BiCGSTAB solver.”
+- `docs/source/user_guide/optional_arguments.rst:185-187` becomes
+  “`preconditioner_order` sets the number of terms in the truncated Neumann
+  series. Each additional term adds one operator application.”
+- `docs/source/user_guide/optional_arguments.rst:195-201` becomes “`beta` and
+  `gamma` change the implicit equations. A mass matrix belongs to the system
+  definition and requires an implicit algorithm.”
+- `docs/source/user_guide/optional_arguments.rst:230-239` becomes
+  “`save_variables` and `summarise_variables` restrict output to named states
+  or observables. Their index-based counterparts select the same variables.
+  Selection
+  lists default to all indices, while `output_types` determines which output
+  categories are active.”
+- `docs/source/user_guide/optional_arguments.rst:244-251` becomes “Each
+  `*_location` compile setting selects local or shared memory for one working
+  buffer. Defaults are component-specific. Benchmark a location override on
+  the target GPU.”
+- `docs/source/user_guide/results.rst:11` and
+  `docs/source/user_guide/results.rst:47` are deleted. Retain the existing
+  section headings and definitions.
+- `docs/source/user_guide/results.rst:68-78` deletes “Points to note.” Replace
+  the GPU-result instruction with “Use a normal host solve when host arrays are
+  required.”
+- `docs/source/user_guide/results.rst:130-131` becomes “Summary outputs compute
+  metrics without saving the full trajectory.”
+- `docs/source/user_guide/results.rst:179-184` becomes “CuBIE combines requested
+  metrics that share accumulators. The result legend preserves each requested
+  metric name.”
+- `docs/source/user_guide/results.rst:208-210` becomes “Requesting
+  `iteration_counters` records Newton iterations, Krylov iterations, accepted
+  steps, and rejected steps at each save point.”
+- `docs/source/user_guide/solving.rst:4-7` becomes “Solve a defined ODE system
+  with :func:`~cubie.batchsolving.solver.solve_ivp` or a reusable
+  :class:`~cubie.batchsolving.solver.Solver`.”
+- `docs/source/user_guide/solving.rst:12-13` becomes “The `solve_ivp` function
+  constructs a solver and executes one batch. Call it with the Lotka-Volterra
+  system and one initial condition.”
+- `docs/source/user_guide/solving.rst:74-78` becomes “Create one
+  :class:`~cubie.Solver` and call
+  :meth:`~cubie.batchsolving.solver.Solver.solve` repeatedly to retain compiled
+  objects and managed allocations.”
+- `docs/source/user_guide/solving.rst:100-106` becomes “`Solver.update`
+  reconfigures a live solver. `Solver.build_grid` constructs an input grid for
+  reuse by solves with the same batch layout.”
+- `docs/source/user_guide/solving.rst:117-120` becomes “`duration` sets the
+  recorded integration length. `t0` sets the start time. `settling_time`
+  integrates before output recording starts.”
+- `docs/source/user_guide/systems.rst:100-124` becomes “Equation strings define
+  assignments directly. A left-hand side of `dx` defines state `x`. Undeclared
+  right-hand-side symbols are inferred as parameters with value `0.0` and emit
+  a warning. Explicit `states`, `parameters`, and `constants` mappings assign
+  roles and default values.”
+- `docs/source/user_guide/systems.rst:145-151` becomes “Default values are
+  optional. Unlisted assigned auxiliaries remain in the symbolic expressions.
+  Their trajectories are not saved.”
+- `docs/source/user_guide/timing.rst:111-119` becomes “Updating a derived step
+  parameter recalculates dependent values when validation rules require it.
+  `Solver.update` preserves an explicitly supplied `dt_min` when a later `dt`
+  is below it.”
+- `docs/source/user_guide/timing.rst:278-280` becomes “`settling_time` integrates
+  from `t0` without recording output. Use it to exclude the initial transient
+  from recorded data.”
+- `docs/source/user_guide/timing.rst:311-315` uses the heading “Combined timing
+  configuration” and deletes the sentence introducing the example.
+- `docs/source/user_guide/troubleshooting.rst:44-48` becomes “Reduce the number
+  of saved variables or request summaries instead of trajectories. Lower
+  `mem_proportion` to reserve VRAM for other processes. Reduce the batch size
+  when host memory is the limiting resource.”
+- `docs/source/user_guide/troubleshooting.rst:64-69` becomes “CUDASIM executes
+  CUDA kernels on one CPU thread and does not require a GPU. Use it for
+  CPU-only logic checks. It is available only with the deprecated numba-cuda
+  backend.”
+- `docs/source/user_guide/userfunctions.rst:4-11` becomes “System equations
+  accept supplied Python function and CUDA device function calls. CuBIE inlines
+  Python functions that evaluate on symbolic arguments. A device function
+  remains an opaque call. Supply its derivative function when an algorithm
+  generates Jacobian terms.”
+- `docs/source/user_guide/userfunctions.rst:159-166` becomes “A device function
+  without a derivative helper cannot be used by an algorithm that generates
+  Jacobian terms. CuBIE inlines Python functions that evaluate on symbolic
+  arguments. Functions that do not evaluate on symbolic arguments remain named
+  calls and require a derivative for differentiation.”
+
+### UFR-S02: Remove prose em dashes and semicolons
+
+For every prose occurrence listed in the companion inventory, replace a dash or
+semicolon joining independent clauses with a full stop. Keep punctuation that
+is required by Python, MATLAB, CSS, Make, URLs, RST roles and directives, or
+mathematical notation. Keep a colon only for a literal mapping, signature,
+directive, table field, or a short list whose introduction is a complete
+sentence.
+
+The following high-density files should be rewritten by paragraph rather than
+with character substitution.
+
+- `docs/source/user_guide/optional_arguments.rst`: replace dash-led definition
+  entries with RST definition-list terms. Split all semicolon-joined defaults
+  and constraints into sentences.
+- `docs/source/user_guide/results.rst`: replace dash-separated accessor
+  definitions with a table. Split clauses at lines 18, 31, 42, 58-59, 70-75,
+  84-86, 183, and 209.
+- `docs/source/user_guide/coming_from_matlab.rst` and
+  `docs/source/user_guide/coming_from_scipy.rst`: retain semicolons inside source
+  code. Split them in narrative prose.
+- `docs/source/user_guide/configuration.rst`: replace punctuation-heavy table
+  descriptions with one factual sentence per field.
+- `docs/source/user_guide/optional_arguments.rst`: convert the fragment
+  lead-ins at lines 75, 98, 128, 148, 183, and 195 into RST subsection
+  headings without colons.
+- `docs/source/user_guide/results.rst`: delete the framed lead-ins “Key
+  attributes,” “Convenience accessors,” and “Points to note.” The existing
+  section heading and following definitions carry the structure.
+- `docs/source/user_guide/timing.rst`: convert “Adaptive controllers,” “Fixed
+  controllers,” “Example usage,” and the complete-example lead-in into RST
+  headings without colons.
+- `docs/source/user_guide/choosing_algorithms.rst`: replace subjective labels
+  such as “good default,” “excellent,” “most common,” and “sensible” with
+  method properties such as order, stability, stage count, and embedded-error
+  availability.
+- `readme.md:98-115`: replace acknowledgement dashes with complete sentences
+  under one heading per project.
+
+## Completeness additions
+
+### UFR-C01: Add an environment and backend page
+
+Document `CUBIE_CUDA_BACKEND`, `NUMBA_ENABLE_CUDASIM`, `CUBIE_LINEINFO`,
+`CUBIE_CACHE_DIR`, `CUBIE_KERNEL_CACHE_DIR`, and
+`CUBIE_MAX_CACHE_ENTRIES`. State import-time versus call-time behavior.
+
+### UFR-C02: Add memory ownership and cleanup
+
+Document solver and result lifetime, host buffer loans, pinned or memmap spill,
+`auto_memory`, stream-group ownership, `Solver.close`, and context-manager use.
+
+### UFR-C03: Add DAE workflow documentation
+
+Document implicit equations, algebraic unknowns, higher-order derivatives,
+automatic structural simplification, `simplify`, `state_priority`,
+`irreducible`, `simplify_options`, mass matrices, and the requirement for an
+implicit algorithm after tearing.
+
+### UFR-C04: Generate algorithm and setting tables from registries
+
+Generate alias, order, stage, embedded-estimate, and default-controller tables
+from the tableau and algorithm registries during the docs build.
+
+### UFR-C05: Add result status and device-result lifecycle pages
+
+Document every `CUBIE_RESULT_CODES` member, bitwise combinations,
+`status_messages`, `DeviceSolveResult`, `on_device`, stream ordering, host
+materialization, and the live-solver requirement.
+
+## Changelog decision
+
+`CHANGELOG.md` is current through version 0.4.0 and was read in full. No entry
+was found to contradict its historical release context. No style rewrite is
+proposed because repository policy forbids editing the changelog.


### PR DESCRIPTION
## Summary

- Add a review index and combined completeness and freshness ledger.
- Add page-by-page, source-backed inventories and proposed rewrites for all 149 documentation pages.
- Reconcile all 585 tracked repository entries across source, tests, instructions, configuration, schemas, fixtures, and generated data.
- Record exact rewrites for stale facts, missing API coverage, framing, intensifiers, em dashes, prose semicolons, and avoidable colons.

No existing documentation, source, test, or configuration file is changed. These artifacts are for review before implementation.

## Key findings

- Documentation version, navigation, cache, CellML, algorithm, controller, memory, result, and example claims are stale or incomplete.
- Broken or mismatched autodoc targets and missing public API pages affect several packages.
- Nested developer instructions contain stale Jacobian, CellML, summary-metric, and test-map guidance.
- The generated test inventory contains removed symbols and its query tool names a missing generator.
- Proposed replacement text has been checked against the same language rules as the source corpus.

## Validation

- Independent verifier passed the original specification.
- Exact repository reconciliation passed with 524 preassigned entries plus a disjoint 61-entry complement, totaling 585.
- All 149 RST pages are reachable with zero bad toctree targets.
- All 1,101 parsed path-and-line citations resolve within bounds.
- `git diff --cached --check` passed before commit.
- No code tests or performance gate were run because the commit adds review Markdown only and does not touch `src/`.
- A Sphinx build was not run because Sphinx is absent from both the system Python and project virtual environment. The failed import receipt is recorded in the inventory.